### PR TITLE
Handle unsupported envelope timing

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
@@ -110,7 +110,7 @@ class HapticEngineWrapper(private val context: Context) {
     }
 
     fun getMinControlPointDurationMillis(): Long {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        return if (isEnvelopeSupported()) {
             vibrator?.envelopeEffectInfo?.minControlPointDurationMillis ?: 15L
         } else {
             15L

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
@@ -110,7 +110,7 @@ class HapticEngineWrapper(private val context: Context) {
     }
 
     fun getMinControlPointDurationMillis(): Long {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        return if (isEnvelopeSupported()) {
             vibrator?.envelopeEffectInfo?.minControlPointDurationMillis ?: 15L
         } else {
             15L

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/haptics/HapticEngineWrapper.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/haptics/HapticEngineWrapper.kt
@@ -110,7 +110,7 @@ class HapticEngineWrapper(private val context: Context) {
     }
 
     fun getMinControlPointDurationMillis(): Long {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        return if (isEnvelopeSupported()) {
             vibrator?.envelopeEffectInfo?.minControlPointDurationMillis ?: 15L
         } else {
             15L

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/haptics/HapticEngineWrapper.kt
@@ -110,7 +110,7 @@ class HapticEngineWrapper(private val context: Context) {
     }
 
     fun getMinControlPointDurationMillis(): Long {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        return if (isEnvelopeSupported()) {
             vibrator?.envelopeEffectInfo?.minControlPointDurationMillis ?: 15L
         } else {
             15L


### PR DESCRIPTION
Some Android devices do not play short haptic presets because Pulsar may pass an unsupported envelope control point duration into peak timing conversion.

Android returns `0` for `VibratorEnvelopeEffectInfo.minControlPointDurationMillis` when envelope effects are not supported:

    If the device does not support envelope effects, this method will return 0.

Use Pulsar's existing `15ms` default when envelope effects are not supported.

May be related with #27.