### PR TITLE
sync(kmp): mirror recent iOS native fixes into Kotlin/Native impl

### DIFF
--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -104,8 +104,6 @@ internal class IOSAudioSimulator {
 
         updateAudioSessionCategory()
 
-        // Lazily allocate the AVFoundation graph on first use — see field
-        // comment for the cold-start cost we avoid by deferring this.
         val audioContext = this.audioContext ?: AVAudioEngine()
         val playerNode = this.playerNode ?: AVAudioPlayerNode()
         val filterNode = this.filterNode ?: AVAudioUnitEQ(numberOfBands = 1u)

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -34,11 +34,6 @@ import kotlin.native.Platform
 internal class IOSAudioSimulator {
     private val sampleRate = 22_050.0
     private val isSimulatorDevice = NSProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != null
-    // AVAudioEngine / AVAudioPlayerNode / AVAudioUnitEQ each pull in AVFAudio
-    // class realization and the AudioToolbox AudioUnit component registry on
-    // first allocation. Keeping these nullable and constructing them lazily in
-    // configureAudioContext() avoids paying that cost on cold start in release
-    // builds where playSound is false and the graph is never used.
     private var audioContext: AVAudioEngine? = null
     private var playerNode: AVAudioPlayerNode? = null
     private var filterNode: AVAudioUnitEQ? = null

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -34,9 +34,14 @@ import kotlin.native.Platform
 internal class IOSAudioSimulator {
     private val sampleRate = 22_050.0
     private val isSimulatorDevice = NSProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != null
-    private val audioContext = AVAudioEngine()
-    private val playerNode = AVAudioPlayerNode()
-    private val filterNode = AVAudioUnitEQ(numberOfBands = 1u)
+    // AVAudioEngine / AVAudioPlayerNode / AVAudioUnitEQ each pull in AVFAudio
+    // class realization and the AudioToolbox AudioUnit component registry on
+    // first allocation. Keeping these nullable and constructing them lazily in
+    // configureAudioContext() avoids paying that cost on cold start in release
+    // builds where playSound is false and the graph is never used.
+    private var audioContext: AVAudioEngine? = null
+    private var playerNode: AVAudioPlayerNode? = null
+    private var filterNode: AVAudioUnitEQ? = null
     private var isEngineConfigured = false
     private var playSound = isSimulatorDevice || Platform.isDebugBinary
     private var shouldForceAudiblePlayback = false
@@ -55,7 +60,7 @@ internal class IOSAudioSimulator {
         shouldForceAudiblePlayback = value
         if (!value) {
             stop()
-            audioContext.pause()
+            audioContext?.pause()
             deactivateAudioSession()
         } else {
             updateAudioSessionCategory()
@@ -66,6 +71,9 @@ internal class IOSAudioSimulator {
     fun play(buffer: IOSAudioBuffer?) {
         if (buffer == null || !playSound || buffer.samples.isEmpty()) return
         configureAudioContext()
+
+        val audioContext = this.audioContext ?: return
+        val playerNode = this.playerNode ?: return
 
         if (playerNode.playing) {
             playerNode.stop()
@@ -85,16 +93,25 @@ internal class IOSAudioSimulator {
     }
 
     fun stop() {
-        playerNode.stop()
+        playerNode?.stop()
     }
 
     val isPlaying: Boolean
-        get() = playerNode.playing
+        get() = playerNode?.playing ?: false
 
     private fun configureAudioContext() {
         if (isEngineConfigured) return
 
         updateAudioSessionCategory()
+
+        // Lazily allocate the AVFoundation graph on first use — see field
+        // comment for the cold-start cost we avoid by deferring this.
+        val audioContext = this.audioContext ?: AVAudioEngine()
+        val playerNode = this.playerNode ?: AVAudioPlayerNode()
+        val filterNode = this.filterNode ?: AVAudioUnitEQ(numberOfBands = 1u)
+        this.audioContext = audioContext
+        this.playerNode = playerNode
+        this.filterNode = filterNode
 
         audioContext.attachNode(playerNode)
         (filterNode.bands.firstOrNull() as? AVAudioUnitEQFilterParameters)?.let { band ->

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/haptics/HapticEngineWrapper.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/haptics/HapticEngineWrapper.kt
@@ -21,6 +21,8 @@ import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.UIKit.UIApplicationWillResignActiveNotification
 import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 import platform.objc.sel_registerName
 
 @OptIn(ExperimentalForeignApi::class)
@@ -183,14 +185,26 @@ internal class IOSHapticEngineWrapper {
     }
 
     private fun setupEngineHandlers() {
+        // CoreHaptics invokes these handlers from an internal background queue.
+        // Every other path through this object (public API on the RN module's
+        // main methodQueue, UIApplication.* notifications) mutates shared
+        // state — engine, initialized, playerRegistry, playerCreationOrder,
+        // cachedRealtimePlayer — on the main thread. Hop the handler bodies
+        // to main so a CoreHaptics-triggered callback cannot race with a
+        // concurrent createPlayer / playPlayer / stopHaptics and corrupt the
+        // player registry.
         engine?.stoppedHandler = {
-            initialized = false
-            clearPlayerState(stopPlayers = false)
+            dispatch_async(dispatch_get_main_queue()) {
+                initialized = false
+                clearPlayerState(stopPlayers = false)
+            }
         }
         engine?.resetHandler = {
-            initialized = false
-            clearPlayerState(stopPlayers = false)
-            engine = null
+            dispatch_async(dispatch_get_main_queue()) {
+                initialized = false
+                clearPlayerState(stopPlayers = false)
+                engine = null
+            }
         }
     }
 


### PR DESCRIPTION
Two iOS-only fixes landed recently in the Swift core that the KMP `iosMain` layer
mirrors almost line-for-line. Reproducing both keeps the Kotlin/Native impl from
silently drifting behind the Swift one.

## Changes

### `HapticEngineWrapper.kt` — mirror of [#40](https://github.com/software-mansion/pulsar/pull/40)

CoreHaptics invokes `stoppedHandler` / `resetHandler` from a private background
queue, but every other path through the wrapper — public API (RN main
`methodQueue`) and the `UIApplication.*` notifications — mutates the same state
(`engine`, `initialized`, `playerRegistry`, `playerCreationOrder`,
`cachedRealtimePlayer`) on the main thread.

Hop both handler bodies onto main via `dispatch_async(dispatch_get_main_queue())`
so every read/write of that state remains main-thread-confined, removing the
race without an explicit lock — same fix as the Swift PR.

### `AudioSimulator.kt` — mirror of [#41](https://github.com/software-mansion/pulsar/pull/41)

`AVAudioEngine`, `AVAudioPlayerNode`, and `AVAudioUnitEQ(numberOfBands = 1u)`
were eagerly constructed at field-init time. That forces AVFAudio class
realization and bootstraps the AudioToolbox AudioUnit component registry on
every cold start — wasted work in release builds where `playSound` is `false`
and the graph is never used.

Convert the three to nullables and allocate inside `configureAudioContext()`,
which already runs lazily on the first `play()` call. Call sites use safe-call
or unwrap-once so observable behaviour with `playSound = true` is unchanged.

### Why no Android change for [#42](https://github.com/software-mansion/pulsar/pull/42)

PR #42 replaced `PulsarReactNative`'s reflective `PresetsWrapper` construction
with an `open createPresets()` hook. `AndroidPulsarFactory` in this module
consumes `AndroidPulsar`'s public API and never reached for that reflection
path, so nothing to mirror.

## Verification

Local build of the iOS Kotlin target hits pre-existing Kotlin/Native cinterop
signature mismatches on this machine's Xcode 26.3 SDK (`scheduleBuffer` overload,
`AVAudioSession.setActive`) — they reproduce on `main` unchanged and are
unrelated to the lines touched here. CI (`iosSimulatorArm64Test` on
`macos-latest`) is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)