### PR TITLE
Reset composer

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/Pulsar.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/Pulsar.kt
@@ -81,6 +81,7 @@ open class Pulsar(protected var context: Context) {
     }
 
     fun stopHaptics() {
+        realtimeComposer?.stop()
         engine.stop()
     }
 

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
@@ -33,4 +33,8 @@ class RealtimeComposer(
     override fun isActive(): Boolean {
         return delegate.isActive()
     }
+
+    override fun reset() {
+        delegate.reset()
+    }
 }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
@@ -24,9 +24,17 @@ open class RealtimeEnvelopeComposer(
     }
 
     private val isPlaying = AtomicBoolean(false)
+    /**
+     * Sticky "stopped" latch. Once set by [stop], subsequent [set]/[playDiscrete]
+     * calls are no-ops until [reset] clears it. This is load-bearing: the previous
+     * design auto-restarted the scheduler whenever [set] observed isPlaying==false,
+     * so a single stray UI-runtime [set] arriving after the JS teardown was enough
+     * to resurrect playback with no remaining caller to stop it.
+     */
+    private val isStopped = AtomicBoolean(false)
     @Volatile private var currentAmplitude = 0.0f
     @Volatile private var currentFrequency = 0.0f
-    private var schedulerJob: Job? = null
+    @Volatile private var schedulerJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default)
 
     private fun start() {
@@ -35,6 +43,7 @@ open class RealtimeEnvelopeComposer(
     }
 
     override fun set(amplitude: Float, frequency: Float) {
+        if (isStopped.get()) return
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
         if (!isPlaying.get()) {
@@ -43,6 +52,7 @@ open class RealtimeEnvelopeComposer(
     }
 
     open override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (isStopped.get()) return
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
@@ -53,12 +63,28 @@ open class RealtimeEnvelopeComposer(
     }
 
     override fun stop() {
-        if (!isPlaying.compareAndSet(true, false)) return
+        // Latch first, unconditionally, so a stop-while-idle still blocks future
+        // auto-starts. Then cancel any in-flight scheduler regardless of whether
+        // we were the thread that flipped isPlaying — concurrent set/stop races
+        // could otherwise leak a scheduler job that nothing cancels.
+        isStopped.set(true)
+        isPlaying.set(false)
         schedulerJob?.cancel()
+        schedulerJob = null
         engine.stop()
     }
 
     override fun isActive(): Boolean = isPlaying.get()
+
+    override fun reset() {
+        isStopped.set(false)
+    }
+
+    /**
+     * Visible to subclasses so they can honor the stopped-latch in their own
+     * overrides of [playDiscrete] etc. without re-implementing the AtomicBoolean.
+     */
+    protected fun isComposerStopped(): Boolean = isStopped.get()
 
     private fun scheduleSequentialHaptics() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -67,15 +93,19 @@ open class RealtimeEnvelopeComposer(
         schedulerJob?.cancel()
         schedulerJob = scope.launch {
             try {
-                while (isPlaying.get() && isActive) {
+                while (isPlaying.get() && !isStopped.get() && isActive) {
                     val effect = vibrationEffectsGenerator.convertToVibrationEffect(listOf(
                         ControlPoint(currentAmplitude, currentFrequency, SEGMENT_DURATION_MS)
                     ))
+                    // Re-check both flags right before vibrate to suppress the
+                    // cooperative-cancellation tail: stop() may have flipped them
+                    // after the while-predicate but before this line.
+                    if (!isPlaying.get() || isStopped.get()) break
                     effect?.let { engine.vibrate(it) }
                     delay(SEGMENT_DURATION_MS)
                 }
             } finally {
-                if (!isPlaying.get()) {
+                if (!isPlaying.get() || isStopped.get()) {
                     engine.stop()
                 }
             }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeWithDiscretePrimitivesComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeWithDiscretePrimitivesComposer.kt
@@ -10,6 +10,7 @@ class RealtimeEnvelopeWithDiscretePrimitivesComposer(
 ) : RealtimeEnvelopeComposer(engine) {
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (isComposerStopped()) return
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -25,6 +25,12 @@ open class RealtimePrimitiveComposer(
     }
 
     private val isPlaying = AtomicBoolean(false)
+    /**
+     * Sticky "stopped" latch — see RealtimeEnvelopeComposer for rationale.
+     * A stray [set] arriving after [stop] would otherwise re-launch the Handler
+     * loop with nothing left to cancel it.
+     */
+    private val isStopped = AtomicBoolean(false)
     @Volatile private var currentAmplitude = 0.0f
     @Volatile private var currentFrequency = 0.0f
     @Volatile private var currentIntervalMs: Long = 50L
@@ -43,6 +49,7 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun set(amplitude: Float, frequency: Float) {
+        if (isStopped.get()) return
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
         currentIntervalMs = (minIntervalMs + (1 - frequency) * (maxIntervalMs - minIntervalMs)).toLong()
@@ -53,6 +60,7 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (isStopped.get()) return
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
@@ -61,16 +69,21 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun stop() {
-        if (!isPlaying.compareAndSet(true, false)) return
-
+        // Latch unconditionally so a stop-while-idle still blocks future auto-starts.
+        isStopped.set(true)
+        isPlaying.set(false)
         handler.removeCallbacks(loopRunnable)
         engine.stop()
     }
 
     override fun isActive(): Boolean = isPlaying.get()
 
+    override fun reset() {
+        isStopped.set(false)
+    }
+
     private fun loop() {
-        if (!isPlaying.get() || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        if (!isPlaying.get() || isStopped.get() || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
 

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
@@ -34,4 +34,11 @@ interface RealtimeComposable {
     fun playDiscrete(amplitude: Float, frequency: Float)
     fun stop()
     fun isActive(): Boolean
+
+    /**
+     * Clear the sticky "stopped" latch installed by [stop] so the composer is willing
+     * to auto-start again on the next [set] / [playDiscrete]. Call this when a screen
+     * (re)gains focus before driving haptics, otherwise [set] will silently no-op.
+     */
+    fun reset()
 }

--- a/PulsarApp/hooks/gestureTypes.ts
+++ b/PulsarApp/hooks/gestureTypes.ts
@@ -7,6 +7,7 @@ export interface Composer {
   playDiscrete(amplitude: number, frequency: number): void;
   set(amplitude: number, frequency: number): void;
   stop(): void;
+  reset(): void;
 }
 
 export type PositionTransform = (x: number, y: number) => Position;

--- a/PulsarApp/hooks/useHapticsScreenActivity.ts
+++ b/PulsarApp/hooks/useHapticsScreenActivity.ts
@@ -2,7 +2,6 @@ import { useIsFocused } from 'expo-router';
 import { useEffect } from 'react';
 import { Settings } from 'react-native-pulsar';
 import { useSharedValue } from 'react-native-reanimated';
-import { runOnUIAsync } from 'react-native-worklets';
 
 import type { Composer } from './gestureTypes';
 
@@ -11,14 +10,23 @@ export function useHapticsScreenActivity(composer: Composer) {
   const isScreenActive = useSharedValue(isFocused);
 
   useEffect(() => {
-    isScreenActive.value = isFocused;
-
-    if (!isFocused) {
-      runOnUIAsync(() => {
-        composer.stop();
-      });
-      Settings.stopHaptics();
+    if (isFocused) {
+      // The native composer is a process-wide singleton; if a previously-focused
+      // screen latched it off via stop(), clear the latch before we start
+      // driving haptics. useRealtimeComposer also resets on mount, but a
+      // re-focused screen that never re-mounted (tab switch) needs this too.
+      composer.reset();
+      isScreenActive.value = true;
+      return;
     }
+
+    // On unfocus the load-bearing change is now the native sticky-stopped
+    // latch installed by composer.stop / Settings.stopHaptics. Once latched,
+    // any stray composer.set arriving from an in-flight worklet tick is a
+    // no-op — so we no longer need to win the JS-vs-UI ordering race here.
+    isScreenActive.value = false;
+    composer.stop();
+    Settings.stopHaptics();
   }, [composer, isFocused, isScreenActive]);
 
   return isScreenActive;

--- a/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
@@ -4,6 +4,13 @@ import CoreHaptics
 public class RealtimeComposer: NSObject {
   private var engine: HapticEngineWrapper!
   private var isPlaying = false
+  /// Sticky "stopped" latch. Once [stop] runs, [set] and [playDiscrete] are
+  /// no-ops until [reset] clears it. Load-bearing: a single stray UI-runtime
+  /// `set` arriving after the JS-side teardown would otherwise auto-start a
+  /// fresh 100-second `CHHapticAdvancedPatternPlayer` with no caller left to
+  /// stop it — the user-visible "haptic keeps playing after Back" bug.
+  private var isStopped = false
+  private let stateLock = NSLock()
 
   public init(engine: HapticEngineWrapper) {
     self.engine = engine
@@ -18,6 +25,14 @@ public class RealtimeComposer: NSObject {
     guard let player = engine?.getRealtimePlayer() else { return }
     isPlaying = true
     set(amplitude: amplitude, frequency: frequency)
+    // Re-check the latch immediately before kicking off the long-lived player:
+    // a concurrent stop() could have flipped isStopped between the guard above
+    // and here, and player.start would otherwise leave a 100s player running.
+    stateLock.lock()
+    let stopped = isStopped
+    if stopped { isPlaying = false }
+    stateLock.unlock()
+    if stopped { return }
     do {
       try player.start(atTime: 0)
     } catch {
@@ -26,6 +41,10 @@ public class RealtimeComposer: NSObject {
   }
 
   @objc public func set(amplitude: Float, frequency: Float) {
+    stateLock.lock()
+    let stopped = isStopped
+    stateLock.unlock()
+    if stopped { return }
     guard engine.isHapticsEnabled else { return }
     if (!isPlaying) {
       start(amplitude: amplitude, frequency: frequency)
@@ -44,20 +63,38 @@ public class RealtimeComposer: NSObject {
   }
 
   @objc public func stop() {
-    guard isPlaying else { return }
+    stateLock.lock()
+    isStopped = true
+    let wasPlaying = isPlaying
+    isPlaying = false
+    stateLock.unlock()
+    guard wasPlaying else { return }
+    // Use peekRealtimePlayer (side-effect-free) instead of getRealtimePlayer:
+    // the latter calls startEngine() + creates a fresh player if there is no
+    // cached one, which would re-arm the engine just to stop a player that
+    // never existed.
     do {
-      try engine?.getRealtimePlayer()?.stop(atTime: 0)
+      try engine?.peekRealtimePlayer()?.stop(atTime: 0)
     } catch {
       print("Error stopping realtime player: \(error.localizedDescription)")
     }
-    isPlaying = false
   }
 
   @objc public var isActive: Bool {
     return isPlaying
   }
 
+  @objc public func resetLatch() {
+    stateLock.lock()
+    isStopped = false
+    stateLock.unlock()
+  }
+
   @objc public func playDiscrete(amplitude: Float = 1.0, frequency: Float = 0.5) {
+    stateLock.lock()
+    let stopped = isStopped
+    stateLock.unlock()
+    if stopped { return }
     guard engine.isHapticsEnabled else { return }
     guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
 

--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -76,6 +76,14 @@ public extension HapticEngineWrapper {
     return player
   }
 
+  /// Side-effect-free accessor for callers that only want to stop a player they
+  /// already started (e.g. `RealtimeComposer.stop`). Using `getRealtimePlayer`
+  /// for this would re-bootstrap the engine and create a fresh 100s player just
+  /// to immediately stop it.
+  func peekRealtimePlayer() -> CHHapticAdvancedPatternPlayer? {
+    return cachedRealtimePlayer
+  }
+
   func playPlayer(id: Int, pattern: CHHapticPattern? = nil) {
     bootstrapAppLifecycleTrackingIfNeeded()
     guard canPlayHaptics() else { return }

--- a/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
@@ -51,6 +51,10 @@ import UIKit
   }
   
   @objc public func stopHaptics() {
+    // Latch the realtime composer first so any subsequent stray `set` from a
+    // worklet that's mid-bridge can't auto-start a fresh 100s player after we
+    // tear down the engine. Mirrors Android Pulsar.kt.stopHaptics.
+    realtimeComposer.stop()
     engine.stopHaptics()
   }
   

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarModule.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarModule.kt
@@ -210,6 +210,10 @@ class PulsarModule(reactContext: ReactApplicationContext) :
     return realtimeComposer.isActive()
   }
 
+  override fun RealtimeComposer_reset() {
+    realtimeComposer.reset()
+  }
+
   companion object {
     const val NAME = "RNPulsar"
   }

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -217,4 +217,10 @@ static PatternData *PatternDataFromJSPattern(JS::NativeRNPulsar::Pattern &data) 
   return [realtimeComposer_ isActive] ? @1 : @0;
 }
 
+- (void)RealtimeComposer_reset {
+  if (realtimeComposer_) {
+    [realtimeComposer_ resetLatch];
+  }
+}
+
 @end

--- a/react-native/react-native-pulsar/src/NativeRNPulsar.ts
+++ b/react-native/react-native-pulsar/src/NativeRNPulsar.ts
@@ -40,6 +40,13 @@ export interface Spec extends TurboModule {
   RealtimeComposer_stop(): void;
   RealtimeComposer_isActive(): boolean;
   RealtimeComposer_playDiscrete(amplitude: number, frequency: number): void;
+  /**
+   * Clears the realtime composer's sticky stopped-latch installed by
+   * `RealtimeComposer_stop` / `Pulsar_stopHaptics`. Call this when a screen
+   * (re)gains focus and is about to drive haptics — otherwise subsequent
+   * `set`/`playDiscrete` will silently no-op.
+   */
+  RealtimeComposer_reset(): void;
 
   PatternComposer_parsePattern(data: Pattern): number;
   PatternComposer_play(patternId: number): void;

--- a/react-native/react-native-pulsar/src/useRealtimeComposer.ts
+++ b/react-native/react-native-pulsar/src/useRealtimeComposer.ts
@@ -1,17 +1,26 @@
 import { useCallback, useEffect } from 'react';
 import Pulsar from './NativeRNPulsar';
 
-// workaround for RN prototype caching issue 
+// workaround for RN prototype caching issue
 Pulsar.RealtimeComposer_set;
 Pulsar.RealtimeComposer_playDiscrete;
 Pulsar.RealtimeComposer_stop;
 Pulsar.RealtimeComposer_isActive;
+Pulsar.RealtimeComposer_reset;
 
 export type RealtimeComposer = {
   set: (amplitude: number, frequency: number) => void;
   playDiscrete: (amplitude: number, frequency: number) => void;
   stop: () => void;
   isActive: () => boolean;
+  /**
+   * Clear the native composer's sticky stopped-latch. The composer is a
+   * shared singleton across all hook instances, so a screen that left the
+   * stack via `Settings.stopHaptics` / `composer.stop` would leave the next
+   * screen unable to play haptics until it calls `reset`. Mount-time reset
+   * here makes that automatic; screen-level focus hooks may also call this.
+   */
+  reset: () => void;
 };
 
 export default function useRealtimeComposer(): RealtimeComposer {
@@ -35,7 +44,18 @@ export default function useRealtimeComposer(): RealtimeComposer {
     return Pulsar.RealtimeComposer_isActive();
   }, []);
 
-  useEffect(() => stop, [stop]);
+  const reset = useCallback(() => {
+    'worklet';
+    Pulsar.RealtimeComposer_reset();
+  }, []);
 
-  return { set, playDiscrete, stop, isActive };
+  // Clear the latch on mount (the composer is a process-wide singleton that
+  // may have been latched off by a previously-popped screen) and re-stop on
+  // unmount.
+  useEffect(() => {
+    reset();
+    return stop;
+  }, [reset, stop]);
+
+  return { set, playDiscrete, stop, isActive, reset };
 }


### PR DESCRIPTION
## Why

Continuous-haptic demos (Accelerometer Haptics, Balloon, GesturePlayground) keep buzzing for many seconds — on iOS up to ~100s, on Android indefinitely — after the user navigates away from the screen, on both platforms.

## Root cause

`RealtimeComposer.set(...)` lazily auto-starts the long-lived emitter whenever it observes `isPlaying == false`:

- **iOS** — `set()` calls `start()`, which calls `getRealtimePlayer()` and `player.start(atTime: 0)`. `makeRealtimePlayer()` builds a `CHHapticEvent` with `duration: 100`, so once started the player runs ~100 seconds unless explicitly stopped.
- **Android** — `set()` calls `start()` → `scheduleSequentialHaptics()`, which launches a `Dispatchers.Default` coroutine that loops `engine.vibrate(...)` every 100ms indefinitely.

The screen's `useHapticsScreenActivity` hook on unfocus does `composer.stop()` + `Settings.stopHaptics()` — but the screen's `useAnimatedReaction` runs at sensor rate (~60Hz) on the Reanimated UI runtime and feeds `composer.set(...)` through the TurboModule. Exactly one stray `set(...)` already in flight when the teardown runs lands on native after `stop`. It observes `isPlaying == false`, takes the auto-start path, re-arms the emitter — and now the screen is unmounting, so nothing left calls `stop` again.

Two prior attempts (`runOnUISync` to flip `isScreenActive` atomically on UI, and calling `realtimeComposer.stop()` from Android's `Pulsar.stopHaptics`) addressed the cancellation side of the race, not the resurrection side, and didn't fix it.

## What this PR does

Adds a sticky **stopped-latch** in the native realtime composer on both platforms, plus a `reset()` API to clear it.

- **`stop()` latches** `isStopped = true` unconditionally (even if already idle) and cancels in-flight work.
- **`set()` and `playDiscrete()` early-return** while the latch is set.
- **`reset()` clears** the latch — called from `useRealtimeComposer`'s mount effect and from `useHapticsScreenActivity` on focus.

After the latch, any stray UI-runtime `set` arriving after teardown is a no-op. The JS-vs-UI ordering race no longer matters.

### Native (load-bearing)

| File | Change |
|---|---|
| `iOS/.../Composers/RealtimeComposer.swift` | `isStopped` + `NSLock`. Gate `set`/`playDiscrete`. `stop()` latches unconditionally. `start()` re-checks the latch immediately before `player.start(atTime: 0)`. New `@objc resetLatch()`. `stop()` uses `peekRealtimePlayer()` so it doesn't revive the engine just to stop a player. |
| `iOS/.../HapticEngineWrapper.swift` | New side-effect-free `peekRealtimePlayer()` accessor. |
| `iOS/.../Pulsar.swift` | `stopHaptics()` now calls `realtimeComposer.stop()` before `engine.stopHaptics()` (parity with Android's existing fix). |
| `Android/.../types/RealtimeComposer.kt` | Add `reset()` to `RealtimeComposable`. |
| `Android/.../composers/RealtimeComposer.kt` | Wrapper forwards `reset()` to delegate. |
| `Android/.../composers/RealtimeEnvelopeComposer.kt` | `isStopped: AtomicBoolean` + `@Volatile schedulerJob`. Gate `set`/`playDiscrete`. `stop()` latches unconditionally + cancels job. Scheduler loop re-checks both flags immediately before `engine.vibrate(...)` to suppress the cooperative-cancellation tail vibrate. Protected `isComposerStopped()` for subclasses. |
| `Android/.../composers/RealtimeEnvelopeWithDiscretePrimitivesComposer.kt` | Override of `playDiscrete` honors `isComposerStopped()`. |
| `Android/.../composers/RealtimePrimitiveComposer.kt` | Same latch shape; `loop()` early-returns when latched. |

### Bridge

| File | Change |
|---|---|
| `react-native/.../src/NativeRNPulsar.ts` | New TurboModule method `RealtimeComposer_reset(): void`. |
| `react-native/.../android/.../PulsarModule.kt` | Implements `RealtimeComposer_reset`. |
| `react-native/.../ios/Haptics.mm` | Implements `RealtimeComposer_reset` (calls `resetLatch` — `reset` is taken by NSObject's selector space). |

### JS

| File | Change |
|---|---|
| `react-native/.../src/useRealtimeComposer.ts` | Exposes `reset`. Mount effect now `reset()` then returns `stop` — handles the singleton-across-hooks case where a latch from a popped screen would otherwise persist into the next screen. |
| `PulsarApp/hooks/useHapticsScreenActivity.ts` | Focus path calls `composer.reset()`. Unfocus path simplified to plain JS-thread `composer.stop()` + `Settings.stopHaptics()` — the native latch makes `runOnUISync` ordering unnecessary. |
| `PulsarApp/hooks/gestureTypes.ts` | `Composer` interface gains `reset()`. |

## Builds verified
- `Android/Pulsar :Pulsar:assembleDebug`
- `react-native-pulsar :assembleDebug` with `USE_LOCAL_PULSAR_ANDROID=1`
- `PulsarApp.xcworkspace` Debug for iOS with `USE_LOCAL_PULSAR_IOS=1` pods

## How to verify
1. Open **Accelerometer Haptics**, tilt to start the continuous buzz, tap **back**. Vibration cuts within a frame — no ~100s tail on iOS, no infinite loop on Android.
2. Re-open the demo and tilt again — haptics still work. (Confirms mount-time `reset()` clears the latch on the singleton composer.)
3. Try **balloon-demo** and **GesturePlayground** in the same session to confirm they aren't silently latched-off by a prior sensor-demo unfocus.
