### PR TITLE
fix(kmp): resolve iOS cinterop errors in AudioSimulator

### DIFF
--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt
@@ -19,6 +19,7 @@ import platform.AVFAudio.AVAudioSessionModeDefault
 import platform.AVFAudio.AVAudioUnitEQ
 import platform.AVFAudio.AVAudioUnitEQFilterTypeLowPass
 import platform.AVFAudio.AVAudioUnitEQFilterParameters
+import platform.AVFAudio.setActive
 import platform.Foundation.NSProcessInfo
 import platform.posix.memcpy
 import kotlin.math.PI
@@ -80,7 +81,7 @@ internal class IOSAudioSimulator {
         }
 
         val pcmBuffer = buffer.toPcmBuffer(sampleRate) ?: return
-        playerNode.scheduleBuffer(pcmBuffer)
+        playerNode.scheduleBuffer(pcmBuffer, completionHandler = null)
         playerNode.play()
     }
 
@@ -143,9 +144,9 @@ internal class IOSAudioSimulator {
 
     private fun resolveAudioSessionCategory(): String {
         return if (isSimulatorDevice || shouldForceAudiblePlayback) {
-            AVAudioSessionCategoryPlayback
+            AVAudioSessionCategoryPlayback ?: ""
         } else {
-            AVAudioSessionCategoryAmbient
+            AVAudioSessionCategoryAmbient ?: ""
         }
     }
 


### PR DESCRIPTION
## Summary

The Kotlin/Native AVFAudio cinterop bindings (Kotlin 2.3.20) shifted a few signatures, leaving the iOS target of `AudioSimulator.kt` unable to compile. The Android and common targets were unaffected. This PR makes the minimal code-only changes needed to match the new bindings — no Kotlin / KN / Gradle version bumps.

## Errors before the fix

All in `kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/audio/AudioSimulator.kt`:

| Line | Error |
| --- | --- |
| 83:20 | `None of the following candidates is applicable` / `No value passed for parameter 'completionHandler'` on `playerNode.scheduleBuffer(pcmBuffer)` |
| 123:9 | `Cannot infer type for type parameter 'R'` (inside `runCatching { ... }`) |
| 130:21 | `Unresolved reference 'setActive'` on `session.setActive(true, error = null)` |
| 131:11 | `Cannot infer type for type parameter 'T'` (`onFailure`) |
| 137:9 | `Cannot infer type for type parameter 'R'` (second `runCatching`) |
| 138:45 | `Unresolved reference 'setActive'` on `AVAudioSession.sharedInstance().setActive(false, withOptions = 1uL, error = null)` |
| 145:16 | `Return type mismatch: expected 'String', actual 'String?'` on the category constants |

## Cause

Kotlin/Native cinterop binding changes between recent versions:

- `AVAudioPlayerNode.scheduleBuffer(buffer)` — the buffer-only overload no longer exists. All overloads now take an explicit `completionHandler`.
- `AVAudioSession.setActive` — no longer a *member* of `AVAudioSession`. It's now generated as a *top-level extension function* in the `platform.AVFAudio` package (signatures still take `Boolean`, optional options/flags, and `error: CPointer<ObjCObjectVar<NSError?>>?`). That's why the reference is unresolved: it isn't imported.
- `AVAudioSessionCategoryPlayback` / `AVAudioSessionCategoryAmbient` — exposed as `String?` instead of `String`.
- The `Cannot infer type` errors on `runCatching` were just cascading failures from the unresolved `setActive` reference; they resolve once `setActive` is back in scope.

## Fix

Per line:

- **Line 83** — pass `completionHandler = null` to keep the previous fire-and-forget behaviour:
  ```kotlin
  playerNode.scheduleBuffer(pcmBuffer, completionHandler = null)
  ```
- **Lines 130 & 138** — add `import platform.AVFAudio.setActive` so the extension function resolves. No call-site change needed.
- **Lines 123, 131, 137, 139** — automatically fixed once `setActive` resolves (cascading inference failures).
- **Line 145** — fall back to an empty string with `?: ""` so the function keeps its non-null `String` return type (these category constants are always non-null at runtime).

## Test plan

```bash
export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
export PATH="$JAVA_HOME/bin:$PATH"
export ANDROID_HOME="$HOME/Library/Android"
cd kmp/Pulsar

# iOS target (the one that was broken)
USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :library:compileKotlinIosSimulatorArm64
USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :library:compileKotlinIosArm64

# Regression checks
USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :library:compileAndroidMain
USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :library:compileCommonMainKotlinMetadata
```

All four print `BUILD SUCCESSFUL` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)