### PR TITLE
docs: add Flutter tab to presets playground code tabs

### DIFF
--- a/docs/src/content/docs/components/CodeTabs/CodeTabs.tsx
+++ b/docs/src/content/docs/components/CodeTabs/CodeTabs.tsx
@@ -6,17 +6,28 @@ interface CodeTabsProps {
   kotlin: string;
   kmp: string;
   reactNative: string;
+  flutter: string;
   className?: string;
 }
 
-export function CodeTabs({ swift, reactNative, kotlin, kmp, className = '' }: CodeTabsProps) {
-  const [activeTab, setActiveTab] = useState<'swift' | 'kotlin' | 'kmp' | 'reactNative'>('swift');
+export function CodeTabs({
+  swift,
+  reactNative,
+  kotlin,
+  kmp,
+  flutter,
+  className = '',
+}: CodeTabsProps) {
+  const [activeTab, setActiveTab] = useState<
+    'swift' | 'kotlin' | 'kmp' | 'reactNative' | 'flutter'
+  >('swift');
 
   const content = {
     swift,
     kotlin,
     kmp,
     reactNative,
+    flutter,
   };
 
   return (
@@ -45,6 +56,12 @@ export function CodeTabs({ swift, reactNative, kotlin, kmp, className = '' }: Co
           onClick={() => setActiveTab('reactNative')}
         >
           React Native
+        </div>
+        <div
+          className={`${styles.tab} ${activeTab === 'flutter' ? styles.active : ''}`}
+          onClick={() => setActiveTab('flutter')}
+        >
+          Flutter
         </div>
       </div>
 

--- a/docs/src/content/docs/components/Preset/Preset.tsx
+++ b/docs/src/content/docs/components/Preset/Preset.tsx
@@ -56,6 +56,12 @@ function getKmpPresetImport(shortName: string) {
   return `import com.swmansion.pulsar.kmp.Pulsar\n\nval pulsar = Pulsar.create()\npulsar.getPresets().${normalizedName}()`;
 }
 
+function getFlutterPresetImport(shortName: string) {
+  const cleanName = shortName.replace(/Preset$/, '');
+  const normalizedName = cleanName.charAt(0).toLowerCase() + cleanName.slice(1);
+  return `import 'package:pulsar_haptics/pulsar.dart';\n\nfinal pulsar = Pulsar();\npulsar.getPresets().${normalizedName}()`;
+}
+
 function toAnchorId(name: string) {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
@@ -237,6 +243,7 @@ export function Preset(preset: PresetProps) {
             kotlin={getKotlinPresetImport(data.name)}
             kmp={getKmpPresetImport(data.name)}
             reactNative={getReactNativePresetImport(data.name)}
+            flutter={getFlutterPresetImport(data.name)}
           />
         </Accordion>
       </div>


### PR DESCRIPTION
## Summary
- Add a Flutter tab to the per-preset `CodeTabs` widget in the Presets playground so the snippet sits alongside Swift, Kotlin, KMP, and React Native.
- Add `getFlutterPresetImport` in [Preset.tsx](docs/src/content/docs/components/Preset/Preset.tsx) — renders the `pulsar_haptics` import + `pulsar.getPresets().<name>()` call. Strips the `Preset` suffix on system entries so Android system presets render as `systemEffectClick()` instead of `systemEffectClickPreset()`.

## Test plan
- [x] `docs` builds (Astro dev server starts cleanly) on the worktree
- [x] First preset (`Afterglow`) → Flutter tab shows `import 'package:pulsar_haptics/pulsar.dart';` + `pulsar.getPresets().afterglow()`
- [x] Verified normalization for `SystemImpactHeavy` → `systemImpactHeavy()` and `SystemEffectClickPreset` → `systemEffectClick()` matches the documented Flutter API in [docs/src/content/docs/sdk/flutter.mdx](docs/src/content/docs/sdk/flutter.mdx)
- [ ] Reviewer: scroll the Presets playground page, open "Usage" on a few presets, confirm the new tab styling matches the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)