### PR TITLE
fix(ios): adopt Swift 6 language mode in Pulsar Swift Package

### DIFF
--- a/iOS/Pulsar/Package.swift
+++ b/iOS/Pulsar/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -23,12 +23,14 @@ let package = Package(
             dependencies: ["Pulsar"]
         ),
     ],
-    // Pin to Swift 5 language mode. Several call sites (e.g. SystemPresetsImpl
-    // constructing UIImpactFeedbackGenerator) invoke main-actor-isolated APIs
-    // from synchronous nonisolated contexts and don't yet build cleanly under
-    // Swift 6's strict concurrency checking. Using `swiftLanguageVersions:`
-    // (the tools-5.x API) so SPM consumers pinned to tools-5.x can still depend
-    // on this package — required by `flutter/pulsar/ios/pulsar_haptics/Package
-    // .swift`, which is tools-5.9.
-    swiftLanguageVersions: [.v5]
+    // Build under the Swift 6 language mode so the package and its consumers
+    // get full strict-concurrency checking. The source has been audited and
+    // the MainActor-isolated UIKit feedback generators are reached through
+    // synchronous `MainActor.assumeIsolated` helpers (see
+    // `Sources/Pulsar/Presets/SystemPresetsImpl.swift`). CoreHaptics callbacks
+    // and the AVAudioEngine pipeline are serialized via a serial dispatch
+    // queue + `@unchecked Sendable` wrapper classes; see the rationale
+    // comments at the top of `HapticEngineWrapper.swift` and
+    // `AudioSimulator.swift`.
+    swiftLanguageModes: [.v6]
 )

--- a/iOS/Pulsar/Package.swift
+++ b/iOS/Pulsar/Package.swift
@@ -23,14 +23,5 @@ let package = Package(
             dependencies: ["Pulsar"]
         ),
     ],
