### PR TITLE
Respect user audio settings on device

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -18,12 +18,14 @@ import com.swmansion.pulsar.types.ValuePoint
 import com.swmansion.pulsar.types.WaveformType
 import kotlin.math.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -43,7 +45,7 @@ class AudioSimulator(
     private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
-    private var playSound: Boolean = BuildConfig.DEBUG
+    private var playSound: Boolean = isEmulatorDevice || BuildConfig.DEBUG
     private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
@@ -61,9 +63,15 @@ class AudioSimulator(
     }
 
     fun enableSound(value: Boolean) {
-        this.playSound = value
-        this.shouldForceAudiblePlayback = value
-        resetAudioContext()
+        runBlocking {
+            currentPlayJob?.cancelAndJoin()
+            currentPlayJob = null
+            audioMutex.withLock {
+                stopAndReleaseAudioTrack()
+            }
+            this@AudioSimulator.shouldForceAudiblePlayback = value
+            this@AudioSimulator.playSound = value
+        }
     }
 
     fun play(buffer: ByteArray?) {
@@ -201,6 +209,18 @@ class AudioSimulator(
         } catch (_: Exception) {}
         audioTrack = null
         isInitialized = false
+    }
+
+    private fun stopAndReleaseAudioTrack() {
+        try {
+            audioTrack?.apply {
+                if (playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    stop()
+                    flush()
+                }
+            }
+        } catch (_: Exception) {}
+        resetAudioContext()
     }
 
     private fun resolveAudioUsage(): Int {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -3,6 +3,7 @@ package com.swmansion.pulsar.audio
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import com.swmansion.pulsar.BuildConfig
 import com.swmansion.pulsar.types.AudioDataConfig
 import com.swmansion.pulsar.types.AudioPatternConfig
@@ -39,9 +40,11 @@ class AudioSimulator(
 
     private val sampleRate: Int = 22050
     private val sampleRateF: Float = sampleRate.toFloat()
+    private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
     private var playSound: Boolean = BuildConfig.DEBUG
+    private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
     private var currentPlayJob: Job? = null
@@ -59,6 +62,8 @@ class AudioSimulator(
 
     fun enableSound(value: Boolean) {
         this.playSound = value
+        this.shouldForceAudiblePlayback = value
+        resetAudioContext()
     }
 
     fun play(buffer: ByteArray?) {
@@ -172,7 +177,7 @@ class AudioSimulator(
         audioTrack = AudioTrack.Builder()
             .setAudioAttributes(
                 AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setUsage(resolveAudioUsage())
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                     .build()
             )
@@ -188,6 +193,50 @@ class AudioSimulator(
             .build()
 
         isInitialized = true
+    }
+
+    private fun resetAudioContext() {
+        try {
+            audioTrack?.release()
+        } catch (_: Exception) {}
+        audioTrack = null
+        isInitialized = false
+    }
+
+    private fun resolveAudioUsage(): Int {
+        return if (isEmulatorDevice || shouldForceAudiblePlayback) {
+            AudioAttributes.USAGE_MEDIA
+        } else {
+            AudioAttributes.USAGE_ASSISTANCE_SONIFICATION
+        }
+    }
+
+    private fun isEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val manufacturer = Build.MANUFACTURER
+        val brand = Build.BRAND
+        val device = Build.DEVICE
+        val hardware = Build.HARDWARE
+        val board = Build.BOARD.lowercase()
+        val bootloader = Build.BOOTLOADER.lowercase()
+        val hardwareLower = hardware.lowercase()
+        val product = Build.PRODUCT
+
+        return fingerprint.startsWith("generic") ||
+            fingerprint.startsWith("unknown") ||
+            model.contains("google_sdk") ||
+            model.contains("Emulator") ||
+            model.contains("Android SDK built for x86") ||
+            manufacturer.contains("Genymotion") ||
+            (brand.startsWith("generic") && device.startsWith("generic")) ||
+            product == "google_sdk" ||
+            hardware.contains("goldfish") ||
+            hardware.contains("ranchu") ||
+            board.contains("nox") ||
+            bootloader.contains("nox") ||
+            hardwareLower.contains("nox") ||
+            product.lowercase().contains("nox")
     }
 
     private fun generateWaveform(waveform: WaveformType, phase: Float): Float {

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -18,12 +18,14 @@ import com.swmansion.pulsar.types.ValuePoint
 import com.swmansion.pulsar.types.WaveformType
 import kotlin.math.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -43,7 +45,7 @@ class AudioSimulator(
     private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
-    private var playSound: Boolean = BuildConfig.DEBUG
+    private var playSound: Boolean = isEmulatorDevice || BuildConfig.DEBUG
     private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
@@ -61,9 +63,15 @@ class AudioSimulator(
     }
 
     fun enableSound(value: Boolean) {
-        this.playSound = value
-        this.shouldForceAudiblePlayback = value
-        resetAudioContext()
+        runBlocking {
+            currentPlayJob?.cancelAndJoin()
+            currentPlayJob = null
+            audioMutex.withLock {
+                stopAndReleaseAudioTrack()
+            }
+            this@AudioSimulator.shouldForceAudiblePlayback = value
+            this@AudioSimulator.playSound = value
+        }
     }
 
     fun play(buffer: ByteArray?) {
@@ -201,6 +209,18 @@ class AudioSimulator(
         } catch (_: Exception) {}
         audioTrack = null
         isInitialized = false
+    }
+
+    private fun stopAndReleaseAudioTrack() {
+        try {
+            audioTrack?.apply {
+                if (playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    stop()
+                    flush()
+                }
+            }
+        } catch (_: Exception) {}
+        resetAudioContext()
     }
 
     private fun resolveAudioUsage(): Int {

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -3,6 +3,7 @@ package com.swmansion.pulsar.audio
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import com.swmansion.pulsar.BuildConfig
 import com.swmansion.pulsar.types.AudioDataConfig
 import com.swmansion.pulsar.types.AudioPatternConfig
@@ -39,9 +40,11 @@ class AudioSimulator(
 
     private val sampleRate: Int = 22050
     private val sampleRateF: Float = sampleRate.toFloat()
+    private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
     private var playSound: Boolean = BuildConfig.DEBUG
+    private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
     private var currentPlayJob: Job? = null
@@ -59,6 +62,8 @@ class AudioSimulator(
 
     fun enableSound(value: Boolean) {
         this.playSound = value
+        this.shouldForceAudiblePlayback = value
+        resetAudioContext()
     }
 
     fun play(buffer: ByteArray?) {
@@ -172,7 +177,7 @@ class AudioSimulator(
         audioTrack = AudioTrack.Builder()
             .setAudioAttributes(
                 AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setUsage(resolveAudioUsage())
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                     .build()
             )
@@ -188,6 +193,50 @@ class AudioSimulator(
             .build()
 
         isInitialized = true
+    }
+
+    private fun resetAudioContext() {
+        try {
+            audioTrack?.release()
+        } catch (_: Exception) {}
+        audioTrack = null
+        isInitialized = false
+    }
+
+    private fun resolveAudioUsage(): Int {
+        return if (isEmulatorDevice || shouldForceAudiblePlayback) {
+            AudioAttributes.USAGE_MEDIA
+        } else {
+            AudioAttributes.USAGE_ASSISTANCE_SONIFICATION
+        }
+    }
+
+    private fun isEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val manufacturer = Build.MANUFACTURER
+        val brand = Build.BRAND
+        val device = Build.DEVICE
+        val hardware = Build.HARDWARE
+        val board = Build.BOARD.lowercase()
+        val bootloader = Build.BOOTLOADER.lowercase()
+        val hardwareLower = hardware.lowercase()
+        val product = Build.PRODUCT
+
+        return fingerprint.startsWith("generic") ||
+            fingerprint.startsWith("unknown") ||
+            model.contains("google_sdk") ||
+            model.contains("Emulator") ||
+            model.contains("Android SDK built for x86") ||
+            manufacturer.contains("Genymotion") ||
+            (brand.startsWith("generic") && device.startsWith("generic")) ||
+            product == "google_sdk" ||
+            hardware.contains("goldfish") ||
+            hardware.contains("ranchu") ||
+            board.contains("nox") ||
+            bootloader.contains("nox") ||
+            hardwareLower.contains("nox") ||
+            product.lowercase().contains("nox")
     }
 
     private fun generateWaveform(waveform: WaveformType, phase: Float): Float {

--- a/flutter/pulsar/ios/Classes/Audio/AudioSimulator.swift
+++ b/flutter/pulsar/ios/Classes/Audio/AudioSimulator.swift
@@ -3,6 +3,13 @@ import AVFoundation
 
 public class AudioSimulator: NSObject {
 	private let sampleRate: Double = 22050
+  private let isSimulatorDevice: Bool = {
+    #if targetEnvironment(simulator)
+      return true
+    #else
+      return false
+    #endif
+  }()
 	private var audioContext: AVAudioEngine = AVAudioEngine()
 	private var offlineContext: AVAudioEngine?
 	private var currentSource: AVAudioPlayerNode?
@@ -11,14 +18,18 @@ public class AudioSimulator: NSObject {
 	private var isInitialized = false
 	private var isEngineConfigured = false
   private var shouldForceAudiblePlayback = false
- #if DEBUG
-  private var playSound: Bool = true
-#else
-  private var playSound: Bool = false
-#endif
+  private var playSound: Bool
 
 	public override init() {
+    #if DEBUG
+      self.playSound = true
+    #else
+      self.playSound = false
+    #endif
 		super.init()
+    if (isSimulatorDevice) {
+      self.playSound = true
+    }
     if (playSound) {
       configureAudioContext()
     }
@@ -40,7 +51,13 @@ public class AudioSimulator: NSObject {
   public func enableSound(_ value: Bool) {
     self.playSound = value
     self.shouldForceAudiblePlayback = value
-    updateAudioSessionCategory()
+    if (!value) {
+      stop()
+      audioContext.pause()
+      deactivateAudioSession()
+    } else {
+      updateAudioSessionCategory()
+    }
   }
 
 	private func configureAudioContext() {
@@ -81,12 +98,19 @@ public class AudioSimulator: NSObject {
 		}
   }
 
+  private func deactivateAudioSession() {
+    do {
+      try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    } catch {
+      print("AudioSession deactivation error: \(error)")
+    }
+  }
+
   private func resolveAudioSessionCategory() -> AVAudioSession.Category {
-    #if targetEnvironment(simulator)
+    if (isSimulatorDevice || shouldForceAudiblePlayback) {
       return .playback
-    #else
-      return shouldForceAudiblePlayback ? .playback : .ambient
-    #endif
+    }
+    return .ambient
   }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {

--- a/flutter/pulsar/ios/Classes/Audio/AudioSimulator.swift
+++ b/flutter/pulsar/ios/Classes/Audio/AudioSimulator.swift
@@ -10,6 +10,7 @@ public class AudioSimulator: NSObject {
 	private var filterNode: AVAudioUnitEQ = AVAudioUnitEQ(numberOfBands: 1)
 	private var isInitialized = false
 	private var isEngineConfigured = false
+  private var shouldForceAudiblePlayback = false
  #if DEBUG
   private var playSound: Bool = true
 #else
@@ -38,18 +39,14 @@ public class AudioSimulator: NSObject {
 
   public func enableSound(_ value: Bool) {
     self.playSound = value
+    self.shouldForceAudiblePlayback = value
+    updateAudioSessionCategory()
   }
 
 	private func configureAudioContext() {
 		guard !isEngineConfigured else { return }
 
-    let session = AVAudioSession.sharedInstance()
-		do {
-			try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
-			try session.setActive(true)
-		} catch {
-			print("AudioSession error: \(error)")
-		}
+    updateAudioSessionCategory()
 
 		// Setup audio engine: Player -> Filter(lowpass) -> MainMixer
 		audioContext.attach(playerNode)
@@ -73,6 +70,24 @@ public class AudioSimulator: NSObject {
 			print("Failed to start AVAudioEngine: \(error)")
 		}
 	}
+
+  private func updateAudioSessionCategory() {
+    let session = AVAudioSession.sharedInstance()
+		do {
+			try session.setCategory(resolveAudioSessionCategory(), mode: .default, options: [.mixWithOthers])
+			try session.setActive(true)
+		} catch {
+			print("AudioSession error: \(error)")
+		}
+  }
+
+  private func resolveAudioSessionCategory() -> AVAudioSession.Category {
+    #if targetEnvironment(simulator)
+      return .playback
+    #else
+      return shouldForceAudiblePlayback ? .playback : .ambient
+    #endif
+  }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {
 		let normalizedPhase = phase.truncatingRemainder(dividingBy: Double.pi * 2) / (Double.pi * 2)

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -3,6 +3,13 @@ import AVFoundation
 
 public class AudioSimulator: NSObject {
 	private let sampleRate: Double = 22050
+  private let isSimulatorDevice: Bool = {
+    #if targetEnvironment(simulator)
+      return true
+    #else
+      return false
+    #endif
+  }()
 	private var audioContext: AVAudioEngine = AVAudioEngine()
 	private var offlineContext: AVAudioEngine?
 	private var currentSource: AVAudioPlayerNode?
@@ -11,14 +18,18 @@ public class AudioSimulator: NSObject {
 	private var isInitialized = false
 	private var isEngineConfigured = false
   private var shouldForceAudiblePlayback = false
- #if DEBUG
-  private var playSound: Bool = true
-#else
-  private var playSound: Bool = false
-#endif
+  private var playSound: Bool
 
 	public override init() {
+    #if DEBUG
+      self.playSound = true
+    #else
+      self.playSound = false
+    #endif
 		super.init()
+    if (isSimulatorDevice) {
+      self.playSound = true
+    }
     if (playSound) {
       configureAudioContext()
     }
@@ -40,7 +51,13 @@ public class AudioSimulator: NSObject {
   public func enableSound(_ value: Bool) {
     self.playSound = value
     self.shouldForceAudiblePlayback = value
-    updateAudioSessionCategory()
+    if (!value) {
+      stop()
+      audioContext.pause()
+      deactivateAudioSession()
+    } else {
+      updateAudioSessionCategory()
+    }
   }
 
 	private func configureAudioContext() {
@@ -81,12 +98,19 @@ public class AudioSimulator: NSObject {
 		}
   }
 
+  private func deactivateAudioSession() {
+    do {
+      try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    } catch {
+      print("AudioSession deactivation error: \(error)")
+    }
+  }
+
   private func resolveAudioSessionCategory() -> AVAudioSession.Category {
-    #if targetEnvironment(simulator)
+    if (isSimulatorDevice || shouldForceAudiblePlayback) {
       return .playback
-    #else
-      return shouldForceAudiblePlayback ? .playback : .ambient
-    #endif
+    }
+    return .ambient
   }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -10,6 +10,7 @@ public class AudioSimulator: NSObject {
 	private var filterNode: AVAudioUnitEQ = AVAudioUnitEQ(numberOfBands: 1)
 	private var isInitialized = false
 	private var isEngineConfigured = false
+  private var shouldForceAudiblePlayback = false
  #if DEBUG
   private var playSound: Bool = true
 #else
@@ -38,18 +39,14 @@ public class AudioSimulator: NSObject {
 
   public func enableSound(_ value: Bool) {
     self.playSound = value
+    self.shouldForceAudiblePlayback = value
+    updateAudioSessionCategory()
   }
 
 	private func configureAudioContext() {
 		guard !isEngineConfigured else { return }
 
-    let session = AVAudioSession.sharedInstance()
-		do {
-			try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
-			try session.setActive(true)
-		} catch {
-			print("AudioSession error: \(error)")
-		}
+    updateAudioSessionCategory()
 
 		// Setup audio engine: Player -> Filter(lowpass) -> MainMixer
 		audioContext.attach(playerNode)
@@ -73,6 +70,24 @@ public class AudioSimulator: NSObject {
 			print("Failed to start AVAudioEngine: \(error)")
 		}
 	}
+
+  private func updateAudioSessionCategory() {
+    let session = AVAudioSession.sharedInstance()
+		do {
+			try session.setCategory(resolveAudioSessionCategory(), mode: .default, options: [.mixWithOthers])
+			try session.setActive(true)
+		} catch {
+			print("AudioSession error: \(error)")
+		}
+  }
+
+  private func resolveAudioSessionCategory() -> AVAudioSession.Category {
+    #if targetEnvironment(simulator)
+      return .playback
+    #else
+      return shouldForceAudiblePlayback ? .playback : .ambient
+    #endif
+  }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {
 		let normalizedPhase = phase.truncatingRemainder(dividingBy: Double.pi * 2) / (Double.pi * 2)

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/audio/AudioSimulator.kt
@@ -17,12 +17,14 @@ import com.swmansion.pulsar.kmp.androidimpl.types.ValuePoint
 import com.swmansion.pulsar.kmp.androidimpl.types.WaveformType
 import kotlin.math.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -43,7 +45,7 @@ class AudioSimulator(
     private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
-    private var playSound: Boolean = isDebugBuild
+    private var playSound: Boolean = isEmulatorDevice || isDebugBuild
     private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
@@ -61,9 +63,15 @@ class AudioSimulator(
     }
 
     fun enableSound(value: Boolean) {
-        this.playSound = value
-        this.shouldForceAudiblePlayback = value
-        resetAudioContext()
+        runBlocking {
+            currentPlayJob?.cancelAndJoin()
+            currentPlayJob = null
+            audioMutex.withLock {
+                stopAndReleaseAudioTrack()
+            }
+            this@AudioSimulator.shouldForceAudiblePlayback = value
+            this@AudioSimulator.playSound = value
+        }
     }
 
     fun play(buffer: ByteArray?) {
@@ -201,6 +209,18 @@ class AudioSimulator(
         } catch (_: Exception) {}
         audioTrack = null
         isInitialized = false
+    }
+
+    private fun stopAndReleaseAudioTrack() {
+        try {
+            audioTrack?.apply {
+                if (playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    stop()
+                    flush()
+                }
+            }
+        } catch (_: Exception) {}
+        resetAudioContext()
     }
 
     private fun resolveAudioUsage(): Int {

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/androidimpl/audio/AudioSimulator.kt
@@ -3,6 +3,7 @@ package com.swmansion.pulsar.kmp.androidimpl.audio
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import com.swmansion.pulsar.kmp.androidimpl.types.AudioDataConfig
 import com.swmansion.pulsar.kmp.androidimpl.types.AudioPatternConfig
 import com.swmansion.pulsar.kmp.androidimpl.types.CompatibilityMode
@@ -39,9 +40,11 @@ class AudioSimulator(
 
     private val sampleRate: Int = 22050
     private val sampleRateF: Float = sampleRate.toFloat()
+    private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
     private var playSound: Boolean = isDebugBuild
+    private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
     private var currentPlayJob: Job? = null
@@ -59,6 +62,8 @@ class AudioSimulator(
 
     fun enableSound(value: Boolean) {
         this.playSound = value
+        this.shouldForceAudiblePlayback = value
+        resetAudioContext()
     }
 
     fun play(buffer: ByteArray?) {
@@ -172,7 +177,7 @@ class AudioSimulator(
         audioTrack = AudioTrack.Builder()
             .setAudioAttributes(
                 AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setUsage(resolveAudioUsage())
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                     .build()
             )
@@ -188,6 +193,50 @@ class AudioSimulator(
             .build()
 
         isInitialized = true
+    }
+
+    private fun resetAudioContext() {
+        try {
+            audioTrack?.release()
+        } catch (_: Exception) {}
+        audioTrack = null
+        isInitialized = false
+    }
+
+    private fun resolveAudioUsage(): Int {
+        return if (isEmulatorDevice || shouldForceAudiblePlayback) {
+            AudioAttributes.USAGE_MEDIA
+        } else {
+            AudioAttributes.USAGE_ASSISTANCE_SONIFICATION
+        }
+    }
+
+    private fun isEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val manufacturer = Build.MANUFACTURER
+        val brand = Build.BRAND
+        val device = Build.DEVICE
+        val hardware = Build.HARDWARE
+        val board = Build.BOARD.lowercase()
+        val bootloader = Build.BOOTLOADER.lowercase()
+        val hardwareLower = hardware.lowercase()
+        val product = Build.PRODUCT
+
+        return fingerprint.startsWith("generic") ||
+            fingerprint.startsWith("unknown") ||
+            model.contains("google_sdk") ||
+            model.contains("Emulator") ||
+            model.contains("Android SDK built for x86") ||
+            manufacturer.contains("Genymotion") ||
+            (brand.startsWith("generic") && device.startsWith("generic")) ||
+            product == "google_sdk" ||
+            hardware.contains("goldfish") ||
+            hardware.contains("ranchu") ||
+            board.contains("nox") ||
+            bootloader.contains("nox") ||
+            hardwareLower.contains("nox") ||
+            product.lowercase().contains("nox")
     }
 
     private fun generateWaveform(waveform: WaveformType, phase: Float): Float {

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -38,7 +38,7 @@ internal class IOSAudioSimulator {
     private val playerNode = AVAudioPlayerNode()
     private val filterNode = AVAudioUnitEQ(numberOfBands = 1u)
     private var isEngineConfigured = false
-    private var playSound = Platform.isDebugBinary
+    private var playSound = isSimulatorDevice || Platform.isDebugBinary
     private var shouldForceAudiblePlayback = false
 
     fun parsePattern(data: PatternData): IOSAudioBuffer? {
@@ -53,8 +53,12 @@ internal class IOSAudioSimulator {
     fun enableSound(value: Boolean) {
         playSound = value
         shouldForceAudiblePlayback = value
-        updateAudioSessionCategory()
-        if (value) {
+        if (!value) {
+            stop()
+            audioContext.pause()
+            deactivateAudioSession()
+        } else {
+            updateAudioSessionCategory()
             configureAudioContext()
         }
     }
@@ -126,6 +130,14 @@ internal class IOSAudioSimulator {
             session.setActive(true, error = null)
         }.onFailure {
             log("AudioSession error: ${it.message}")
+        }
+    }
+
+    private fun deactivateAudioSession() {
+        runCatching {
+            AVAudioSession.sharedInstance().setActive(false, withOptions = 1uL, error = null)
+        }.onFailure {
+            log("AudioSession deactivation error: ${it.message}")
         }
     }
 

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -12,12 +12,14 @@ import platform.AVFAudio.AVAudioFormat
 import platform.AVFAudio.AVAudioPCMBuffer
 import platform.AVFAudio.AVAudioPlayerNode
 import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryAmbient
 import platform.AVFAudio.AVAudioSessionCategoryOptionMixWithOthers
 import platform.AVFAudio.AVAudioSessionCategoryPlayback
 import platform.AVFAudio.AVAudioSessionModeDefault
 import platform.AVFAudio.AVAudioUnitEQ
 import platform.AVFAudio.AVAudioUnitEQFilterTypeLowPass
 import platform.AVFAudio.AVAudioUnitEQFilterParameters
+import platform.Foundation.NSProcessInfo
 import platform.posix.memcpy
 import kotlin.math.PI
 import kotlin.math.ceil
@@ -31,11 +33,13 @@ import kotlin.native.Platform
 @OptIn(ExperimentalForeignApi::class, kotlin.experimental.ExperimentalNativeApi::class)
 internal class IOSAudioSimulator {
     private val sampleRate = 22_050.0
+    private val isSimulatorDevice = NSProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != null
     private val audioContext = AVAudioEngine()
     private val playerNode = AVAudioPlayerNode()
     private val filterNode = AVAudioUnitEQ(numberOfBands = 1u)
     private var isEngineConfigured = false
     private var playSound = Platform.isDebugBinary
+    private var shouldForceAudiblePlayback = false
 
     fun parsePattern(data: PatternData): IOSAudioBuffer? {
         if (!playSound) return null
@@ -48,6 +52,8 @@ internal class IOSAudioSimulator {
 
     fun enableSound(value: Boolean) {
         playSound = value
+        shouldForceAudiblePlayback = value
+        updateAudioSessionCategory()
         if (value) {
             configureAudioContext()
         }
@@ -84,17 +90,7 @@ internal class IOSAudioSimulator {
     private fun configureAudioContext() {
         if (isEngineConfigured) return
 
-        val session = AVAudioSession.sharedInstance()
-        runCatching {
-            session.setCategory(
-                AVAudioSessionCategoryPlayback,
-                mode = AVAudioSessionModeDefault,
-                options = AVAudioSessionCategoryOptionMixWithOthers,
-                error = null,
-            )
-        }.onFailure {
-            log("AudioSession error: ${it.message}")
-        }
+        updateAudioSessionCategory()
 
         audioContext.attachNode(playerNode)
         (filterNode.bands.firstOrNull() as? AVAudioUnitEQFilterParameters)?.let { band ->
@@ -115,6 +111,29 @@ internal class IOSAudioSimulator {
             isEngineConfigured = true
         }.onFailure {
             log("Failed to start AVAudioEngine: ${it.message}")
+        }
+    }
+
+    private fun updateAudioSessionCategory() {
+        val session = AVAudioSession.sharedInstance()
+        runCatching {
+            session.setCategory(
+                resolveAudioSessionCategory(),
+                mode = AVAudioSessionModeDefault,
+                options = AVAudioSessionCategoryOptionMixWithOthers,
+                error = null,
+            )
+            session.setActive(true, error = null)
+        }.onFailure {
+            log("AudioSession error: ${it.message}")
+        }
+    }
+
+    private fun resolveAudioSessionCategory(): String {
+        return if (isSimulatorDevice || shouldForceAudiblePlayback) {
+            AVAudioSessionCategoryPlayback
+        } else {
+            AVAudioSessionCategoryAmbient
         }
     }
 

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -18,12 +18,14 @@ import com.swmansion.pulsar.types.ValuePoint
 import com.swmansion.pulsar.types.WaveformType
 import kotlin.math.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -43,7 +45,7 @@ class AudioSimulator(
     private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
-    private var playSound: Boolean = BuildConfig.DEBUG
+    private var playSound: Boolean = isEmulatorDevice || BuildConfig.DEBUG
     private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
@@ -61,9 +63,15 @@ class AudioSimulator(
     }
 
     fun enableSound(value: Boolean) {
-        this.playSound = value
-        this.shouldForceAudiblePlayback = value
-        resetAudioContext()
+        runBlocking {
+            currentPlayJob?.cancelAndJoin()
+            currentPlayJob = null
+            audioMutex.withLock {
+                stopAndReleaseAudioTrack()
+            }
+            this@AudioSimulator.shouldForceAudiblePlayback = value
+            this@AudioSimulator.playSound = value
+        }
     }
 
     fun play(buffer: ByteArray?) {
@@ -201,6 +209,18 @@ class AudioSimulator(
         } catch (_: Exception) {}
         audioTrack = null
         isInitialized = false
+    }
+
+    private fun stopAndReleaseAudioTrack() {
+        try {
+            audioTrack?.apply {
+                if (playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    stop()
+                    flush()
+                }
+            }
+        } catch (_: Exception) {}
+        resetAudioContext()
     }
 
     private fun resolveAudioUsage(): Int {

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/audio/AudioSimulator.kt
@@ -3,6 +3,7 @@ package com.swmansion.pulsar.audio
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
+import android.os.Build
 import com.swmansion.pulsar.BuildConfig
 import com.swmansion.pulsar.types.AudioDataConfig
 import com.swmansion.pulsar.types.AudioPatternConfig
@@ -39,9 +40,11 @@ class AudioSimulator(
 
     private val sampleRate: Int = 22050
     private val sampleRateF: Float = sampleRate.toFloat()
+    private val isEmulatorDevice = isEmulator()
     private var audioTrack: AudioTrack? = null
     private var isInitialized = false
     private var playSound: Boolean = BuildConfig.DEBUG
+    private var shouldForceAudiblePlayback = false
     private val audioScope = CoroutineScope(Dispatchers.IO)
     private val audioMutex = Mutex()
     private var currentPlayJob: Job? = null
@@ -59,6 +62,8 @@ class AudioSimulator(
 
     fun enableSound(value: Boolean) {
         this.playSound = value
+        this.shouldForceAudiblePlayback = value
+        resetAudioContext()
     }
 
     fun play(buffer: ByteArray?) {
@@ -172,7 +177,7 @@ class AudioSimulator(
         audioTrack = AudioTrack.Builder()
             .setAudioAttributes(
                 AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setUsage(resolveAudioUsage())
                     .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                     .build()
             )
@@ -188,6 +193,50 @@ class AudioSimulator(
             .build()
 
         isInitialized = true
+    }
+
+    private fun resetAudioContext() {
+        try {
+            audioTrack?.release()
+        } catch (_: Exception) {}
+        audioTrack = null
+        isInitialized = false
+    }
+
+    private fun resolveAudioUsage(): Int {
+        return if (isEmulatorDevice || shouldForceAudiblePlayback) {
+            AudioAttributes.USAGE_MEDIA
+        } else {
+            AudioAttributes.USAGE_ASSISTANCE_SONIFICATION
+        }
+    }
+
+    private fun isEmulator(): Boolean {
+        val fingerprint = Build.FINGERPRINT
+        val model = Build.MODEL
+        val manufacturer = Build.MANUFACTURER
+        val brand = Build.BRAND
+        val device = Build.DEVICE
+        val hardware = Build.HARDWARE
+        val board = Build.BOARD.lowercase()
+        val bootloader = Build.BOOTLOADER.lowercase()
+        val hardwareLower = hardware.lowercase()
+        val product = Build.PRODUCT
+
+        return fingerprint.startsWith("generic") ||
+            fingerprint.startsWith("unknown") ||
+            model.contains("google_sdk") ||
+            model.contains("Emulator") ||
+            model.contains("Android SDK built for x86") ||
+            manufacturer.contains("Genymotion") ||
+            (brand.startsWith("generic") && device.startsWith("generic")) ||
+            product == "google_sdk" ||
+            hardware.contains("goldfish") ||
+            hardware.contains("ranchu") ||
+            board.contains("nox") ||
+            bootloader.contains("nox") ||
+            hardwareLower.contains("nox") ||
+            product.lowercase().contains("nox")
     }
 
     private fun generateWaveform(waveform: WaveformType, phase: Float): Float {

--- a/react-native/react-native-pulsar/deps/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/react-native/react-native-pulsar/deps/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -3,6 +3,13 @@ import AVFoundation
 
 public class AudioSimulator: NSObject {
 	private let sampleRate: Double = 22050
+  private let isSimulatorDevice: Bool = {
+    #if targetEnvironment(simulator)
+      return true
+    #else
+      return false
+    #endif
+  }()
 	private var audioContext: AVAudioEngine = AVAudioEngine()
 	private var offlineContext: AVAudioEngine?
 	private var currentSource: AVAudioPlayerNode?
@@ -11,14 +18,18 @@ public class AudioSimulator: NSObject {
 	private var isInitialized = false
 	private var isEngineConfigured = false
   private var shouldForceAudiblePlayback = false
- #if DEBUG
-  private var playSound: Bool = true
-#else
-  private var playSound: Bool = false
-#endif
+  private var playSound: Bool
 
 	public override init() {
+    #if DEBUG
+      self.playSound = true
+    #else
+      self.playSound = false
+    #endif
 		super.init()
+    if (isSimulatorDevice) {
+      self.playSound = true
+    }
     if (playSound) {
       configureAudioContext()
     }
@@ -40,7 +51,13 @@ public class AudioSimulator: NSObject {
   public func enableSound(_ value: Bool) {
     self.playSound = value
     self.shouldForceAudiblePlayback = value
-    updateAudioSessionCategory()
+    if (!value) {
+      stop()
+      audioContext.pause()
+      deactivateAudioSession()
+    } else {
+      updateAudioSessionCategory()
+    }
   }
 
 	private func configureAudioContext() {
@@ -81,12 +98,19 @@ public class AudioSimulator: NSObject {
 		}
   }
 
+  private func deactivateAudioSession() {
+    do {
+      try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    } catch {
+      print("AudioSession deactivation error: \(error)")
+    }
+  }
+
   private func resolveAudioSessionCategory() -> AVAudioSession.Category {
-    #if targetEnvironment(simulator)
+    if (isSimulatorDevice || shouldForceAudiblePlayback) {
       return .playback
-    #else
-      return shouldForceAudiblePlayback ? .playback : .ambient
-    #endif
+    }
+    return .ambient
   }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {

--- a/react-native/react-native-pulsar/deps/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/react-native/react-native-pulsar/deps/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -10,6 +10,7 @@ public class AudioSimulator: NSObject {
 	private var filterNode: AVAudioUnitEQ = AVAudioUnitEQ(numberOfBands: 1)
 	private var isInitialized = false
 	private var isEngineConfigured = false
+  private var shouldForceAudiblePlayback = false
  #if DEBUG
   private var playSound: Bool = true
 #else
@@ -38,18 +39,14 @@ public class AudioSimulator: NSObject {
 
   public func enableSound(_ value: Bool) {
     self.playSound = value
+    self.shouldForceAudiblePlayback = value
+    updateAudioSessionCategory()
   }
 
 	private func configureAudioContext() {
 		guard !isEngineConfigured else { return }
 
-    let session = AVAudioSession.sharedInstance()
-		do {
-			try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
-			try session.setActive(true)
-		} catch {
-			print("AudioSession error: \(error)")
-		}
+    updateAudioSessionCategory()
 
 		// Setup audio engine: Player -> Filter(lowpass) -> MainMixer
 		audioContext.attach(playerNode)
@@ -73,6 +70,24 @@ public class AudioSimulator: NSObject {
 			print("Failed to start AVAudioEngine: \(error)")
 		}
 	}
+
+  private func updateAudioSessionCategory() {
+    let session = AVAudioSession.sharedInstance()
+		do {
+			try session.setCategory(resolveAudioSessionCategory(), mode: .default, options: [.mixWithOthers])
+			try session.setActive(true)
+		} catch {
+			print("AudioSession error: \(error)")
+		}
+  }
+
+  private func resolveAudioSessionCategory() -> AVAudioSession.Category {
+    #if targetEnvironment(simulator)
+      return .playback
+    #else
+      return shouldForceAudiblePlayback ? .playback : .ambient
+    #endif
+  }
 
 	private func generateWaveform(_ waveform: WaveformType, phase: Double) -> Double {
 		let normalizedPhase = phase.truncatingRemainder(dividingBy: Double.pi * 2) / (Double.pi * 2)


### PR DESCRIPTION
Fixes https://github.com/software-mansion/pulsar/issues/23

Respect user audio settings during haptic playback

| Environment | Build | Default sound | Respects system sound prefs | `enableSound(true)` |
|---|---|---:|---:|---:|
| Simulator / Emulator | Debug | Yes | No | Yes |
| Simulator / Emulator | Release | Yes | No | Yes |
| Real device | Debug | Yes | Yes | Yes |
| Real device | Release | No | N/A | Yes |