### PR TITLE
fix(flutter): make pulsar_haptics iOS plugin build under SPM

### DIFF
--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -1,6 +1,10 @@
 import Flutter
 import UIKit
+#if canImport(Pulsar_haptics)
 import Pulsar_haptics
+#elseif canImport(Pulsar)
+import Pulsar
+#endif
 
 public class PulsarPlugin: NSObject, FlutterPlugin {
   private let pulsar = Pulsar()

--- a/flutter/pulsar/ios/pulsar_haptics/Package.swift
+++ b/flutter/pulsar/ios/pulsar_haptics/Package.swift
@@ -12,9 +12,13 @@ let package = Package(
         .library(name: "pulsar-haptics", targets: ["pulsar_haptics"]),
         .library(name: "pulsar_haptics", targets: ["pulsar_haptics"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.1.4"),
+    ],
     targets: [
         .target(
             name: "pulsar_haptics",
+            dependencies: [.product(name: "Pulsar", package: "pulsar-ios")],
             path: "Sources/pulsar_haptics",
             linkerSettings: [
                 .linkedFramework("CoreHaptics"),


### PR DESCRIPTION
## Summary

- Adds an SPM dependency on [`software-mansion-labs/pulsar-ios`](https://github.com/software-mansion-labs/pulsar-ios) (≥ 1.1.4) to `flutter/pulsar/ios/pulsar_haptics/Package.swift` and wires the `Pulsar` product as a dependency of the `pulsar_haptics` target.
- Switches the plugin's `import` to `#if canImport(Pulsar_haptics) / #elseif canImport(Pulsar)` so the same file builds under both CocoaPods (module `Pulsar_haptics`) and SPM (module `Pulsar`).

## Why

Flutter ≥ 3.32 uses Swift Package Manager by default. Under SPM, `cd flutter/PulsarApp && flutter build ios --debug --no-codesign --simulator` was failing with:

```
Swift Compiler Error (Xcode): No such module 'Pulsar_haptics'
.../flutter/pulsar/ios/pulsar_haptics/Sources/pulsar_haptics/Classes/PulsarPlugin.swift:2:7
```

Root cause:

- `PulsarPlugin.swift` does `import Pulsar_haptics`. That module name is what CocoaPods auto-generates for the `Pulsar-haptics` pod.
- The plugin's `Package.swift` declared no external SPM dependencies — nothing provides a `Pulsar_haptics` module under SPM.
- The published Pulsar iOS SDK exposes its product as `Pulsar` (see `iOS/Pulsar/Package.swift`: `name: "Pulsar"`, library `Pulsar`). Under SPM the correct import is `import Pulsar`.
- Disabling Flutter SPM with `flutter config --no-enable-swift-package-manager` is not a workaround — Flutter then refuses the plugin with _"Plugin pulsar_haptics is only compatible with Swift Package Manager"_ because `ios/Package.swift` is present.

The conditional import keeps the CocoaPods path (`Pulsar_haptics`) working while letting the SPM path resolve to `Pulsar`. Note: `flutter/pulsar/ios/Classes/PulsarPlugin.swift` and `flutter/pulsar/ios/pulsar_haptics/Sources/pulsar_haptics/Classes/PulsarPlugin.swift` are the same inode (hard-linked), so a single edit updates both.

## Heads up — published Pulsar 1.1.4 has a Swift 6 strict-concurrency break

Published `pulsar-ios` 1.1.4 still uses Swift 6 by default and fails to compile under Xcode 16 with multiple "main actor-isolated initializer in synchronous nonisolated context" errors in `iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift` (UIImpactFeedbackGenerator usage). PR #54 in this repo pins `iOS/Pulsar/Package.swift` to `swiftLanguageModes: [.v5]` for local builds, but that pin does **not** apply to the remote 1.1.4 that SPM resolves here. So after this PR, the SPM build will still fail at compile time inside the resolved `Pulsar` target until either:

- 1.1.5 ships with the Swift 5 mode pin (or with the actor-isolation issues actually fixed) and the lower bound here is bumped; OR
- The actor-isolation issues are fixed properly in `SystemPresetsImpl.swift` (e.g. `@MainActor`, `MainActor.assumeIsolated`, or `@preconcurrency import UIKit`) and re-published.

## Test plan

- [ ] After the 1.1.5 publish (or fix above), `cd flutter/PulsarApp && flutter build ios --debug --no-codesign --simulator` succeeds end-to-end.
- [ ] CocoaPods path still builds — confirm with `flutter config --no-enable-swift-package-manager` once the SPM path is green (or by checking that the `Pulsar-haptics` pod still resolves the import via the `#if canImport(Pulsar_haptics)` branch).
- [ ] Re-run the `ios-flutter` job in `.github/workflows/test-build-apps.yml` once 1.1.5 is published.

> Note: the `ios-flutter` job in `.github/workflows/test-build-apps.yml` did not have a `continue-on-error` marker on this branch, so no workflow edit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)