### PR TITLE
perf(android): cache PresetsWrapper ctor resolution; drop string compares

### DIFF
--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarReactNative.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarReactNative.kt
@@ -1,25 +1,56 @@
 package com.swmansion.pulsar
 
+import android.app.Activity
 import android.content.Context
 import com.facebook.react.bridge.ReactApplicationContext
 import com.swmansion.pulsar.presets.PresetsWrapper
+import java.lang.reflect.Constructor
 
 class PulsarReactNative(context: Context) : Pulsar(context) {
     override fun getPresets(): PresetsWrapper {
         if (_presets == null) {
             val reactContext = context as ReactApplicationContext
-            val constructor = PresetsWrapper::class.java.constructors.firstOrNull { it.parameterTypes.size == 3 }
-                ?: throw IllegalStateException("PresetsWrapper constructor not found")
-            val secondArgument = when (constructor.parameterTypes[1].name) {
-                "com.swmansion.pulsar.ActivityProvider" -> ReactNativeActivityProvider(reactContext)
-                "android.app.Activity" -> reactContext.currentActivity
-                else -> throw IllegalStateException(
-                    "Unsupported PresetsWrapper constructor parameter: ${constructor.parameterTypes[1].name}"
-                )
+            val descriptor = resolvedPresetsCtor
+            val secondArgument: Any? = when (descriptor.secondArgKind) {
+                SecondArgKind.ActivityProvider -> ReactNativeActivityProvider(reactContext)
+                SecondArgKind.Activity -> reactContext.currentActivity
             }
             @Suppress("UNCHECKED_CAST")
-            _presets = constructor.newInstance(this, secondArgument, engine) as PresetsWrapper
+            _presets = descriptor.constructor.newInstance(this, secondArgument, engine) as PresetsWrapper
         }
         return _presets!!
+    }
+
+    private enum class SecondArgKind { ActivityProvider, Activity }
+
+    private data class PresetsCtorDescriptor(
+        val constructor: Constructor<*>,
+        val secondArgKind: SecondArgKind,
+    )
+
+    private companion object {
+        /**
+         * `PresetsWrapper`'s constructor signature differs between published
+         * versions of the underlying `Pulsar` Android library: older builds
+         * take an `android.app.Activity` as the second parameter, newer ones
+         * take a `com.swmansion.pulsar.ActivityProvider`. Resolving once and
+         * caching keeps cold start cheap (the reflection lookup ran on every
+         * first-use of presets before this change was cached only via
+         * `_presets`, which meant the call site still had to do the lookup
+         * once per `Pulsar` instance).
+         */
+        val resolvedPresetsCtor: PresetsCtorDescriptor by lazy {
+            val ctor = PresetsWrapper::class.java.constructors
+                .firstOrNull { it.parameterTypes.size == 3 }
+                ?: throw IllegalStateException("PresetsWrapper constructor not found")
+            val kind = when (ctor.parameterTypes[1]) {
+                ActivityProvider::class.java -> SecondArgKind.ActivityProvider
+                Activity::class.java -> SecondArgKind.Activity
+                else -> throw IllegalStateException(
+                    "Unsupported PresetsWrapper constructor parameter: ${ctor.parameterTypes[1].name}"
+                )
+            }
+            PresetsCtorDescriptor(ctor, kind)
+        }
     }
 }


### PR DESCRIPTION
## Why

[PulsarReactNative.kt:9-23](https://github.com/software-mansion/pulsar/blob/main/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarReactNative.kt#L9-L23) resolves the right `PresetsWrapper` constructor by:

1. Reflecting over `PresetsWrapper::class.java.constructors`
2. Filtering on arity (3 params)
3. `.firstOrNull { ... }` + string-comparing `parameterTypes[1].name` against `"com.swmansion.pulsar.ActivityProvider"` / `"android.app.Activity"`

This is there to support two published shapes of the underlying `Pulsar` Android library (older signature took an `Activity`, newer takes an `ActivityProvider`). The constructor shape is fixed per process, so the work doesn't need to repeat on every call site — and string-comparing class names is fragile.

## What

- Resolve the constructor once via a `companion object` `lazy`.
- Identify the variant via direct `Class<?>` equality, not string compare.
- Encode the result as a small `SecondArgKind` enum, switched on at the call site.

## Expected impact

Not a real startup bottleneck — the audit ranked this **low** for cold start because `_presets` already gated the work to first use. This PR is a quality cleanup that came out of the same investigation: it removes string-based type comparison, makes the supported-version contract explicit, and ensures the resolution never repeats across instances.

## Risks

Behavioural change: none. Same two ctor shapes supported; same error if neither matches.