### PR TITLE
fix(ios): resolve Swift 6 strict-concurrency errors in HapticEngineWrapper

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -217,17 +217,8 @@ private extension HapticEngineWrapper {
   }
 
   func seedAppActiveCache() {
-    if Thread.isMainThread {
-      isAppActiveCache = MainActor.assumeIsolated {
-        UIApplication.shared.applicationState == .active
-      }
-    } else {
-      isAppActiveCache = DispatchQueue.main.sync {
-        MainActor.assumeIsolated {
-          UIApplication.shared.applicationState == .active
-        }
-      }
-    }
+    let read = { MainActor.assumeIsolated { UIApplication.shared.applicationState == .active } }
+    isAppActiveCache = Thread.isMainThread ? read() : DispatchQueue.main.sync(execute: read)
   }
 
   func createEngineIfNeeded() throws {
@@ -247,8 +238,15 @@ private extension HapticEngineWrapper {
     // single thread; otherwise the BG handler can race with a main-thread
     // call into createPlayer / playPlayer / stopHaptics and crash on a
     // concurrent Dictionary mutation.
+    //
+    // Use `DispatchQueue.main.async` rather than `Task { @MainActor }` so the
+    // handler bodies stay strictly ordered FIFO with the rest of the main
+    // queue's work (e.g. RN bridge calls dispatched on `main` from
+    // `Haptics.mm`). Capturing `self` into the GCD closure is allowed under
+    // Swift 6 because the class is `@unchecked Sendable`; no actor hop is
+    // needed because the stored properties touched here are non-isolated.
     engine?.stoppedHandler = { [weak self] _ in
-      Task { @MainActor [weak self] in
+      DispatchQueue.main.async { [weak self] in
         guard let self else { return }
         self.initialized = false
         self.clearPlayerState(stopPlayers: false)
@@ -256,7 +254,7 @@ private extension HapticEngineWrapper {
     }
 
     engine?.resetHandler = { [weak self] in
-      Task { @MainActor [weak self] in
+      DispatchQueue.main.async { [weak self] in
         guard let self else { return }
         self.initialized = false
         self.clearPlayerState(stopPlayers: false)

--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -2,7 +2,11 @@ import Foundation
 import CoreHaptics
 import SwiftUI
 
-public class HapticEngineWrapper {
+public final class HapticEngineWrapper: @unchecked Sendable {
+  // `@unchecked Sendable` is justified: all stored state is mutated only on
+  // the main thread (see `setupEngineHandlers()` comment for details). The
+  // conformance lets us capture `self` into the main-actor closures used to
+  // serialize CoreHaptics callbacks back onto the main thread.
   private var engine: CHHapticEngine?
   private var initialized = false
   private(set) var isHapticsEnabled = true
@@ -167,7 +171,9 @@ private extension HapticEngineWrapper {
   }
 
   @objc func appWillEnterForeground() {
-    updatePlaybackAvailability(for: UIApplication.shared.applicationState)
+    // UIApplication lifecycle notifications are posted on the main thread.
+    let state = MainActor.assumeIsolated { UIApplication.shared.applicationState }
+    updatePlaybackAvailability(for: state)
   }
 
   @objc func appDidBecomeActive() {
@@ -212,10 +218,14 @@ private extension HapticEngineWrapper {
 
   func seedAppActiveCache() {
     if Thread.isMainThread {
-      isAppActiveCache = UIApplication.shared.applicationState == .active
+      isAppActiveCache = MainActor.assumeIsolated {
+        UIApplication.shared.applicationState == .active
+      }
     } else {
       isAppActiveCache = DispatchQueue.main.sync {
-        UIApplication.shared.applicationState == .active
+        MainActor.assumeIsolated {
+          UIApplication.shared.applicationState == .active
+        }
       }
     }
   }
@@ -238,7 +248,7 @@ private extension HapticEngineWrapper {
     // call into createPlayer / playPlayer / stopHaptics and crash on a
     // concurrent Dictionary mutation.
     engine?.stoppedHandler = { [weak self] _ in
-      DispatchQueue.main.async {
+      Task { @MainActor [weak self] in
         guard let self else { return }
         self.initialized = false
         self.clearPlayerState(stopPlayers: false)
@@ -246,7 +256,7 @@ private extension HapticEngineWrapper {
     }
 
     engine?.resetHandler = { [weak self] in
-      DispatchQueue.main.async {
+      Task { @MainActor [weak self] in
         guard let self else { return }
         self.initialized = false
         self.clearPlayerState(stopPlayers: false)


### PR DESCRIPTION
## Problem

Building the iOS Pulsar SwiftPM target on `main` (Swift 6, strict concurrency) currently fails:

```
iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift:242:9: error: sending 'self' risks causing data races
iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift:250:9: error: sending 'self' risks causing data races
```

Plus two related warnings on `UIApplication.shared.applicationState` access from nonisolated methods:

```
HapticEngineWrapper.swift:170: warning: main actor-isolated property 'applicationState' can not be referenced from a nonisolated context
HapticEngineWrapper.swift:215: warning: main actor-isolated property 'applicationState' can not be referenced from a nonisolated context
```

## Cause

Surfaced by #40, which routed CoreHaptics' `stoppedHandler` / `resetHandler` through `DispatchQueue.main.async { [weak self] in ... }`. CoreHaptics invokes these handlers from an internal background queue. `HapticEngineWrapper` is not `Sendable`, so under strict concurrency the compiler flags the cross-isolation capture of `self` as a data-race risk.

The two warnings come from reading the main-actor-isolated `UIApplication.shared.applicationState` from nonisolated methods (`appWillEnterForeground`, `seedAppActiveCache`).

## Fix

Minimal, surgical edits in a single file (`iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift`):

1. **`final` + `@unchecked Sendable`** on `HapticEngineWrapper`. The class's own comment in `setupEngineHandlers()` already documents that all stored state is mutated only on the main thread — `@unchecked Sendable` matches that reality and avoids cascading `@MainActor` onto `Pulsar`, `RealtimeComposer`, and `PatternComposer` (which would in turn force the `@objc` bridge consumed by the RN, Flutter, and KMP iOS modules to become main-actor too).
2. **Keep the existing `DispatchQueue.main.async` hop** in the two CoreHaptics handlers. With the class now `@unchecked Sendable`, capturing `self` into the GCD `@Sendable` closure compiles cleanly, no `Task`/`MainActor.assumeIsolated` needed there. Preserves GCD's documented FIFO ordering — both between the two handlers, and against other `DispatchQueue.main.async` work on `main` (notably the RN bridge's `methodQueue` set to `dispatch_get_main_queue()` in `react-native/react-native-pulsar/ios/Haptics.mm:49`). Added a comment paragraph explaining this choice.
3. **Wrap `UIApplication.shared.applicationState` reads** in `MainActor.assumeIsolated { ... }` at the two flagged sites (`appWillEnterForeground` and `seedAppActiveCache`). Both call sites are already main-thread-only by construction (UIKit lifecycle notifications post on main; `seedAppActiveCache` guards with `Thread.isMainThread` / `DispatchQueue.main.sync`). Also collapsed `seedAppActiveCache`'s `if/else` to a 2-line ternary with a shared reader closure.

### Why this shape (and not `Task { @MainActor }`)

An earlier iteration of this PR used `Task { @MainActor [weak self] in ... }` for the engine handlers. Three independent self-review agents (necessity / safety / consequences lenses) converged on the same finding: `Task { @MainActor }` works under Swift 6 but **loses two FIFO ordering guarantees** that the existing in-file race-avoidance comment relies on:

- **Between `stoppedHandler` and `resetHandler`** — GCD's serial-queue FIFO is documented; `Task { @MainActor }` ordering across two unstructured tasks is not part of the language contract.
- **Against other `DispatchQueue.main.async` work** — the RN bridge dispatches every method call onto `dispatch_get_main_queue()`. With GCD on both sides, those calls are guaranteed to interleave with engine cleanup in arrival order. With a `Task` on one side and GCD on the other, that's "currently funnels through the same underlying dispatch queue but isn't guaranteed."

Switching back to `DispatchQueue.main.async` once the `@unchecked Sendable` annotation was in place produced the smaller, more conservative diff and preserved the exact runtime semantics of the pre-PR code while satisfying Swift 6.

## Test plan

```bash
cd iOS/Pulsar
xcodebuild -scheme Pulsar -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "error:|warning:|BUILD"
```

- Before this PR: 2 errors + 4 warnings in `HapticEngineWrapper.swift`, `** BUILD FAILED **`.
- After this PR: 0 errors, 0 warnings in `HapticEngineWrapper.swift`, `** BUILD SUCCEEDED **`.

Remaining warnings in `AudioSimulator.swift` and `Presets/SystemPresetsImpl.swift` are pre-existing and unrelated to this change.

## Out of scope

Self-review also surfaced pre-existing latent concerns that `@unchecked Sendable` will now silently hide from the compiler (e.g. `bootstrapAppLifecycleTrackingIfNeeded` is a check-then-set without synchronization; `isHapticsEnabled` and `isAppActiveCache` are read off-main from some `@objc` paths). These predate this PR and aren't its job to fix — worth a separate hardening pass (either a `@MainActor` migration of the whole `Pulsar` / composer surface, or `dispatchPrecondition(.onQueue(.main))` guards on the public entry points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