-    // Build under the Swift 6 language mode so the package and its consumers
-    // get full strict-concurrency checking. The source has been audited and
-    // the MainActor-isolated UIKit feedback generators are reached through
-    // synchronous `MainActor.assumeIsolated` helpers (see
-    // `Sources/Pulsar/Presets/SystemPresetsImpl.swift`). CoreHaptics callbacks
-    // and the AVAudioEngine pipeline are serialized via a serial dispatch
-    // queue + `@unchecked Sendable` wrapper classes; see the rationale
-    // comments at the top of `HapticEngineWrapper.swift` and
-    // `AudioSimulator.swift`.
     swiftLanguageModes: [.v6]
 )

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -9,12 +9,26 @@ import Foundation
 @preconcurrency import AVFoundation
 
 public final class AudioSimulator: NSObject, @unchecked Sendable {
-  // `@unchecked Sendable` rationale: every mutable stored property is either
-  // protected by `playSoundLock` (`_playSound`) or is only mutated inside the
-  // serial `audioQueue` (`audioContext`, `playerNode`, `filterNode`,
-  // `isEngineConfigured`, `shouldForceAudiblePlayback`). The remaining stored
-  // values are `let` constants. This matches the pattern used in
-  // `HapticEngineWrapper`.
+  // `@unchecked Sendable` rationale, by category of stored state:
+  //
+  //  * `audioContext`, `playerNode`, `filterNode`, `isEngineConfigured`,
+  //    `shouldForceAudiblePlayback` — engine state. Only mutated inside the
+  //    serial `audioQueue` (see `enableSound`, `configureAudioContext`,
+  //    `play(buffer:)`, `stop`). Reads also happen on the queue, or in the
+  //    `audioQueue.sync` `isPlaying` getter.
+  //  * `_playSound` — guarded by `playSoundLock` for all post-init reads/
+  //    writes. The init body assigns it directly, which is safe because the
+  //    instance is not yet shared with any other thread.
+  //  * `sampleRate`, `isSimulatorDevice`, `playSoundLock`, `audioQueue` —
+  //    `let` constants.
+  //
+  // The `parsePattern`/`renderPattern` pipeline that synthesises the
+  // `AVAudioPCMBuffer` runs synchronously on the caller's thread and is
+  // pure & reentrant (it reads only its arguments and `let`-constant state,
+  // and the only field it touches is `playSound` via the lock). It is
+  // therefore safe to invoke concurrently from multiple threads.
+  //
+  // This matches the threading model used in `HapticEngineWrapper`.
 	private let sampleRate: Double = 22050
   private let isSimulatorDevice: Bool = {
     #if targetEnvironment(simulator)
@@ -455,6 +469,9 @@ public final class AudioSimulator: NSObject, @unchecked Sendable {
 	}
 
 	public var isPlaying: Bool {
+		// `audioQueue.sync` would deadlock if called from inside an `audioQueue`
+		// block; callers must invoke this from outside the queue. No current
+		// code path re-enters from the queue.
 		return audioQueue.sync { playerNode?.isPlaying ?? false }
 	}
 }

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -1,7 +1,20 @@
 import Foundation
-import AVFoundation
+// AVFoundation's audio types (AVAudioEngine, AVAudioPlayerNode, AVAudioUnitEQ,
+// AVAudioPCMBuffer, AVAudioSession, ...) predate Swift 6 Sendable annotations and
+// are not declared Sendable. Using `@preconcurrency` lets the package import them
+// from the Swift 6 language mode without triggering Sendable-related errors when
+// these types cross our serial `audioQueue` boundary. All actual cross-thread state
+// in this class is serialized either by the queue or by `NSLock`; see the
+// `@unchecked Sendable` rationale below.
+@preconcurrency import AVFoundation
 
-public class AudioSimulator: NSObject {
+public final class AudioSimulator: NSObject, @unchecked Sendable {
+  // `@unchecked Sendable` rationale: every mutable stored property is either
+  // protected by `playSoundLock` (`_playSound`) or is only mutated inside the
+  // serial `audioQueue` (`audioContext`, `playerNode`, `filterNode`,
+  // `isEngineConfigured`, `shouldForceAudiblePlayback`). The remaining stored
+  // values are `let` constants. This matches the pattern used in
+  // `HapticEngineWrapper`.
 	private let sampleRate: Double = 22050
   private let isSimulatorDevice: Bool = {
     #if targetEnvironment(simulator)

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -1,34 +1,7 @@
 import Foundation
-// AVFoundation's audio types (AVAudioEngine, AVAudioPlayerNode, AVAudioUnitEQ,
-// AVAudioPCMBuffer, AVAudioSession, ...) predate Swift 6 Sendable annotations and
-// are not declared Sendable. Using `@preconcurrency` lets the package import them
-// from the Swift 6 language mode without triggering Sendable-related errors when
-// these types cross our serial `audioQueue` boundary. All actual cross-thread state
-// in this class is serialized either by the queue or by `NSLock`; see the
-// `@unchecked Sendable` rationale below.
 @preconcurrency import AVFoundation
 
 public final class AudioSimulator: NSObject, @unchecked Sendable {
-  // `@unchecked Sendable` rationale, by category of stored state:
-  //
-  //  * `audioContext`, `playerNode`, `filterNode`, `isEngineConfigured`,
-  //    `shouldForceAudiblePlayback` — engine state. Only mutated inside the
-  //    serial `audioQueue` (see `enableSound`, `configureAudioContext`,
-  //    `play(buffer:)`, `stop`). Reads also happen on the queue, or in the
-  //    `audioQueue.sync` `isPlaying` getter.
-  //  * `_playSound` — guarded by `playSoundLock` for all post-init reads/
-  //    writes. The init body assigns it directly, which is safe because the
-  //    instance is not yet shared with any other thread.
-  //  * `sampleRate`, `isSimulatorDevice`, `playSoundLock`, `audioQueue` —
-  //    `let` constants.
-  //
-  // The `parsePattern`/`renderPattern` pipeline that synthesises the
-  // `AVAudioPCMBuffer` runs synchronously on the caller's thread and is
-  // pure & reentrant (it reads only its arguments and `let`-constant state,
-  // and the only field it touches is `playSound` via the lock). It is
-  // therefore safe to invoke concurrently from multiple threads.
-  //
-  // This matches the threading model used in `HapticEngineWrapper`.
 	private let sampleRate: Double = 22050
   private let isSimulatorDevice: Bool = {
     #if targetEnvironment(simulator)
@@ -469,9 +442,6 @@ public final class AudioSimulator: NSObject, @unchecked Sendable {
 	}
 
 	public var isPlaying: Bool {
-		// `audioQueue.sync` would deadlock if called from inside an `audioQueue`
-		// block; callers must invoke this from outside the queue. No current
-		// code path re-enters from the queue.
 		return audioQueue.sync { playerNode?.isPlaying ?? false }
 	}
 }

--- a/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
@@ -1,6 +1,47 @@
 import UIKit
 import Foundation
 
+// UIKit feedback generators (UIImpactFeedbackGenerator, UINotificationFeedbackGenerator,
+// UISelectionFeedbackGenerator) are `@MainActor`-isolated under Swift 6. Presets in
+// this file are constructed lazily via `PresetsWrapper.getCacheablePreset(_:)`, which
+// is reached only from the React Native / Flutter bridge entry points; both bridges
+// dispatch onto the main thread, so we can safely call into `@MainActor` synchronously
+// via `MainActor.assumeIsolated` to satisfy isolation requirements without cascading
+// `@MainActor` through the public PresetsWrapper API.
+//
+// The helpers below return freshly constructed generators rather than mutating `self`
+// inside the `@MainActor` closure. That keeps Swift 6's region-based isolation happy:
+// the returned generator is transferred out of the MainActor region (no other live
+// reference exists at the construction site) and then stored into a non-isolated
+// property of the preset.
+
+@inline(__always)
+private func makeImpactGenerator(_ style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
+  MainActor.assumeIsolated {
+    let g = UIImpactFeedbackGenerator(style: style)
+    g.prepare()
+    return g
+  }
+}
+
+@inline(__always)
+private func makeNotificationGenerator() -> UINotificationFeedbackGenerator {
+  MainActor.assumeIsolated {
+    let g = UINotificationFeedbackGenerator()
+    g.prepare()
+    return g
+  }
+}
+
+@inline(__always)
+private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
+  MainActor.assumeIsolated {
+    let g = UISelectionFeedbackGenerator()
+    g.prepare()
+    return g
+  }
+}
+
 @objc public class SystemImpactLightPreset : Player, Preset {
   public static let name: String = "SystemImpactLight"
   private var impactFeedbackGenerator: UIImpactFeedbackGenerator!
@@ -11,8 +52,7 @@ import Foundation
       [0, 0.55, 0.4]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
-    self.impactFeedbackGenerator.prepare()
+    self.impactFeedbackGenerator = makeImpactGenerator(.light)
   }
 
   @objc public override func play() {
@@ -39,8 +79,7 @@ import Foundation
       [0, 0.7, 0.3]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-    self.impactFeedbackGenerator.prepare()
+    self.impactFeedbackGenerator = makeImpactGenerator(.medium)
   }
 
   @objc public override func play() {
@@ -67,8 +106,7 @@ import Foundation
       [0, 1, 0.45]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
-    self.impactFeedbackGenerator.prepare()
+    self.impactFeedbackGenerator = makeImpactGenerator(.heavy)
   }
 
   @objc public override func play() {
@@ -95,8 +133,7 @@ import Foundation
       [0, 0.6, 0.1]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .soft)
-    self.impactFeedbackGenerator.prepare()
+    self.impactFeedbackGenerator = makeImpactGenerator(.soft)
   }
 
   @objc public override func play() {
@@ -123,8 +160,7 @@ import Foundation
       [0, 0.8, 0.95]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .rigid)
-    self.impactFeedbackGenerator.prepare()
+    self.impactFeedbackGenerator = makeImpactGenerator(.rigid)
   }
 
   @objc public override func play() {
@@ -152,8 +188,7 @@ import Foundation
       [150, 1, 1]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = UINotificationFeedbackGenerator()
-    self.feedbackGenerator.prepare()
+    self.feedbackGenerator = makeNotificationGenerator()
   }
 
   @objc public override func play() {
@@ -181,8 +216,7 @@ import Foundation
       [150, 0.6, 0.9]
     ])
   //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = UINotificationFeedbackGenerator()
-    self.feedbackGenerator.prepare()
+    self.feedbackGenerator = makeNotificationGenerator()
   }
 
   @objc public override func play() {
@@ -212,8 +246,7 @@ import Foundation
       [250, 0.8, 0.4]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = UINotificationFeedbackGenerator()
-    self.feedbackGenerator.prepare()
+    self.feedbackGenerator = makeNotificationGenerator()
   }
 
   @objc public override func play() {
@@ -240,8 +273,7 @@ import Foundation
       [0, 0.4, 0.7]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = UISelectionFeedbackGenerator()
-    self.feedbackGenerator.prepare()
+    self.feedbackGenerator = makeSelectionGenerator()
   }
 
   @objc public override func play() {

--- a/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
@@ -7,38 +7,33 @@ import Foundation
 // is reached only from the React Native / Flutter bridge entry points; both bridges
 // dispatch onto the main thread, so we can safely call into `@MainActor` synchronously
 // via `MainActor.assumeIsolated` to satisfy isolation requirements without cascading
-// `@MainActor` through the public PresetsWrapper API.
+// `@MainActor` through the public `PresetsWrapper` API.
 //
-// The helpers below return freshly constructed generators rather than mutating `self`
-// inside the `@MainActor` closure. That keeps Swift 6's region-based isolation happy:
-// the returned generator is transferred out of the MainActor region (no other live
-// reference exists at the construction site) and then stored into a non-isolated
-// property of the preset.
+// `makeMainActorPreparedGenerator` returns a freshly constructed generator rather than
+// mutating `self` inside the `@MainActor` closure. That keeps Swift 6's region-based
+// isolation happy: the returned generator is transferred out of the MainActor region
+// (no other live reference exists at the construction site) and then stored into a
+// non-isolated property of the preset.
+//
+// Defense in depth: `MainActor.assumeIsolated` in release builds may silently allow
+// off-main-thread callers and corrupt UIKit state. `PresetsWrapper`'s public API
+// (`preloadPresetByName`, `getByName`, ...) carries no `@MainActor` constraint, so a
+// third-party SPM consumer could call us from a background queue at app startup. The
+// explicit `Thread.isMainThread` precondition turns that misuse into a deterministic
+// crash with a clear message in both Debug and Release.
 
 @inline(__always)
-private func makeImpactGenerator(_ style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
-  MainActor.assumeIsolated {
-    let g = UIImpactFeedbackGenerator(style: style)
-    g.prepare()
-    return g
-  }
-}
-
-@inline(__always)
-private func makeNotificationGenerator() -> UINotificationFeedbackGenerator {
-  MainActor.assumeIsolated {
-    let g = UINotificationFeedbackGenerator()
-    g.prepare()
-    return g
-  }
-}
-
-@inline(__always)
-private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
-  MainActor.assumeIsolated {
-    let g = UISelectionFeedbackGenerator()
-    g.prepare()
-    return g
+private func makeMainActorPreparedGenerator<G: UIFeedbackGenerator>(
+  _ build: @MainActor () -> G
+) -> G {
+  precondition(
+    Thread.isMainThread,
+    "Pulsar system presets must be constructed on the main thread (UIFeedbackGenerator is @MainActor-isolated)."
+  )
+  return MainActor.assumeIsolated {
+    let generator = build()
+    generator.prepare()
+    return generator
   }
 }
 
@@ -52,7 +47,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 0.55, 0.4]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = makeImpactGenerator(.light)
+    self.impactFeedbackGenerator = makeMainActorPreparedGenerator { UIImpactFeedbackGenerator(style: .light) }
   }
 
   @objc public override func play() {
@@ -79,7 +74,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 0.7, 0.3]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = makeImpactGenerator(.medium)
+    self.impactFeedbackGenerator = makeMainActorPreparedGenerator { UIImpactFeedbackGenerator(style: .medium) }
   }
 
   @objc public override func play() {
@@ -106,7 +101,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 1, 0.45]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = makeImpactGenerator(.heavy)
+    self.impactFeedbackGenerator = makeMainActorPreparedGenerator { UIImpactFeedbackGenerator(style: .heavy) }
   }
 
   @objc public override func play() {
@@ -133,7 +128,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 0.6, 0.1]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = makeImpactGenerator(.soft)
+    self.impactFeedbackGenerator = makeMainActorPreparedGenerator { UIImpactFeedbackGenerator(style: .soft) }
   }
 
   @objc public override func play() {
@@ -160,7 +155,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 0.8, 0.95]
     ])
 //CODEGEN_END_{system_preset}
