### PR TITLE
fix(ios): enableHaptics(false) now suppresses all haptic feedback

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
@@ -26,6 +26,7 @@ public class RealtimeComposer: NSObject {
   }
 
   @objc public func set(amplitude: Float, frequency: Float) {
+    guard engine.isHapticsEnabled else { return }
     if (!isPlaying) {
       start(amplitude: amplitude, frequency: frequency)
     }
@@ -57,6 +58,7 @@ public class RealtimeComposer: NSObject {
   }
 
   @objc public func playDiscrete(amplitude: Float = 1.0, frequency: Float = 0.5) {
+    guard engine.isHapticsEnabled else { return }
     guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
 
     let intensityParam = CHHapticEventParameter(parameterID: .hapticIntensity, value: amplitude)

--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -11,7 +11,7 @@ public class HapticEngineWrapper {
 
   private var engine: CHHapticEngine?
   private var initialized: Bool = false
-  private var isHapticsEnabled: Bool = true
+  private(set) var isHapticsEnabled: Bool = true
   private var playerRegistry: [Int: PlayerEntry] = [:]
   private var playerCreationOrder: [Int] = []
   private let playerLimit = 20
@@ -77,7 +77,7 @@ public class HapticEngineWrapper {
   }
 
   private func startEngine() {
-    if initialized { return }
+    if initialized || !isHapticsEnabled { return }
     do {
       if engine == nil {
         engine = try CHHapticEngine()

--- a/iOS/Pulsar/Sources/Pulsar/Presets/Player.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Presets/Player.swift
@@ -6,9 +6,15 @@ import AVFAudio
 @objc public class Player : NSObject {
   private var patternComposer: PatternComposer!
   private var audioOnly: Bool = false
+  private weak var pulsar: Pulsar?
+
+  public var isEnabled: Bool {
+    return pulsar?.isHapticsEnabled ?? true
+  }
 
   public init(_ haptics: Pulsar, audioOnly: Bool = false, rawContinuousPattern: [[[Double]]] = [], rawDiscretePattern: [[Double]] = []) {
     super.init()
+    self.pulsar = haptics
     self.audioOnly = audioOnly
     patternComposer = haptics.getPatternComposer()
 
@@ -20,6 +26,7 @@ import AVFAudio
   }
 
   @objc public func play() {
+    guard isEnabled else { return }
     if audioOnly {
       patternComposer.playAudioOnly()
     } else {

--- a/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
@@ -16,13 +16,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [impactFeedbackGenerator = self.impactFeedbackGenerator] in
       await impactFeedbackGenerator.impactOccurred()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemImpactLightPreset(haptics)
   }
@@ -43,13 +44,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [impactFeedbackGenerator = self.impactFeedbackGenerator] in
       await impactFeedbackGenerator.impactOccurred()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemImpactMediumPreset(haptics)
   }
@@ -70,13 +72,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [impactFeedbackGenerator = self.impactFeedbackGenerator] in
       await impactFeedbackGenerator.impactOccurred()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemImpactHeavyPreset(haptics)
   }
@@ -97,13 +100,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [impactFeedbackGenerator = self.impactFeedbackGenerator] in
       await impactFeedbackGenerator.impactOccurred()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemImpactSoftPreset(haptics)
   }
@@ -124,13 +128,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [impactFeedbackGenerator = self.impactFeedbackGenerator] in
       await impactFeedbackGenerator.impactOccurred()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemImpactRigidPreset(haptics)
   }
@@ -152,13 +157,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [feedbackGenerator = self.feedbackGenerator] in
       await feedbackGenerator.notificationOccurred(.success)
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemNotificationSuccessPreset(haptics)
   }
@@ -180,13 +186,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [feedbackGenerator = self.feedbackGenerator] in
       await feedbackGenerator.notificationOccurred(.warning)
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemNotificationWarningPreset(haptics)
   }
@@ -210,13 +217,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [feedbackGenerator = self.feedbackGenerator] in
       await feedbackGenerator.notificationOccurred(.error)
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemNotificationErrorPreset(haptics)
   }
@@ -237,13 +245,14 @@ import Foundation
   }
 
   @objc public override func play() {
+    guard isEnabled else { return }
     super.play()
     Task { [feedbackGenerator = self.feedbackGenerator] in
       await feedbackGenerator.selectionChanged()
     }
   }
-  
-  
+
+
   public static func getInstance(haptics: Pulsar) -> Preset {
     return SystemSelectionPreset(haptics)
   }

--- a/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
@@ -30,6 +30,10 @@ import UIKit
     getPresets().preloadPresetByNames(presetNames)
   }
   
+  @objc public var isHapticsEnabled: Bool {
+    return engine.isHapticsEnabled
+  }
+
   @objc public func enableHaptics(state: Bool) {
     engine.enableHaptics(state)
   }


### PR DESCRIPTION
## Summary

`Settings.enableHaptics(false)` is [documented](https://docs.swmansion.com/pulsar/sdk/react-native) to "enable or disable **all** haptic feedback" globally. On Android this works correctly — `HapticEngineWrapper.vibrate()` checks `isHapticsEnabled` early. On iOS, haptic feedback continues to fire after disabling because of three issues:

1. **System presets bypass the engine** — `SystemImpactLightPreset`, `SystemSelectionPreset`, etc. override `play()` to call UIKit feedback generators (`UIImpactFeedbackGenerator.impactOccurred()`, `UISelectionFeedbackGenerator.selectionChanged()`, etc.) unconditionally. These UIKit APIs are independent of `CHHapticEngine` and ignore its stopped state.

2. **Engine restarts itself** — `startEngine()` (called by `createPlayer()`, `getRealtimePlayer()`, `playPlayer()`) doesn't check `isHapticsEnabled`, so any play call after `enableHaptics(false)` silently restarts the engine. This means custom presets and pattern composers also resume haptics.

3. **RealtimeComposer has no enabled check** — `set()` and `playDiscrete()` proceed unconditionally, restarting the engine via `getRealtimePlayer()` → `startEngine()`.

## Changes

- **`HapticEngineWrapper.swift`** — Make `isHapticsEnabled` readable within the module (`private(set)`). Guard `startEngine()` to not restart when haptics are disabled.
- **`Pulsar.swift`** — Add `isHapticsEnabled` computed property so presets can check the state.
- **`Player.swift`** — Store a weak `Pulsar` reference. Expose `isEnabled` property. Gate `play()` with `guard isEnabled`.
- **`SystemPresetsImpl.swift`** — Add `guard isEnabled else { return }` to all 9 system preset `play()` overrides, preventing UIKit generators from firing when disabled.
- **`RealtimeComposer.swift`** — Gate `set()` and `playDiscrete()` with `engine.isHapticsEnabled` check.

## Behavior

- **When haptics are enabled**: No change — all presets, patterns, and realtime haptics work exactly as before.
- **When haptics are disabled**: All haptic output is suppressed — system presets, custom presets, pattern composers, and realtime composer all respect the setting.
- **Android**: Unaffected (already working correctly).