### PR TITLE
fix(ios): serialize CoreHaptics engine handlers onto main thread

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -228,17 +228,30 @@ private extension HapticEngineWrapper {
   }
 
   func setupEngineHandlers() {
+    // CoreHaptics invokes these handlers from an internal background queue.
+    // All other state in this object (engine, initialized, playerRegistry,
+    // playerCreationOrder, cachedRealtimePlayer) is read & written from the
+    // main thread — public methods run on the RN module's main methodQueue,
+    // and UIApplication.* notifications post on main. Hop the handler bodies
+    // to main so that all mutations of shared state remain serialized on a
+    // single thread; otherwise the BG handler can race with a main-thread
+    // call into createPlayer / playPlayer / stopHaptics and crash on a
+    // concurrent Dictionary mutation.
     engine?.stoppedHandler = { [weak self] _ in
-      guard let self else { return }
-      self.initialized = false
-      self.clearPlayerState(stopPlayers: false)
+      DispatchQueue.main.async {
+        guard let self else { return }
+        self.initialized = false
+        self.clearPlayerState(stopPlayers: false)
+      }
     }
 
     engine?.resetHandler = { [weak self] in
-      guard let self else { return }
-      self.initialized = false
-      self.clearPlayerState(stopPlayers: false)
-      self.engine = nil
+      DispatchQueue.main.async {
+        guard let self else { return }
+        self.initialized = false
+        self.clearPlayerState(stopPlayers: false)
+        self.engine = nil
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

Surfaced during a thread-safety audit of the lazy-init paths in [pulsar#36](https://github.com/software-mansion/pulsar/pull/36) / [pulsar#37](https://github.com/software-mansion/pulsar/pull/37): the lazy bootstrap itself is race-free, but the surrounding `HapticEngineWrapper` has a pre-existing race that the audit made it natural to fix in the same pass.

`CHHapticEngine` invokes `stoppedHandler` and `resetHandler` from an internal CoreHaptics background queue (Apple does not document the queue; empirically it's not main). Both bodies mutate:
- `initialized` (Bool)
- `engine` (Optional<CHHapticEngine>)
- `playerRegistry` (Dictionary), `playerCreationOrder` (Array), `cachedRealtimePlayer` (Optional, via `clearPlayerState`)

Every other code path in this class reads and writes the same state on the **main thread** — public API runs on the RN module's `methodQueue = dispatch_get_main_queue()`, and `UIApplication.*` notification observers also post on main. A CoreHaptics-triggered handler firing while `createPlayer` / `playPlayer` / `stopHaptics` is mid-execution on main is a real data race: concurrent `Dictionary` mutation (potential crash) plus torn reads of the engine reference.

## What

Hop both handler bodies onto main via `DispatchQueue.main.async`. Keep `[weak self]` so the dispatched block does not extend a wrapper whose owner has already released it.

```swift
engine?.stoppedHandler = { [weak self] _ in
  DispatchQueue.main.async {
    guard let self else { return }
    self.initialized = false
    self.clearPlayerState(stopPlayers: false)
  }
}
```

## Why this and not a lock

A serial queue / `os_unfair_lock` would work too, but:
- All existing code paths already run on main — adding a lock would force every public-API caller to take it for state that is otherwise main-confined.
- Hopping just the two handlers preserves "all state lives on main" as a simple, auditable invariant.
- The handlers fire rarely (engine stopped on app interruption, system audio reset, VoiceOver takeover) so the queued-block cost is negligible.

## Risks

Low. Behaviour after the hop is identical to before — the handler body still runs, just on main. `[weak self]` prevents the queued block from extending object lifetime. Order-relative-to-other-main-work changes slightly (now strictly after whatever's currently on main), which is what we want.