### PR TITLE
Fix npm i by making prepare install devDeps first

### DIFF
--- a/react-native/react-native-pulsar/package.json
+++ b/react-native/react-native-pulsar/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build lib",
     "build": "bob build",
-    "prepare": "bob build",
+    "prepare": "npm install --ignore-scripts --no-audit --no-fund && bob build",
     "release": "release-it --only-version"
   },
   "keywords": [


### PR DESCRIPTION
Before, running npm i inside PulsarApp would fail as it ran prepare script in react-native-pulsar which call bob build which was not installed

now, the prepare script runs npm i before running bob