### PR TITLE
perf(ios): lazy-init haptic engine and lifecycle observers

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -6,7 +6,12 @@ public class HapticEngineWrapper {
   private var engine: CHHapticEngine?
   private var initialized = false
   private(set) var isHapticsEnabled = true
-  private var isAppActive: Bool
+  // App-active state is resolved lazily on first use so that constructing the
+  // wrapper does not require the main thread (UIApplication.shared can only be
+  // read from the main thread). Once observed, it is kept up to date via the
+  // lifecycle observers registered lazily alongside engine creation.
+  private var isAppActiveCache: Bool?
+  private var lifecycleObserversRegistered = false
   private var playerRegistry: [Int: CHHapticPatternPlayer] = [:]
   private var playerCreationOrder: [Int] = []
   private let playerLimit = 20
@@ -14,21 +19,9 @@ public class HapticEngineWrapper {
   private var cachedRealtimePlayer: CHHapticAdvancedPatternPlayer?
 
   public init() {
-    isAppActive = UIApplication.shared.applicationState == .active
-
-    guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else {
-      print("Error: Device doesn't support haptics")
-      return
-    }
-
-    do {
-      engine = try CHHapticEngine()
-      setupEngineHandlers()
-      startEngine()
-      registerAppLifecycleObservers()
-    } catch {
-      print("Error starting engine: \(error.localizedDescription)")
-    }
+    // Intentionally empty: do NOT touch CoreHaptics, UIApplication or
+    // NotificationCenter here. The engine is started lazily on first use to
+    // keep app startup cheap. See `startEngine()` / `ensureLifecycleObservers()`.
   }
 
   deinit {
@@ -123,11 +116,30 @@ public extension HapticEngineWrapper {
 extension HapticEngineWrapper {
 
   func updatePlaybackAvailability(for state: UIApplication.State) {
-    isAppActive = state == .active
+    isAppActiveCache = state == .active
   }
 
   func canPlayHaptics() -> Bool {
-    isHapticsEnabled && isAppActive && isHapticsSupported()
+    isHapticsEnabled && isAppActive() && isHapticsSupported()
+  }
+
+  /// Lazily resolves the cached UIApplication state. The first read must happen
+  /// on the main thread; subsequent reads use the cache updated by lifecycle
+  /// observers (registered lazily by `ensureLifecycleObservers()`).
+  func isAppActive() -> Bool {
+    if let cached = isAppActiveCache {
+      return cached
+    }
+    let resolved: Bool
+    if Thread.isMainThread {
+      resolved = UIApplication.shared.applicationState == .active
+    } else {
+      resolved = DispatchQueue.main.sync {
+        UIApplication.shared.applicationState == .active
+      }
+    }
+    isAppActiveCache = resolved
+    return resolved
   }
 
   func isHapticsSupported() -> Bool {
@@ -202,10 +214,17 @@ private extension HapticEngineWrapper {
       try createEngineIfNeeded()
       try engine?.start()
       initialized = true
+      ensureLifecycleObservers()
     } catch {
       print("Error starting engine: \(error.localizedDescription)")
       engine = nil
     }
+  }
+
+  func ensureLifecycleObservers() {
+    guard !lifecycleObserversRegistered else { return }
+    lifecycleObserversRegistered = true
+    registerAppLifecycleObservers()
   }
 
   func createEngineIfNeeded() throws {

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -41,11 +41,16 @@ RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  // Module construction does no UI / CoreHaptics / AVAudio work, so we don't
+  // need to block the main queue during bridge setup. Methods that need to
+  // run on the main thread still dispatch via `methodQueue` below.
+  return NO;
 }
 
 - (dispatch_queue_t)methodQueue
 {
+  // Methods read UIApplication state and drive CoreHaptics / AVAudio APIs that
+  // are most reliable on the main queue, so keep method dispatch there.
   return dispatch_get_main_queue();
 }
 


### PR DESCRIPTION
## Why

Investigation of a user report that Pulsar may spike app cold-start time on iOS found two synchronous costs paid by every consuming app, even ones that never trigger a haptic:

1. `HapticEngineWrapper.init()` allocated a `CHHapticEngine`, called `engine.start()` (CoreHaptics XPC roundtrip, can spike >100 ms on first launch), and registered four `NotificationCenter` lifecycle observers.
2. The RN module declared `requiresMainQueueSetup = YES`, so all of that ran on the main thread during bridge boot.

There was no production guard around any of it.

## What

- `HapticEngineWrapper.init()` is now empty. Engine allocation + `start()` are deferred to the existing `startEngine()` path that already fires on the first `createPlayer` / `getRealtimePlayer` / `playPlayer` call. The change is invisible to consumers that actually use haptics — the first call pays the same cost it would have paid at startup.
- Lifecycle observers are registered lazily the first time the engine starts (`ensureLifecycleObservers()`).
- `UIApplication.applicationState` is now read lazily on the first `canPlayHaptics()` check (main-thread-hopped if needed), then kept in sync by the existing observers.
- `Haptics.mm` flips `requiresMainQueueSetup` to `NO`. `methodQueue` stays `dispatch_get_main_queue()` so per-method calls still hit CoreHaptics/AVAudio from a safe thread.

## Expected impact

Apps that import `react-native-pulsar` but don't trigger haptics during startup should no longer see any Pulsar-attributable work on the main thread before first interaction. Apps that do trigger a haptic immediately at boot will see the same total cost — just attributed to the first call instead of bridge setup.

## Risks

Low. The deferred-start path is already exercised by every `enableHaptics(true)` / `stopHaptics()` / app-foreground transition. Lifecycle observers fire on the first real engine start instead of at boot — a benign timing difference because the observers only matter once an engine exists.