-    self.impactFeedbackGenerator = makeImpactGenerator(.rigid)
+    self.impactFeedbackGenerator = makeMainActorPreparedGenerator { UIImpactFeedbackGenerator(style: .rigid) }
   }
 
   @objc public override func play() {
@@ -188,7 +183,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [150, 1, 1]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = makeNotificationGenerator()
+    self.feedbackGenerator = makeMainActorPreparedGenerator { UINotificationFeedbackGenerator() }
   }
 
   @objc public override func play() {
@@ -216,7 +211,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [150, 0.6, 0.9]
     ])
   //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = makeNotificationGenerator()
+    self.feedbackGenerator = makeMainActorPreparedGenerator { UINotificationFeedbackGenerator() }
   }
 
   @objc public override func play() {
@@ -246,7 +241,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [250, 0.8, 0.4]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = makeNotificationGenerator()
+    self.feedbackGenerator = makeMainActorPreparedGenerator { UINotificationFeedbackGenerator() }
   }
 
   @objc public override func play() {
@@ -273,7 +268,7 @@ private func makeSelectionGenerator() -> UISelectionFeedbackGenerator {
       [0, 0.4, 0.7]
     ])
 //CODEGEN_END_{system_preset}
-    self.feedbackGenerator = makeSelectionGenerator()
+    self.feedbackGenerator = makeMainActorPreparedGenerator { UISelectionFeedbackGenerator() }
   }
 
   @objc public override func play() {

--- a/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift
@@ -1,27 +1,6 @@
 import UIKit
 import Foundation
 
-// UIKit feedback generators (UIImpactFeedbackGenerator, UINotificationFeedbackGenerator,
-// UISelectionFeedbackGenerator) are `@MainActor`-isolated under Swift 6. Presets in
-// this file are constructed lazily via `PresetsWrapper.getCacheablePreset(_:)`, which
-// is reached only from the React Native / Flutter bridge entry points; both bridges
-// dispatch onto the main thread, so we can safely call into `@MainActor` synchronously
-// via `MainActor.assumeIsolated` to satisfy isolation requirements without cascading
-// `@MainActor` through the public `PresetsWrapper` API.
-//
-// `makeMainActorPreparedGenerator` returns a freshly constructed generator rather than
-// mutating `self` inside the `@MainActor` closure. That keeps Swift 6's region-based
-// isolation happy: the returned generator is transferred out of the MainActor region
-// (no other live reference exists at the construction site) and then stored into a
-// non-isolated property of the preset.
-//
-// Defense in depth: `MainActor.assumeIsolated` in release builds may silently allow
-// off-main-thread callers and corrupt UIKit state. `PresetsWrapper`'s public API
-// (`preloadPresetByName`, `getByName`, ...) carries no `@MainActor` constraint, so a
-// third-party SPM consumer could call us from a background queue at app startup. The
-// explicit `Thread.isMainThread` precondition turns that misuse into a deterministic
-// crash with a clear message in both Debug and Release.
-
 @inline(__always)
 private func makeMainActorPreparedGenerator<G: UIFeedbackGenerator>(
   _ build: @MainActor () -> G


### PR DESCRIPTION
## Summary

The Pulsar Swift Package was pinned to Swift 5 language mode (`swiftLanguageVersions: [.v5]`) because two files emitted strict-concurrency diagnostics under Swift 6, see the pre-change comment in `Package.swift`. This PR closes the gap so the package builds cleanly under Swift 6 and removes the pin, giving the package and its consumers full strict-concurrency checking.

### Files changed

- **`iOS/Pulsar/Package.swift`** — bumped `swift-tools-version` to `6.0` and switched `swiftLanguageVersions: [.v5]` → `swiftLanguageModes: [.v6]`. SPM consumers pinned to tools-5.x (e.g. `flutter/pulsar/ios/pulsar_haptics/Package.swift`) can still depend on this package — SPM resolves each package against its own tools-version.
- **`iOS/Pulsar/Sources/Pulsar/Presets/SystemPresetsImpl.swift`** — UIKit feedback generators are now constructed via a generic `makeMainActorPreparedGenerator<G: UIFeedbackGenerator>` helper.
- **`iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift`** — switched to `@preconcurrency import AVFoundation` and declared the class `final` + `@unchecked Sendable`.

## Design rationale (kept out of the source per review feedback)

### `SystemPresetsImpl.swift` — `MainActor.assumeIsolated` for UIKit feedback generators

`UIImpactFeedbackGenerator`, `UINotificationFeedbackGenerator`, and `UISelectionFeedbackGenerator` are `@MainActor`-isolated under Swift 6. Presets in this file are constructed lazily via `PresetsWrapper.getCacheablePreset(_:)`, which is reached only from the React Native / Flutter bridge entry points; both bridges dispatch onto the main thread, so we can safely call into `@MainActor` synchronously via `MainActor.assumeIsolated` to satisfy isolation requirements without cascading `@MainActor` through the public `PresetsWrapper` API. Cascading would force `@MainActor` onto `Pulsar.getPresets()` (which is `@objc` and called from RN's `Haptics.mm` on `dispatch_get_main_queue()` and from Flutter's `PulsarPlugin.handle` which is also main-dispatched) — it would *work* but would publicly expose an isolation requirement that's purely a UIKit construction detail.

The helper returns a freshly-constructed generator rather than mutating `self` inside the `@MainActor` closure. That keeps Swift 6's region-based isolation happy: the returned generator is transferred out of the MainActor region (no other live reference exists at the construction site) and then stored into a non-isolated property of the preset.

**Defense in depth:** `MainActor.assumeIsolated` in release builds may silently allow off-main-thread callers and corrupt UIKit state. `PresetsWrapper`'s public API (`preloadPresetByName`, `getByName`, ...) carries no `@MainActor` constraint, so a third-party SPM consumer could call us from a background queue at app startup. The explicit `Thread.isMainThread` precondition turns that misuse into a deterministic crash with a clear message in both Debug and Release.

### `AudioSimulator.swift` — `@unchecked Sendable` rationale

By category of stored state:

- `audioContext`, `playerNode`, `filterNode`, `isEngineConfigured`, `shouldForceAudiblePlayback` — engine state. Only mutated inside the serial `audioQueue` (see `enableSound`, `configureAudioContext`, `play(buffer:)`, `stop`). Reads also happen on the queue, or in the `audioQueue.sync` `isPlaying` getter (which would deadlock if invoked from inside the queue — no current caller does so).
- `_playSound` — guarded by `playSoundLock` for all post-init reads/writes. The init body assigns it directly, which is safe because the instance is not yet shared with any other thread.
- `sampleRate`, `isSimulatorDevice`, `playSoundLock`, `audioQueue` — `let` constants.

The `parsePattern`/`renderPattern` pipeline that synthesises the `AVAudioPCMBuffer` runs synchronously on the caller's thread and is pure & reentrant (it reads only its arguments and `let`-constant state, and the only field it touches is `playSound` via the lock). It is therefore safe to invoke concurrently from multiple threads.

This matches the threading model used in `HapticEngineWrapper`.

### `AudioSimulator.swift` — `@preconcurrency import AVFoundation`

AVFoundation's audio types (`AVAudioEngine`, `AVAudioPlayerNode`, `AVAudioUnitEQ`, `AVAudioPCMBuffer`, `AVAudioSession`, ...) predate Swift 6 Sendable annotations and are not declared `Sendable`. `@preconcurrency` lets the package import them from the Swift 6 language mode without triggering Sendable-related errors when these types cross the serial `audioQueue` boundary.

## Test plan

Verified locally on Xcode 26.3 / Swift 6.2.4:

- [x] `xcodebuild -scheme Pulsar -destination 'generic/platform=iOS Simulator' clean build` → **BUILD SUCCEEDED**, zero errors, zero warnings (down from 23 strict-concurrency warnings under Swift 6 mode before this patch).
- [x] `xcodebuild -project iOS/PulsarApp/PulsarApp.xcodeproj -scheme PulsarApp -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**.
- [x] Same as above with `-configuration Release` → **BUILD SUCCEEDED**.
- [x] `xcodebuild -scheme Pulsar -destination 'platform=iOS Simulator,id=…' test` → **TEST SUCCEEDED**.
- [x] Ran the built native PulsarApp on an iPhone 17 Pro simulator (iOS 26.2) and exercised the four UIKit-backed paths whose isolation changed: tapped **System Impact Heavy**, **Notification Success**, **System Selection**, and an audio-rendering preset (**Afterglow**). The `Thread.isMainThread` precondition passes on the main-thread happy path, app launched cleanly and stayed responsive.

CI should also re-verify `_build-ios-native.yml` (the workflow that builds `PulsarApp.xcodeproj` against the local SPM resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
