### PR TITLE
Fix repository and bugs URLs in web package

### DIFF
--- a/web/Pulsar/package.json
+++ b/web/Pulsar/package.json
@@ -70,9 +70,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pulsar-org/pulsar-haptics.git"
+    "url": "https://github.com/software-mansion/pulsar"
   },
   "bugs": {
-    "url": "https://github.com/pulsar-org/pulsar-haptics/issues"
+    "url": "https://github.com/software-mansion/pulsar/issues"
   }
 }


### PR DESCRIPTION
## Summary
- Point `pulsar-haptics` `repository.url` and `bugs.url` at the real repo (`software-mansion/pulsar`) instead of the stale `pulsar-org/pulsar-haptics` placeholder.
- These URLs surface on the npm package page and in `npm bugs` / `npm repo` — fixing them before the next publish avoids broken links from npm.

## Test plan
- [ ] On the npm page after publish, "Repository" and "Issues" links resolve to `software-mansion/pulsar`.