### PR TITLE
docs: fix github links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,7 +28,9 @@ export default defineConfig({
         '@fontsource/bebas-neue/400.css',
       ],
       pagination: false,
-      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/swmansion/pulsar' }],
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/software-mansion/pulsar' },
+      ],
       sidebar: [
         {
           label: 'Getting started',

--- a/docs/src/pages/components/TopBar/TopBar.tsx
+++ b/docs/src/pages/components/TopBar/TopBar.tsx
@@ -30,7 +30,7 @@ export function TopBar() {
           <a href={`${BASE_PATH}/getting-started`}>Getting started</a>
           <a href={`${BASE_PATH}/sdk/overview`}>Docs</a>
         </div>
-        <a href="https://github.com/software-mansion-labs/pulsar" target="_blank">
+        <a href="https://github.com/software-mansion/pulsar" target="_blank">
           <img className={styles.gitLogo} src={logoGitHub.src} alt="GitHub" />
         </a>
         <button className={styles.hamburger} onClick={toggleMenu} aria-label="Toggle menu">
@@ -66,7 +66,7 @@ export function TopBar() {
               </a>
             </nav>
             <div className={styles.mobileMenuFooter}>
-              <a href="https://github.com/software-mansion-labs/pulsar" target="_blank">
+              <a href="https://github.com/software-mansion/pulsar" target="_blank">
                 <img className={styles.gitLogo} src={logoGitHub.src} alt="GitHub" />
               </a>
             </div>


### PR DESCRIPTION
During going through the docs, I've noticed that one of the GH links is incorrect, so I've fixed that and updated others, which were pointing to `software-mansion-labs` (no need to rely on GH redirections 😄 )