### PR TITLE
perf(js): defer Settings TurboModule primes to first call

### DIFF
--- a/react-native/react-native-pulsar/src/Settings.ts
+++ b/react-native/react-native-pulsar/src/Settings.ts
@@ -1,49 +1,73 @@
 import Pulsar, { HapticSupport, RealtimeComposerStrategy } from './NativeRNPulsar';
 
-// workaround for RN prototype caching issue 
-Pulsar.Pulsar_enableSound;
-Pulsar.Pulsar_enableCache;
-Pulsar.Pulsar_clearCache;
-Pulsar.Pulsar_preloadPresets;
-Pulsar.Pulsar_stopHaptics;
-Pulsar.Pulsar_shutDownEngine;
-Pulsar.Pulsar_hapticSupport;
-Pulsar.Pulsar_forceHapticsSupportLevel;
-Pulsar.Pulsar_enableImpulseCompositionMode;
-Pulsar.Pulsar_setRealtimeComposerStrategy;
+// Workaround for RN prototype caching issue: TurboModule method bindings need
+// to be read once on the JS thread before they can be called reliably. We do
+// this lazily, on the first call into Settings, so that simply importing
+// `react-native-pulsar` (e.g. via `import { Settings } from ...`) does not
+// force eager native-module materialization at app cold start. None of these
+// methods are called from worklets, so a lazy prime on JS thread is safe —
+// `Presets` keeps its top-level prime because those wrappers are worklets and
+// need the bindings ready before the first worklet invocation.
+let settingsPrimed = false;
+const primeSettings = () => {
+  if (settingsPrimed) return;
+  settingsPrimed = true;
+  Pulsar.Pulsar_enableHaptics;
+  Pulsar.Pulsar_enableSound;
+  Pulsar.Pulsar_enableCache;
+  Pulsar.Pulsar_clearCache;
+  Pulsar.Pulsar_preloadPresets;
+  Pulsar.Pulsar_stopHaptics;
+  Pulsar.Pulsar_shutDownEngine;
+  Pulsar.Pulsar_hapticSupport;
+  Pulsar.Pulsar_forceHapticsSupportLevel;
+  Pulsar.Pulsar_enableImpulseCompositionMode;
+  Pulsar.Pulsar_setRealtimeComposerStrategy;
+};
 
 const Settings = {
   enableHaptics: (state: boolean) => {
+    primeSettings();
     Pulsar.Pulsar_enableHaptics(state);
   },
   enableSound: (state: boolean) => {
+    primeSettings();
     Pulsar.Pulsar_enableSound(state);
   },
   enableCache: (state: boolean) => {
+    primeSettings();
     Pulsar.Pulsar_enableCache(state);
   },
   clearCache: () => {
+    primeSettings();
     Pulsar.Pulsar_clearCache();
   },
   preloadPresets: (presetNames: Array<String>) => {
+    primeSettings();
     Pulsar.Pulsar_preloadPresets(presetNames);
   },
   stopHaptics: () => {
+    primeSettings();
     Pulsar.Pulsar_stopHaptics();
   },
   shutDownEngine: () => {
+    primeSettings();
     Pulsar.Pulsar_shutDownEngine();
   },
   getHapticsSupportLevel: () => {
+    primeSettings();
     return Pulsar.Pulsar_hapticSupport();
   },
   forceHapticsSupportLevel: (level: HapticSupport) => {
+    primeSettings();
     Pulsar.Pulsar_forceHapticsSupportLevel(level);
   },
   enableImpulseCompositionMode: (state: boolean) => {
+    primeSettings();
     Pulsar.Pulsar_enableImpulseCompositionMode(state);
   },
   setRealtimeComposerStrategy: (strategy: RealtimeComposerStrategy) => {
+    primeSettings();
     Pulsar.Pulsar_setRealtimeComposerStrategy(strategy);
   },
 


### PR DESCRIPTION
## Why

[Settings.ts:4-13](https://github.com/software-mansion/pulsar/blob/main/react-native/react-native-pulsar/src/Settings.ts#L4-L13) reads 10 properties off the `RNPulsar` TurboModule at module-evaluation time as a known workaround for an RN prototype caching issue — the bindings must be touched once on the JS thread before they can be called reliably. The price: merely importing `react-native-pulsar` (which the index.tsx barrel does for every consumer) forces synchronous TurboModule resolution and native-module construction at cold start, even for apps that never call into Settings during startup.

## What

Move the prime into a one-shot `primeSettings()` helper called from every Settings method. The first call from JS thread primes all bindings; subsequent calls are a single boolean check.

None of the Settings methods run inside worklets, so a lazy JS-thread prime is safe. `Presets.ts` is intentionally **not** changed — its wrappers are worklets and need the prime done before the first worklet invocation, so the top-level read stays there.

## Expected impact

Pairs with the iOS lazy-init PRs ([pulsar#36](https://github.com/software-mansion/pulsar/pull/36), [pulsar#37](https://github.com/software-mansion/pulsar/pull/37)): with those merged, native module construction is cheap; with this one, it doesn't even need to happen until something in Settings is actually called. Apps that only use `Presets` (worklet-driven haptic playback) get a strictly lazier startup path; apps that call `Settings.enableHaptics(...)` etc. during their own boot pay the same cost as before, just attributed to the first call instead of import time.

## Risks

Low. Behaviour after the first call is identical to before. The prime is idempotent and guarded; the prime list matches the pre-existing top-level reads 1:1.