### PR TITLE
ci: fix Deploy Docs — build web/Pulsar + install figma/preview before docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,21 @@ jobs:
         working-directory: docs
         run: npm ci
 
+      # The docs build's prebuild step (scripts/build-figma-preview.mjs) bundles
+      # the standalone figma/preview app into an embedded <iframe srcdoc>. That
+      # app imports `pulsar-haptics` from web/Pulsar via a file: dependency, so
+      # web/Pulsar must be built (its dist/ is gitignored) and figma/preview's
+      # deps installed before the docs build runs.
+      - name: Build web haptics (pulsar-haptics) for the figma-preview embed
+        working-directory: web/Pulsar
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install figma-preview dependencies
+        working-directory: figma/preview
+        run: npm ci
+
       - name: Build docs
         working-directory: docs
         run: npm run build


### PR DESCRIPTION
## Summary
- Fixes the **Deploy Docs to GitHub Pages** workflow, which started failing after #60 merged with `[figma-preview] node_modules missing`.
- The docs `prebuild` ([scripts/build-figma-preview.mjs](docs/scripts/build-figma-preview.mjs)) bundles the standalone `figma/preview` app into the embedded `<iframe srcdoc>` preview. That app imports `pulsar-haptics` from `web/Pulsar` via a `file:` dependency, and `web/Pulsar/dist` is gitignored — so the workflow has to **build `web/Pulsar`** and **install `figma/preview`'s deps** before `docs` builds. It previously only ran `npm ci` in `docs/`.

## Fix
Two steps added before "Build docs" in [.github/workflows/deploy-docs.yml](.github/workflows/deploy-docs.yml):
- `npm ci && npm run build` in `web/Pulsar` (produces the gitignored `dist/` that `pulsar-haptics` resolves to).
- `npm ci` in `figma/preview`.

## Test plan
- [x] Reproduced the chain locally: `node docs/scripts/build-figma-preview.mjs` builds `embed.html` successfully when `web/Pulsar/dist` and `figma/preview/node_modules` are present, and fails with the exact CI error otherwise.
- [ ] CI: the **Deploy Docs** `build` job completes on this branch (then deploys).

Failing run: https://github.com/software-mansion/pulsar/actions/runs/27308388450/job/80672113714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
