### PR TITLE
Add start method to RealtimeComposer

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
@@ -18,8 +18,12 @@ class RealtimeComposer(
         RealtimeComposerStrategy.PRIMITIVE_COMPLEX -> RealtimePrimitiveComplexComposer(engine, compatibilityMode)
     }
 
-    override fun set(amplitude: Float, frequency: Float) {
-        delegate.set(amplitude, frequency)
+    override fun start() {
+        delegate.start()
+    }
+
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        delegate.set(amplitude, frequency, startIfNeeded)
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
@@ -29,17 +29,19 @@ open class RealtimeEnvelopeComposer(
     private var schedulerJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default)
 
-    private fun start() {
-        isPlaying.set(true)
+    override fun start() {
+        if (!isPlaying.compareAndSet(false, true)) return
         scheduleSequentialHaptics()
     }
 
-    override fun set(amplitude: Float, frequency: Float) {
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        if (!isPlaying.get()) {
+            if (!startIfNeeded) return
+            start()
+            if (!isPlaying.get()) return
+        }
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
-        if (!isPlaying.get()) {
-            start()
-        }
     }
 
     open override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -32,24 +32,20 @@ open class RealtimePrimitiveComposer(
     private val handler = Handler(Looper.getMainLooper())
     private val loopRunnable = Runnable { loop() }
 
-    private fun start(amplitude: Float, frequency: Float) {
-        if (isPlaying.get()) {
-            stop()
-        }
-
-        isPlaying.set(true)
-        set(amplitude, frequency)
+    override fun start() {
+        if (!isPlaying.compareAndSet(false, true)) return
         loop()
     }
 
-    override fun set(amplitude: Float, frequency: Float) {
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        if (!isPlaying.get()) {
+            if (!startIfNeeded) return
+            start()
+            if (!isPlaying.get()) return
+        }
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
         currentIntervalMs = (minIntervalMs + (1 - frequency) * (maxIntervalMs - minIntervalMs)).toLong()
-
-        if (!isPlaying.get()) {
-            start(currentAmplitude, currentFrequency)
-        }
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
@@ -30,7 +30,10 @@ enum class RealtimeComposerStrategy {
 }
 
 interface RealtimeComposable {
-    fun set(amplitude: Float, frequency: Float)
+    fun start()
+    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean)
+    fun set(amplitude: Float, frequency: Float) = set(amplitude, frequency, false)
+
     fun playDiscrete(amplitude: Float, frequency: Float)
     fun stop()
     fun isActive(): Boolean

--- a/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/RealtimeComposerScreen.kt
+++ b/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/RealtimeComposerScreen.kt
@@ -141,6 +141,7 @@ fun RealtimeComposerScreen() {
                                 isActive = true
                                 frequency = (offset.x / size.width).coerceIn(0f, 1f)
                                 amplitude = (1f - (offset.y / size.height)).coerceIn(0f, 1f)
+                                realtimeComposer.start()
                                 realtimeComposer.set(amplitude, frequency)
                             },
                             onDrag = { change, _ ->

--- a/PulsarApp/app/(tabs)/demos/balloon-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/balloon-demo.tsx
@@ -155,7 +155,7 @@ function BalloonCell({ index }: { index: number }) {
       if (current > 0 && current < shakeThreshold) {
         const amplitude = interpolate(current, [0, shakeThreshold], [ampMin, ampMid], Extrapolation.CLAMP);
         const frequency = interpolate(current, [0, shakeThreshold], [freqHigh, freqLow], Extrapolation.CLAMP);
-        composer.set(amplitude, frequency);
+        composer.set(amplitude, frequency, true);
       }
 
       // Enter shake zone: stop continuous haptic, let shakeOffset drive impulses

--- a/PulsarApp/app/(tabs)/demos/sensor-haptics-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/sensor-haptics-demo.tsx
@@ -106,7 +106,7 @@ export default function SensorHapticsDemo() {
         if (postBounceSpeed > 0.5) {
           const amplitude = interpolate(postBounceSpeed, [0.5, 12], [0.1, 0.5], Extrapolation.CLAMP);
           const frequency = interpolate(postBounceSpeed, [0.5, 12], [0.2, 0.7], Extrapolation.CLAMP);
-          composer.set(amplitude, frequency);
+          composer.set(amplitude, frequency, true);
         } else {
           composer.stop();
         }
@@ -121,7 +121,7 @@ export default function SensorHapticsDemo() {
         if (velocityMagnitude > 0.5) {
           const amplitude = interpolate(velocityMagnitude, [0.5, 12], [0.1, 0.5], Extrapolation.CLAMP);
           const frequency = interpolate(velocityMagnitude, [0.5, 12], [0.2, 0.7], Extrapolation.CLAMP);
-          composer.set(amplitude, frequency);
+          composer.set(amplitude, frequency, true);
         } else {
           composer.stop();
         }

--- a/PulsarApp/hooks/useComposedGesture.ts
+++ b/PulsarApp/hooks/useComposedGesture.ts
@@ -35,6 +35,7 @@ export const useComposedGesture = (
 
   const panGesture = Gesture.Pan()
     .onStart(() => {
+      composer.start();
       recordEvent('pan', 0, 0);
     })
     .onUpdate((e) => {

--- a/PulsarApp/hooks/useOnboardingComposedGesture.ts
+++ b/PulsarApp/hooks/useOnboardingComposedGesture.ts
@@ -30,6 +30,9 @@ export const useOnboardingComposedGesture = (
     });
 
   const onboardingPanGesture = Gesture.Pan()
+    .onStart(() => {
+      composer.start();
+    })
     .onUpdate((e) => {
       const normalized = normalizePosition(e.x, e.y);
       composer.set(normalized.y, normalized.x);

--- a/docs/src/content/docs/sdk/android.mdx
+++ b/docs/src/content/docs/sdk/android.mdx
@@ -666,12 +666,20 @@ val realtime = pulsar.getRealtimeComposer(strategy = RealtimeComposerStrategy.EN
 
 ### Methods
 
-#### `set(amplitude, frequency)`
+#### `start()`
 
-Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0-1 range.
+Starts the realtime composer so that subsequent `set(amplitude, frequency)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Available on `RealtimeComposer` and every strategy implementation (envelope, primitive, etc.).
 
 ```kotlin
-fun set(amplitude: Float, frequency: Float)
+fun start()
+```
+
+#### `set(amplitude, frequency, startIfNeeded)`
+
+Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded = true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+
+```kotlin
+fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean = false)
 ```
 
 #### `playDiscrete(amplitude, frequency)`
@@ -703,18 +711,22 @@ fun isActive(): Boolean
 ```kotlin
 val realtime = pulsar.getRealtimeComposer()
 
-// Start a continuous haptic
-realtime.set(amplitude = 0.5f, frequency = 0.8f)
+// Begin a continuous haptic — required before set(...) will play
+realtime.start()
 
-// Update parameters over time
+// Update parameters over time as the gesture progresses
+realtime.set(amplitude = 0.5f, frequency = 0.8f)
 realtime.set(amplitude = 1.0f, frequency = 0.3f)
 
 // Play a one-off discrete event
 realtime.playDiscrete(amplitude = 0.7f, frequency = 0.5f)
 
-// Stop
+// End the continuous haptic. After this the composer is inactive
+// again — call start() before the next set(...).
 realtime.stop()
 ```
+
+> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture and `stop()` with its end, or pass `startIfNeeded = true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -529,12 +529,20 @@ await pulsar.setRealtimeComposerStrategy(RealtimeComposerStrategy.envelope);
 
 ### Methods
 
-#### `set(amplitude, frequency)`
+#### `start()`
 
-Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0–1 range.
+Starts the realtime composer so that subsequent `set(...)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Routes through the active strategy on the same path as the other methods.
 
 ```dart
-Future<void> set(double amplitude, double frequency);
+Future<void> start();
+```
+
+#### `set(amplitude, frequency, {startIfNeeded})`
+
+Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0–1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+
+```dart
+Future<void> set(double amplitude, double frequency, {bool startIfNeeded = false});
 ```
 
 #### `playDiscrete([amplitude, frequency])`
@@ -566,13 +574,23 @@ Future<bool> isActive();
 ```dart
 final realtime = pulsar.getRealtimeComposer();
 
+// Begin a continuous haptic — required before set(...) will play
+await realtime.start();
+
+// Update parameters over time as the gesture progresses
 await realtime.set(0.5, 0.8);
 await realtime.set(1.0, 0.3);
 
 await realtime.playDiscrete(0.7, 0.5);
 
+// End the continuous haptic. After this the composer is inactive
+// again — call start() before the next set(...).
 await realtime.stop();
 ```
+
+<Aside type="note" title="Lifecycle">
+  `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture (e.g. `onPanStart`) and `stop()` with its end, or pass `startIfNeeded: true` to `set(...)` to opt into auto-start when no clear begin hook is available.
+</Aside>
 
 ---
 

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -558,12 +558,20 @@ let realtime = pulsar.getRealtimeComposer()
 
 ### Methods
 
-#### `set(amplitude:frequency:)`
+#### `start()`
 
-Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values are clamped to the 0-1 range.
+Starts the realtime composer so that subsequent `set(amplitude:frequency:)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`.
 
 ```swift
-func set(amplitude: Float, frequency: Float)
+func start()
+```
+
+#### `set(amplitude:frequency:startIfNeeded:)`
+
+Updates the ongoing haptic with new amplitude and frequency values. Values are clamped to the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+
+```swift
+func set(amplitude: Float, frequency: Float, startIfNeeded: Bool = false)
 ```
 
 #### `playDiscrete(amplitude:frequency:)`
@@ -597,18 +605,22 @@ var isActive: Bool { get }
 ```swift
 let realtime = pulsar.getRealtimeComposer()
 
-// Start a continuous haptic
-realtime.set(amplitude: 0.5, frequency: 0.8)
+// Begin a continuous haptic — required before set(...) will play
+realtime.start()
 
-// Update parameters over time
+// Update parameters over time as the gesture progresses
+realtime.set(amplitude: 0.5, frequency: 0.8)
 realtime.set(amplitude: 1.0, frequency: 0.3)
 
 // Play a one-off discrete event
 realtime.playDiscrete(amplitude: 0.7, frequency: 0.5)
 
-// Stop
+// End the continuous haptic. After this the composer is inactive
+// again — call start() before the next set(...).
 realtime.stop()
 ```
+
+> **Note:** `set(amplitude:frequency:)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture (e.g. a drag's begin phase) and `stop()` with its end, or pass `startIfNeeded: true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -498,12 +498,20 @@ pulsar.realtimeComposerStrategy = RealtimeComposerStrategy.ENVELOPE
 
 ### Methods
 
-#### `set(amplitude, frequency)`
+#### `start()`
 
-Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0-1 range.
+Starts the realtime composer so that subsequent `set(amplitude, frequency)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Backed by `RealtimeComposerHandle.start()` on each platform target.
 
 ```kotlin
-fun set(amplitude: Float, frequency: Float)
+fun start()
+```
+
+#### `set(amplitude, frequency, startIfNeeded)`
+
+Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded = true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+
+```kotlin
+fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean = false)
 ```
 
 #### `playDiscrete(amplitude, frequency)`
@@ -535,13 +543,21 @@ fun isActive(): Boolean
 ```kotlin
 val realtime = pulsar.getRealtimeComposer()
 
+// Begin a continuous haptic — required before set(...) will play
+realtime.start()
+
+// Update parameters over time as the gesture progresses
 realtime.set(amplitude = 0.5f, frequency = 0.8f)
 realtime.set(amplitude = 1.0f, frequency = 0.3f)
 
 realtime.playDiscrete(amplitude = 0.7f, frequency = 0.5f)
 
+// End the continuous haptic. After this the composer is inactive
+// again — call start() before the next set(...).
 realtime.stop()
 ```
+
+> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture and `stop()` with its end, or pass `startIfNeeded = true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/react-native.mdx
+++ b/docs/src/content/docs/sdk/react-native.mdx
@@ -424,7 +424,7 @@ function MyComponent() {
 A React hook for real-time haptic control. Provides live amplitude and frequency modulation, useful for gesture-driven or continuously evolving haptic experiences. Haptics stop automatically on unmount.
 
 ```ts
-const { set, playDiscrete, stop, isActive } = useRealtimeComposer();
+const { start, set, playDiscrete, stop, isActive } = useRealtimeComposer();
 ```
 
 ### Parameters
@@ -433,9 +433,13 @@ const { set, playDiscrete, stop, isActive } = useRealtimeComposer();
 
 ### Returns
 
-#### `set(amplitude: number, frequency: number)`
+#### `start()`
 
-Updates the ongoing haptic with new amplitude and frequency values.
+Starts the realtime composer so that subsequent `set(...)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Worklet-safe, takes no arguments.
+
+#### `set(amplitude: number, frequency: number, startIfNeeded?: boolean)`
+
+Updates the ongoing haptic with new amplitude and frequency values. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior. Worklet-safe.
 
 #### `playDiscrete(amplitude: number, frequency: number)`
 
@@ -459,17 +463,25 @@ function MyComponent() {
   const realtime = useRealtimeComposer();
 
   const pan = Gesture.Pan()
+    .onStart(() => {
+      // Required before set(...) will play
+      realtime.start();
+    })
     .onUpdate((e) => {
       const amplitude = Math.min(Math.abs(e.velocityY) / 1000, 1);
       realtime.set(amplitude, 0.5);
     })
     .onEnd(() => {
+      // After stop() the composer is inactive again — call start()
+      // before the next set(...).
       realtime.stop();
     });
 
   return <GestureDetector gesture={pan}>...</GestureDetector>;
 }
 ```
+
+> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the gesture's `onStart` (or equivalent, like a slider's `onChangeStart`) and `stop()` with its `onEnd`, or pass `startIfNeeded: true` to `set(...)` from an `onChange`-style callback that has no clear begin hook.
 
 ---
 

--- a/flutter/PulsarApp/lib/main.dart
+++ b/flutter/PulsarApp/lib/main.dart
@@ -67,7 +67,9 @@ class _PulsarDemoScreenState extends State<PulsarDemoScreen> {
   Future<void> _onSliderChange(double value) async {
     setState(() => _amplitude = value);
     try {
-      await _pulsar.getRealtimeComposer().set(_amplitude, _frequency);
+      await _pulsar
+          .getRealtimeComposer()
+          .set(_amplitude, _frequency, startIfNeeded: true);
     } catch (_) {}
   }
 

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
@@ -168,11 +168,7 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success(null)
             }
 
-            "RealtimeComposer_set" -> {
-                val amplitude = call.argument<Double>("amplitude")?.toFloat()
-                    ?: return result.error("INVALID_ARGS", "amplitude required", null)
-                val frequency = call.argument<Double>("frequency")?.toFloat()
-                    ?: return result.error("INVALID_ARGS", "frequency required", null)
+            "RealtimeComposer_start" -> {
                 val strategyIndex = call.argument<Int>("strategy")
                 val strategy = if (strategyIndex != null) {
                     RealtimeComposerStrategy.entries.getOrNull(strategyIndex)
@@ -180,7 +176,24 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 } else {
                     null
                 }
-                p.getRealtimeComposer(strategy).set(amplitude, frequency)
+                p.getRealtimeComposer(strategy).start()
+                result.success(null)
+            }
+
+            "RealtimeComposer_set" -> {
+                val amplitude = call.argument<Double>("amplitude")?.toFloat()
+                    ?: return result.error("INVALID_ARGS", "amplitude required", null)
+                val frequency = call.argument<Double>("frequency")?.toFloat()
+                    ?: return result.error("INVALID_ARGS", "frequency required", null)
+                val startIfNeeded = call.argument<Boolean>("startIfNeeded") ?: false
+                val strategyIndex = call.argument<Int>("strategy")
+                val strategy = if (strategyIndex != null) {
+                    RealtimeComposerStrategy.entries.getOrNull(strategyIndex)
+                        ?: return result.error("INVALID_ARGS", "invalid strategy", null)
+                } else {
+                    null
+                }
+                p.getRealtimeComposer(strategy).set(amplitude, frequency, startIfNeeded)
                 result.success(null)
             }
 

--- a/flutter/pulsar/example/lib/main.dart
+++ b/flutter/pulsar/example/lib/main.dart
@@ -159,7 +159,9 @@ class _RealtimeSliderState extends State<_RealtimeSlider> {
   Future<void> _onChanged(double value) async {
     setState(() => _amplitude = value);
     try {
-      await widget.pulsar.getRealtimeComposer().set(_amplitude, 0.5);
+      await widget.pulsar
+          .getRealtimeComposer()
+          .set(_amplitude, 0.5, startIfNeeded: true);
       if (!mounted) return;
       setState(() => _active = true);
     } on PlatformException {

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -113,6 +113,14 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
       result(nil)
 
     // MARK: — RealtimeComposer
+    case "RealtimeComposer_start":
+      if let strategyError = applyRealtimeStrategy(args) {
+        result(strategyError)
+        return
+      }
+      realtimeComposer.start()
+      result(nil)
+
     case "RealtimeComposer_set":
       guard let amplitude = args?["amplitude"] as? Double,
             let frequency = args?["frequency"] as? Double else {
@@ -123,7 +131,8 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
         result(strategyError)
         return
       }
-      realtimeComposer.set(amplitude: Float(amplitude), frequency: Float(frequency))
+      let startIfNeeded = (args?["startIfNeeded"] as? Bool) ?? false
+      realtimeComposer.set(amplitude: Float(amplitude), frequency: Float(frequency), startIfNeeded: startIfNeeded)
       result(nil)
 
     case "RealtimeComposer_stop":

--- a/flutter/pulsar/lib/pulsar_method_channel.dart
+++ b/flutter/pulsar/lib/pulsar_method_channel.dart
@@ -114,13 +114,21 @@ class MethodChannelPulsar extends PulsarPlatform {
   // ── RealtimeComposer ────────────────────────────────────────────────────────
 
   @override
+  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) =>
+      methodChannel.invokeMethod('RealtimeComposer_start', {
+        if (strategy != null) 'strategy': strategy.index,
+      });
+
+  @override
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
+    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) => methodChannel.invokeMethod('RealtimeComposer_set', {
     'amplitude': amplitude,
     'frequency': frequency,
+    'startIfNeeded': startIfNeeded,
     if (strategy != null) 'strategy': strategy.index,
   });
 

--- a/flutter/pulsar/lib/pulsar_platform_interface.dart
+++ b/flutter/pulsar/lib/pulsar_platform_interface.dart
@@ -79,9 +79,13 @@ abstract class PulsarPlatform extends PlatformInterface {
 
   // ── RealtimeComposer ────────────────────────────────────────────────────────
 
+  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) =>
+      throw UnimplementedError('realtimeStart() not implemented');
+
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
+    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) => throw UnimplementedError('realtimeSet() not implemented');
 

--- a/flutter/pulsar/lib/src/pulsar_realtime_composer.dart
+++ b/flutter/pulsar/lib/src/pulsar_realtime_composer.dart
@@ -4,7 +4,9 @@ part of 'package:pulsar_haptics/pulsar.dart';
 ///
 /// Ideal for gesture-driven feedback (e.g. sliders, drag gestures).
 /// ```dart
-/// // Start/update haptic as the user drags
+/// // Start the composer before sending updates
+/// await pulsar.getRealtimeComposer().start();
+/// // Update haptic as the user drags
 /// await pulsar.getRealtimeComposer().set(0.8, 0.5);
 /// // Stop when the gesture ends
 /// await pulsar.getRealtimeComposer().stop();
@@ -14,11 +16,26 @@ class PulsarRealtimeComposer {
 
   final RealtimeComposerStrategy? strategy;
 
-  /// Set continuous haptic parameters. Starts automatically if not already active.
+  /// Start the realtime composer. Must be called before [set] has any effect.
+  /// Calling [set] on a composer that is not started (or already stopped) is a no-op.
+  Future<void> start() =>
+      PulsarPlatform.instance.realtimeStart(strategy: strategy);
+
+  /// Update continuous haptic parameters. The composer must be started via
+  /// [start] first; otherwise this call has no effect — unless
+  /// [startIfNeeded] is `true`, in which case the composer is started
+  /// automatically before applying the new parameters.
   /// [amplitude] and [frequency] are in the range 0.0–1.0.
-  Future<void> set(double amplitude, double frequency) => PulsarPlatform
-      .instance
-      .realtimeSet(amplitude, frequency, strategy: strategy);
+  Future<void> set(
+    double amplitude,
+    double frequency, {
+    bool startIfNeeded = false,
+  }) => PulsarPlatform.instance.realtimeSet(
+    amplitude,
+    frequency,
+    startIfNeeded: startIfNeeded,
+    strategy: strategy,
+  );
 
   /// Stop the continuous haptic.
   Future<void> stop() =>

--- a/flutter/pulsar/test/pulsar_test.dart
+++ b/flutter/pulsar/test/pulsar_test.dart
@@ -81,6 +81,9 @@ class MockPulsarPlatform
   Future<bool> presetExists(String presetName) async => true;
 
   @override
+  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) async {}
+
+  @override
   Future<bool> realtimeIsActive({RealtimeComposerStrategy? strategy}) async =>
       false;
 
@@ -95,6 +98,7 @@ class MockPulsarPlatform
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
+    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) async {}
 

--- a/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
@@ -13,22 +13,28 @@ public class RealtimeComposer: NSObject {
     stop()
   }
 
-  private func start(amplitude: Float = 0.0, frequency: Float = 0.0) {
+  @objc public func start() {
+    guard engine.isHapticsEnabled else { return }
     guard !isPlaying else { return }
     guard let player = engine?.getRealtimePlayer() else { return }
     isPlaying = true
-    set(amplitude: amplitude, frequency: frequency)
     do {
       try player.start(atTime: 0)
     } catch {
+      isPlaying = false
       print("Error starting realtime player: \(error.localizedDescription)")
     }
   }
 
   @objc public func set(amplitude: Float, frequency: Float) {
+    set(amplitude: amplitude, frequency: frequency, startIfNeeded: false)
+  }
+
+  @objc public func set(amplitude: Float, frequency: Float, startIfNeeded: Bool) {
     guard engine.isHapticsEnabled else { return }
-    if (!isPlaying) {
-      start(amplitude: amplitude, frequency: frequency)
+    if !isPlaying {
+      guard startIfNeeded else { return }
+      start()
     }
     guard isPlaying, let player = engine?.getRealtimePlayer() else { return }
 

--- a/iOS/PulsarApp/PulsarApp/RealtimeComposerView.swift
+++ b/iOS/PulsarApp/PulsarApp/RealtimeComposerView.swift
@@ -176,9 +176,10 @@ struct RealtimeComposerView: View {
     
     func handleDrag(at location: CGPoint) {
         pointerLocation = location
-        
+
         if !isDragging {
             isDragging = true
+            composer?.start()
         }
         composer?.set(amplitude: getIntensity(), frequency: getSharpness())
     }

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
@@ -351,8 +351,12 @@ private class AndroidPatternComposerHandle(
 private class AndroidRealtimeComposerHandle(
     private val composer: AndroidRealtimeComposer,
 ) : RealtimeComposerHandle {
-    override fun set(amplitude: Float, frequency: Float) {
-        composer.set(amplitude, frequency)
+    override fun start() {
+        composer.start()
+    }
+
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        composer.set(amplitude, frequency, startIfNeeded)
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarControllers.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarControllers.kt
@@ -853,8 +853,16 @@ class PatternComposer internal constructor(
 class RealtimeComposer internal constructor(
     private val handle: RealtimeComposerHandle,
 ) {
+    fun start() {
+        handle.start()
+    }
+
+    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        handle.set(amplitude, frequency, startIfNeeded)
+    }
+
     fun set(amplitude: Float, frequency: Float) {
-        handle.set(amplitude, frequency)
+        handle.set(amplitude, frequency, false)
     }
 
     fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
@@ -269,7 +269,9 @@ interface PatternComposerHandle {
 }
 
 interface RealtimeComposerHandle {
-    fun set(amplitude: Float, frequency: Float)
+    fun start()
+    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean)
+    fun set(amplitude: Float, frequency: Float) = set(amplitude, frequency, false)
     fun playDiscrete(amplitude: Float, frequency: Float)
     fun stop()
     fun isActive(): Boolean

--- a/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
+++ b/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
@@ -47,7 +47,9 @@ class PulsarFacadeTest {
         composer.playPattern(PatternData())
         composer.playAudioOnly()
         composer.stop()
+        realtime.start()
         realtime.set(0.6f, 0.4f)
+        configuredRealtime.start()
         configuredRealtime.set(0.3f, 0.9f)
         realtime.playDiscrete(1f, 0.5f)
         realtime.stop()
@@ -430,9 +432,15 @@ private class FakePatternHandle : PatternComposerHandle {
 private class FakeRealtimeHandle : RealtimeComposerHandle {
     var lastSet: Pair<Float, Float>? = null
     var lastDiscrete: Pair<Float, Float>? = null
+    var started = false
     var stopped = false
 
-    override fun set(amplitude: Float, frequency: Float) {
+    override fun start() {
+        started = true
+    }
+
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+        if (startIfNeeded && !started) start()
         lastSet = amplitude to frequency
     }
 
@@ -444,5 +452,5 @@ private class FakeRealtimeHandle : RealtimeComposerHandle {
         stopped = true
     }
 
-    override fun isActive(): Boolean = false
+    override fun isActive(): Boolean = started && !stopped
 }

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/RealtimeComposer.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/RealtimeComposer.kt
@@ -20,10 +20,24 @@ internal class IOSRealtimeComposerHandle(
 ) : RealtimeComposerHandle {
     private var isPlaying = false
 
-    override fun set(amplitude: Float, frequency: Float) {
+    override fun start() {
+        if (!engine.isHapticsEnabled) return
+        if (isPlaying) return
+        val player = engine.getRealtimePlayer() ?: return
+        isPlaying = true
+        runCatching { player.startAtTime(0.0, error = null) }
+            .onFailure {
+                isPlaying = false
+                log("Error starting realtime player: ${it.message}")
+            }
+    }
+
+    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
         if (!engine.isHapticsEnabled) return
         if (!isPlaying) {
-            start(amplitude, frequency)
+            if (!startIfNeeded) return
+            start()
+            if (!isPlaying) return
         }
         val player = engine.getRealtimePlayer() ?: return
         val parameters = listOf(
@@ -64,16 +78,4 @@ internal class IOSRealtimeComposerHandle(
     }
 
     override fun isActive(): Boolean = isPlaying
-
-    private fun start(amplitude: Float = 0f, frequency: Float = 0f) {
-        if (isPlaying) return
-        val player = engine.getRealtimePlayer() ?: return
-        isPlaying = true
-        set(amplitude, frequency)
-        runCatching { player.startAtTime(0.0, error = null) }
-            .onFailure {
-                isPlaying = false
-                log("Error starting realtime player: ${it.message}")
-            }
-    }
 }

--- a/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
+++ b/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
@@ -118,7 +118,11 @@ fun App() {
                         value = amplitude,
                         onValueChange = {
                             amplitude = it
-                            pulsar?.getRealtimeComposer()?.set(amplitude = amplitude, frequency = frequency)
+                            pulsar?.getRealtimeComposer()?.set(
+                                amplitude = amplitude,
+                                frequency = frequency,
+                                startIfNeeded = true,
+                            )
                             status = "Updated realtime haptics."
                         },
                         enabled = pulsar != null,
@@ -128,7 +132,11 @@ fun App() {
                         value = frequency,
                         onValueChange = {
                             frequency = it
-                            pulsar?.getRealtimeComposer()?.set(amplitude = amplitude, frequency = frequency)
+                            pulsar?.getRealtimeComposer()?.set(
+                                amplitude = amplitude,
+                                frequency = frequency,
+                                startIfNeeded = true,
+                            )
                             status = "Updated realtime haptics."
                         },
                         enabled = pulsar != null,

--- a/react-native/PulsarApp/src/screens/RealtimeComposerScreen.tsx
+++ b/react-native/PulsarApp/src/screens/RealtimeComposerScreen.tsx
@@ -76,6 +76,7 @@ export default function RealtimeComposerScreen() {
       const normalizedX = (x / containerSize.value.width);
       const normalizedY = ((containerSize.value.height - y) / containerSize.value.height);
 
+      composer.start();
       composer.set(normalizedY, normalizedX);
     })
     .onUpdate((event: any) => {

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarModule.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/PulsarModule.kt
@@ -194,8 +194,12 @@ class PulsarModule(reactContext: ReactApplicationContext) :
 
   // RealtimeComposer -----------------------------------------------------------------
 
-  override fun RealtimeComposer_set(amplitude: Double, frequency: Double) {
-    realtimeComposer.set(amplitude.toFloat(), frequency.toFloat())
+  override fun RealtimeComposer_start() {
+    realtimeComposer.start()
+  }
+
+  override fun RealtimeComposer_set(amplitude: Double, frequency: Double, startIfNeeded: Boolean) {
+    realtimeComposer.set(amplitude.toFloat(), frequency.toFloat(), startIfNeeded)
   }
 
   override fun RealtimeComposer_playDiscrete(amplitude: Double, frequency: Double) {

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -187,13 +187,23 @@ static PatternData *PatternDataFromJSPattern(JS::NativeRNPulsar::Pattern &data) 
 
 // RealtimeComposer -----------------------------------------------------------------
 
-- (void)RealtimeComposer_set:(double)amplitude frequency:(double)frequency {
+- (void)RealtimeComposer_start {
+  if (!RNPulsarIsAppActive()) {
+    return;
+  }
+
+  RNPulsarPerformSafely(@"RealtimeComposer_start", ^{
+    [realtimeComposer_ start];
+  });
+}
+
+- (void)RealtimeComposer_set:(double)amplitude frequency:(double)frequency startIfNeeded:(BOOL)startIfNeeded {
   if (!RNPulsarIsAppActive()) {
     return;
   }
 
   RNPulsarPerformSafely(@"RealtimeComposer_set", ^{
-    [realtimeComposer_ setWithAmplitude:amplitude frequency:frequency];
+    [realtimeComposer_ setWithAmplitude:amplitude frequency:frequency startIfNeeded:startIfNeeded];
   });
 }
 

--- a/react-native/react-native-pulsar/src/NativeRNPulsar.ts
+++ b/react-native/react-native-pulsar/src/NativeRNPulsar.ts
@@ -36,7 +36,8 @@ export interface Spec extends TurboModule {
   Pulsar_enableImpulseCompositionMode(state: boolean): void;
   Pulsar_setRealtimeComposerStrategy(strategy: RealtimeComposerStrategy): void;
 
-  RealtimeComposer_set(amplitude: number, frequency: number): void;
+  RealtimeComposer_start(): void;
+  RealtimeComposer_set(amplitude: number, frequency: number, startIfNeeded: boolean): void;
   RealtimeComposer_stop(): void;
   RealtimeComposer_isActive(): boolean;
   RealtimeComposer_playDiscrete(amplitude: number, frequency: number): void;

--- a/react-native/react-native-pulsar/src/useRealtimeComposer.ts
+++ b/react-native/react-native-pulsar/src/useRealtimeComposer.ts
@@ -1,23 +1,30 @@
 import { useCallback, useEffect } from 'react';
 import Pulsar from './NativeRNPulsar';
 
-// workaround for RN prototype caching issue 
+// workaround for RN prototype caching issue
+Pulsar.RealtimeComposer_start;
 Pulsar.RealtimeComposer_set;
 Pulsar.RealtimeComposer_playDiscrete;
 Pulsar.RealtimeComposer_stop;
 Pulsar.RealtimeComposer_isActive;
 
 export type RealtimeComposer = {
-  set: (amplitude: number, frequency: number) => void;
+  start: () => void;
+  set: (amplitude: number, frequency: number, startIfNeeded?: boolean) => void;
   playDiscrete: (amplitude: number, frequency: number) => void;
   stop: () => void;
   isActive: () => boolean;
 };
 
 export default function useRealtimeComposer(): RealtimeComposer {
-  const set = useCallback((amplitude: number, frequency: number) => {
+  const start = useCallback(() => {
     'worklet';
-    Pulsar.RealtimeComposer_set(amplitude, frequency);
+    Pulsar.RealtimeComposer_start();
+  }, []);
+
+  const set = useCallback((amplitude: number, frequency: number, startIfNeeded: boolean = false) => {
+    'worklet';
+    Pulsar.RealtimeComposer_set(amplitude, frequency, startIfNeeded);
   }, []);
 
   const playDiscrete = useCallback((amplitude: number, frequency: number) => {
@@ -37,5 +44,5 @@ export default function useRealtimeComposer(): RealtimeComposer {
 
   useEffect(() => stop, [stop]);
 
-  return { set, playDiscrete, stop, isActive };
+  return { start, set, playDiscrete, stop, isActive };
 }


### PR DESCRIPTION
## Summary

Adds an explicit lifecycle to the realtime haptics composer across every SDK (iOS, Android, React Native, Flutter, KMP).

Previously, the composer auto-started the first time `set(amplitude, frequency)` was called. That implicit behavior is now opt-in. The new contract:

- `start()` — explicitly begin the realtime player. Required before `set(...)` will have any effect.
- `set(amplitude, frequency)` — update parameters. **No-op if not started or already stopped.**
- `set(amplitude, frequency, startIfNeeded: true)` — convenience: auto-starts the composer if it isn't active. Defaults to `false`, preserving the strict no-op contract.
- `stop()` — unchanged. After `stop()`, the composer is inactive again; the next `set(...)` is a no-op unless `start()` (or `startIfNeeded: true`) is used.
- `playDiscrete(...)` and `isActive()` — unchanged.

The motivation is correctness: callers can now reason about lifecycle explicitly instead of relying on the first-`set` magic, and stale `set` calls (e.g. from worklets that outlive the gesture) no longer accidentally restart playback.

## API surface

All five SDKs converge on the same contract — `startIfNeeded` is optional everywhere and defaults to `false`:

| SDK | 2-arg form | 3-arg form |
|---|---|---|
| iOS Swift / ObjC | `set(amplitude:, frequency:)` (real overload) | `set(amplitude:, frequency:, startIfNeeded:)` |
| Android Kotlin / Java | `set(a, f)` (interface default method) | `set(a, f, startIfNeeded)` |
| React Native (TS) | `set(a, f)` (optional 3rd arg) | `set(a, f, startIfNeeded)` |
| Flutter (Dart) | `set(a, f)` (named optional, defaults `false`) | `set(a, f, startIfNeeded: true)` |
| KMP common Kotlin | `set(a, f)` (interface default method + facade overload) | `set(a, f, startIfNeeded)` |

The 2-arg/3-arg split on iOS and Android/KMP isn't just sugar — it's an explicit ObjC- and Java-compatibility overload. `@objc` doesn't generate ObjC overloads for Swift default args, and Kotlin interface default args don't translate to Java, so each language gets a real overload that ObjC/Java callers can use.

## Changes per layer

### Native libraries
- **iOS** `iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift` — `start()` made public `@objc`; `set` split into 2-arg and 3-arg `@objc` overloads; `set` no-ops when not playing unless `startIfNeeded` is true.
- **Android** `Android/Pulsar/.../types/RealtimeComposer.kt` — `start()` added to the `RealtimeComposable` interface; 2-arg `set` exposed as an interface default method for Java callers.
  - `composers/RealtimeComposer.kt`, `RealtimeEnvelopeComposer.kt`, `RealtimePrimitiveComposer.kt` — all implementations override the 3-arg `set` with the new contract.

### React Native
- `src/NativeRNPulsar.ts` — TurboModule spec adds `RealtimeComposer_start()` and the 3rd `startIfNeeded` arg to `RealtimeComposer_set`.
- `src/useRealtimeComposer.ts` — hook exposes `start` and adds optional `startIfNeeded` (worklet-safe, defaults to `false`).
- `ios/Haptics.mm` and `android/.../PulsarModule.kt` — bridges wired.

### Flutter
- `lib/src/pulsar_realtime_composer.dart` — `PulsarRealtimeComposer.start()` and `set(a, f, {startIfNeeded = false})`.
- `lib/pulsar_platform_interface.dart`, `lib/pulsar_method_channel.dart` — `realtimeStart` added; `realtimeSet` carries the new named arg.
- `ios/Classes/PulsarPlugin.swift`, `android/.../PulsarPlugin.kt` — handle the new method and arg, with `?? false` fallback if missing on the channel.
- `test/pulsar_test.dart` — mock implements the new signature.

### KMP
- `commonMain/.../PulsarRuntime.kt` — `RealtimeComposerHandle` gets `start()` and the 2-arg/3-arg `set` overloads.
- `commonMain/.../PulsarControllers.kt` — `RealtimeComposer` facade mirrors the same overloads.
- `iosMain/.../iosimpl/composers/RealtimeComposer.kt` and `androidMain/.../AndroidPulsarFactory.kt` — platform impls.
- `commonTest/.../PulsarFacadeTest.kt` — `FakeRealtimeHandle` updated to track `started`.

### Demo apps
- Expo `PulsarApp`: `balloon-demo.tsx`, `sensor-haptics-demo.tsx`, `useComposedGesture.ts`, `useOnboardingComposedGesture.ts` — gesture-based demos call `start()` on `onStart`; worklet-driven demos use `set(a, f, true)`.
- Native iOS `iOS/PulsarApp` — drag handler calls `start()` once on first drag, then `set(...)`.
- Native Android `Android/PulsarApp` — drag start calls `realtimeComposer.start()` before the first `set`.
- React Native `react-native/PulsarApp` — pan `onStart` calls `composer.start()`.
- Flutter `flutter/PulsarApp` and `flutter/pulsar/example` — sliders use `set(a, f, startIfNeeded: true)`.
- KMP `kmp/PulsarApp` — sliders use `set(amplitude, frequency, startIfNeeded = true)`.

### Documentation
- `docs/src/content/docs/sdk/{ios,android,react-native,flutter,kmp}.mdx` — `start()` added to each API reference; `set(...)` signature extended; lifecycle note added explaining the no-op-when-inactive contract and the `startIfNeeded` opt-in.

## Test plan

Verified the affected build targets locally (`USE_LOCAL_PULSAR_ANDROID=1` where needed):

| Target | Result |
|---|---|
| `Android/PulsarApp` → `./gradlew :Pulsar:assembleDebug` | ✅ BUILD SUCCESSFUL |
| `react-native/PulsarApp/android` → `./gradlew :react-native-pulsar:assembleDebug` | ✅ BUILD SUCCESSFUL |
| `flutter/pulsar/example` → `flutter build apk --debug` | ✅ Built `app-debug.apk` |
| `flutter/pulsar` → `flutter analyze` | ✅ No issues found |
| `flutter/pulsar` → `flutter test` | ✅ 7/7 tests pass |
| `kmp/Pulsar` → `./gradlew :library:compileCommonMainKotlinMetadata` | ✅ BUILD SUCCESSFUL |
| `kmp/Pulsar` → `./gradlew :library:compileAndroidMain` | ✅ BUILD SUCCESSFUL |

Two pre-existing build failures surfaced during verification (unrelated to this PR) and are being fixed in separate follow-up PRs:
- KMP iOS target (`iosimpl/audio/AudioSimulator.kt`) — AVFoundation cinterop mismatch.
- iOS SwiftPM scheme (`HapticEngineWrapper.swift`) — Swift 6 strict-concurrency errors landing in #40.

## Backwards compatibility

This is a behavior change in the realtime composer's `set(...)` semantics: callers that previously relied on `set` auto-starting the composer now need either an explicit `start()` call or the `startIfNeeded: true` flag. All in-tree demo apps have been migrated. Out-of-tree users will need to do the same — flagged in the docs.

The 2-arg ObjC/Java overloads ensure no compile-time break for those callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
