### PR TITLE
Release web 0.1.1

### DIFF
--- a/web/Pulsar/package-lock.json
+++ b/web/Pulsar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulsar-haptics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulsar-haptics",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.3.0",

--- a/web/Pulsar/package.json
+++ b/web/Pulsar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-haptics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A TypeScript library for playing haptics on web devices — works in vanilla JS, React, and any modern framework.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `pulsar-haptics` to `0.1.1` (patch release).
- Ships the desktop-vibration detection fix from #61.

## Test plan
- [ ] `npm publish --dry-run` from `web/Pulsar` lists the expected files at version 0.1.1.