### PR TITLE
Skip browser vibration on non-touch devices

### DIFF
--- a/web/Pulsar/src/Settings.ts
+++ b/web/Pulsar/src/Settings.ts
@@ -4,13 +4,6 @@ let hapticsEnabled = true;
 let soundEnabled = true;
 const stopHapticsHandlers = new Set<StopHapticsHandler>();
 
-// Desktop browsers (Chrome/Edge/Firefox) expose `navigator.vibrate` but treat
-// it as a silent no-op that still returns `true`. Relying on the function's mere
-// existence makes callers believe a haptic played when nothing was felt, which
-// in turn suppresses the audio fallback the desktop web preview relies on.
-// Only treat the device as actually able to vibrate when its primary pointer is
-// coarse — i.e. a touch-first / mobile device. When there is no DOM (SSR, tests)
-// we can't probe, so we assume capable and let the caller take the vibrate path.
 const canActuallyVibrate = () => {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
     return true;

--- a/web/Pulsar/src/Settings.ts
+++ b/web/Pulsar/src/Settings.ts
@@ -4,8 +4,27 @@ let hapticsEnabled = true;
 let soundEnabled = true;
 const stopHapticsHandlers = new Set<StopHapticsHandler>();
 
+// Desktop browsers (Chrome/Edge/Firefox) expose `navigator.vibrate` but treat
+// it as a silent no-op that still returns `true`. Relying on the function's mere
+// existence makes callers believe a haptic played when nothing was felt, which
+// in turn suppresses the audio fallback the desktop web preview relies on.
+// Only treat the device as actually able to vibrate when its primary pointer is
+// coarse — i.e. a touch-first / mobile device. When there is no DOM (SSR, tests)
+// we can't probe, so we assume capable and let the caller take the vibrate path.
+const canActuallyVibrate = () => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return true;
+  }
+
+  return window.matchMedia("(pointer: coarse)").matches;
+};
+
 const isHapticsAvailable = () => {
-  return typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.vibrate === "function" &&
+    canActuallyVibrate()
+  );
 };
 
 const stopBrowserVibration = () => {


### PR DESCRIPTION
## Summary
- Desktop browsers (Chrome / Edge / Firefox) expose `navigator.vibrate` but treat it as a silent no-op that still returns `true`. `isHapticsAvailable()` therefore reported success on desktop, which suppressed the audio fallback the web preview relies on.
- Gate the check on `matchMedia("(pointer: coarse)")` so we only treat the device as vibrate-capable when its primary pointer is touch-first. SSR / test environments without `matchMedia` keep the previous behavior.

## Test plan
- [ ] Open the web preview in a desktop browser, trigger a haptic — audio fallback plays.
- [ ] Open the web preview on a mobile device — vibration still fires.