### PR TITLE
perf(ios): make AudioSimulator's AVFoundation graph lazy

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -10,9 +10,12 @@ public class AudioSimulator: NSObject {
       return false
     #endif
   }()
-	private var audioContext: AVAudioEngine = AVAudioEngine()
-	private var playerNode: AVAudioPlayerNode = AVAudioPlayerNode()
-	private var filterNode: AVAudioUnitEQ = AVAudioUnitEQ(numberOfBands: 1)
+	// AVFoundation objects are allocated lazily inside `configureAudioContext`,
+	// not at init time, so that the AVFAudio/AudioToolbox dylibs are not loaded
+	// during cold start for apps that never enable sound playback.
+	private var audioContext: AVAudioEngine?
+	private var playerNode: AVAudioPlayerNode?
+	private var filterNode: AVAudioUnitEQ?
 	private var isEngineConfigured = false
   private var shouldForceAudiblePlayback = false
 
@@ -61,8 +64,8 @@ public class AudioSimulator: NSObject {
       guard let self = self else { return }
       self.shouldForceAudiblePlayback = value
       if (!value) {
-        self.playerNode.stop()
-        self.audioContext.pause()
+        self.playerNode?.stop()
+        self.audioContext?.pause()
         self.deactivateAudioSession()
       } else {
         self.updateAudioSessionCategory()
@@ -74,6 +77,14 @@ public class AudioSimulator: NSObject {
 		guard !isEngineConfigured else { return }
 
     updateAudioSessionCategory()
+
+		// Allocate the AVFoundation graph the first time we actually need it.
+		let audioContext = self.audioContext ?? AVAudioEngine()
+		let playerNode = self.playerNode ?? AVAudioPlayerNode()
+		let filterNode = self.filterNode ?? AVAudioUnitEQ(numberOfBands: 1)
+		self.audioContext = audioContext
+		self.playerNode = playerNode
+		self.filterNode = filterNode
 
 		// Setup audio engine: Player -> Filter(lowpass) -> MainMixer
 		audioContext.attach(playerNode)
@@ -405,39 +416,40 @@ public class AudioSimulator: NSObject {
       guard let self = self, self.playSound else { return }
       self.configureAudioContext()
 
+      guard self.isEngineConfigured,
+            let audioContext = self.audioContext,
+            let playerNode = self.playerNode else { return }
 
-      guard self.isEngineConfigured else { return }
-
-      if self.playerNode.isPlaying { self.playerNode.stop() }
-      if !self.audioContext.isRunning {
+      if playerNode.isPlaying { playerNode.stop() }
+      if !audioContext.isRunning {
         do {
           try AVAudioSession.sharedInstance().setActive(true)
-          try self.audioContext.start()
+          try audioContext.start()
         } catch {
           print("Failed to start audio engine: \(error)")
           return
         }
       }
 
-      guard self.audioContext.isRunning,
+      guard audioContext.isRunning,
             buffer.format.sampleRate == self.sampleRate,
             buffer.format.channelCount == 1 else {
         print("Skipping playback: engine not running or buffer format mismatch")
         return
       }
 
-      self.playerNode.scheduleBuffer(buffer, at: nil, options: [])
-      self.playerNode.play()
+      playerNode.scheduleBuffer(buffer, at: nil, options: [])
+      playerNode.play()
     }
 	}
 
 	public func stop() {
     audioQueue.async { [weak self] in
-      self?.playerNode.stop()
+      self?.playerNode?.stop()
     }
 	}
 
 	public var isPlaying: Bool {
-		return audioQueue.sync { playerNode.isPlaying }
+		return audioQueue.sync { playerNode?.isPlaying ?? false }
 	}
 }


### PR DESCRIPTION
## Why

`AudioSimulator`'s stored properties unconditionally allocated `AVAudioEngine`, `AVAudioPlayerNode` and `AVAudioUnitEQ(numberOfBands: 1)` at init time. Because `Pulsar` is constructed when `RNPulsar` is instantiated by the RN bridge, this loaded the AVFAudio and AudioToolbox dylibs on every cold start — even in release builds where `playSound` is `false` and the graph is never used.

## What

Convert the three nodes to `Optional` and allocate them inside `configureAudioContext()`, which already runs lazily on the audio queue and only fires when playback is actually requested. Call sites that previously assumed non-nil access now use optional chaining or unwrap once at the top of the audio-queue block.

## Expected impact

Apps that never call `enableSound(true)` (the production default — `_playSound` is `false` outside DEBUG/simulator) pay zero for the audio graph at startup. The first call to `enableSound(true)` / `play(buffer:)` pays the same cost it would have paid at boot.

## Risks

Low. The audio graph was already only *configured* lazily; this PR makes the underlying object allocations lazy too. Behaviour after first use is unchanged.