### PR TITLE
perf(ios): make AudioSimulator's AVFoundation graph lazy

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -10,9 +10,10 @@ public class AudioSimulator: NSObject {
       return false
     #endif
   }()
-	private var audioContext: AVAudioEngine = AVAudioEngine()
-	private var playerNode: AVAudioPlayerNode = AVAudioPlayerNode()
-	private var filterNode: AVAudioUnitEQ = AVAudioUnitEQ(numberOfBands: 1)
+
+	private var audioContext: AVAudioEngine?
+	private var playerNode: AVAudioPlayerNode?
+	private var filterNode: AVAudioUnitEQ?
 	private var isEngineConfigured = false
   private var shouldForceAudiblePlayback = false
 
@@ -35,11 +36,6 @@ public class AudioSimulator: NSObject {
     if (isSimulatorDevice) {
       self._playSound = true
     }
-    if (_playSound) {
-      audioQueue.async { [weak self] in
-        self?.configureAudioContext()
-      }
-    }
 	}
 
 	public func parsePattern(from data: PatternData) -> AVAudioPCMBuffer? {
@@ -61,8 +57,8 @@ public class AudioSimulator: NSObject {
       guard let self = self else { return }
       self.shouldForceAudiblePlayback = value
       if (!value) {
-        self.playerNode.stop()
-        self.audioContext.pause()
+        self.playerNode?.stop()
+        self.audioContext?.pause()
         self.deactivateAudioSession()
       } else {
         self.updateAudioSessionCategory()
@@ -74,6 +70,13 @@ public class AudioSimulator: NSObject {
 		guard !isEngineConfigured else { return }
 
     updateAudioSessionCategory()
+
+		let audioContext = self.audioContext ?? AVAudioEngine()
+		let playerNode = self.playerNode ?? AVAudioPlayerNode()
+		let filterNode = self.filterNode ?? AVAudioUnitEQ(numberOfBands: 1)
+		self.audioContext = audioContext
+		self.playerNode = playerNode
+		self.filterNode = filterNode
 
 		// Setup audio engine: Player -> Filter(lowpass) -> MainMixer
 		audioContext.attach(playerNode)
@@ -405,39 +408,40 @@ public class AudioSimulator: NSObject {
       guard let self = self, self.playSound else { return }
       self.configureAudioContext()
 
+      guard self.isEngineConfigured,
+            let audioContext = self.audioContext,
+            let playerNode = self.playerNode else { return }
 
-      guard self.isEngineConfigured else { return }
-
-      if self.playerNode.isPlaying { self.playerNode.stop() }
-      if !self.audioContext.isRunning {
+      if playerNode.isPlaying { playerNode.stop() }
+      if !audioContext.isRunning {
         do {
           try AVAudioSession.sharedInstance().setActive(true)
-          try self.audioContext.start()
+          try audioContext.start()
         } catch {
           print("Failed to start audio engine: \(error)")
           return
         }
       }
 
-      guard self.audioContext.isRunning,
+      guard audioContext.isRunning,
             buffer.format.sampleRate == self.sampleRate,
             buffer.format.channelCount == 1 else {
         print("Skipping playback: engine not running or buffer format mismatch")
         return
       }
 
-      self.playerNode.scheduleBuffer(buffer, at: nil, options: [])
-      self.playerNode.play()
+      playerNode.scheduleBuffer(buffer, at: nil, options: [])
+      playerNode.play()
     }
 	}
 
 	public func stop() {
     audioQueue.async { [weak self] in
-      self?.playerNode.stop()
+      self?.playerNode?.stop()
     }
 	}
 
 	public var isPlaying: Bool {
-		return audioQueue.sync { playerNode.isPlaying }
+		return audioQueue.sync { playerNode?.isPlaying ?? false }
 	}
 }


### PR DESCRIPTION
## Why

`AudioSimulator`'s stored properties unconditionally allocated `AVAudioEngine`, `AVAudioPlayerNode` and `AVAudioUnitEQ(numberOfBands: 1)` at init time. Because `Pulsar` is constructed eagerly by the RN bridge (`RNPulsar`), this forced Obj-C class realization in AVFAudio and bootstrapped the AudioToolbox AudioUnit component registry on every cold start — even in release builds where `playSound` is `false` and the graph is never used. Instantiating `AVAudioUnitEQ` is the most expensive piece (it scans/resolves AU components), and `AVAudioEngine` + `AVAudioPlayerNode` add Obj-C class realization and `__DATA` page-in on top.

## What

- Convert `audioContext`, `playerNode`, `filterNode` to `Optional` and allocate them inside `configureAudioContext()`, which already runs lazily on `audioQueue` and only fires on the first playback request.
- Drop the redundant init-time `audioQueue.async { configureAudioContext() }` dispatch — the first `play(buffer:)` call now drives both allocation and configuration. The setup cost is paid once, on the same queue, before scheduling the first buffer.
- Update call sites that previously assumed non-nil access:
  - `enableSound(false)` uses `playerNode?.stop()` / `audioContext?.pause()` (nil-safe no-ops if the graph was never built).
  - `play(buffer:)` unwraps once at the top of the audio-queue closure via `guard let`.
  - `stop()` / `isPlaying` use optional chaining with `?? false` fallback.

## Expected impact

Apps that never call `enableSound(true)` (the production default — `_playSound` is `false` outside DEBUG/simulator) pay zero for the audio graph at startup. The first `play(buffer:)` call pays the same cost it would have paid at boot.

## Thread safety

All reads/writes of the three optionals stay inside `audioQueue.{async,sync}` blocks. The serial queue continues to provide mutual exclusion for the lazy assignment, so no additional lock is needed. `configureAudioContext()` remains idempotent via `guard !isEngineConfigured`, so concurrent first-play callers serialize on the queue and only the first one allocates.

## Risks

Low. Behaviour after first use is unchanged. `setActive(false)` on a never-activated audio session is harmless per Apple docs, so `enableSound(false)` before any play is a strict no-op aside from the session-deactivate call (same as before).
