### PR TITLE
ci: bump deprecated Node 20 actions to v5

### DIFF
--- a/.github/workflows/_build-android-flutter.yml
+++ b/.github/workflows/_build-android-flutter.yml
@@ -20,10 +20,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/_build-android-kmp.yml
+++ b/.github/workflows/_build-android-kmp.yml
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/_build-android-native.yml
+++ b/.github/workflows/_build-android-native.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/_build-android-rn.yml
+++ b/.github/workflows/_build-android-rn.yml
@@ -19,18 +19,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install RN library deps and build TS output
         working-directory: react-native/react-native-pulsar

--- a/.github/workflows/_build-ios-flutter.yml
+++ b/.github/workflows/_build-ios-flutter.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app

--- a/.github/workflows/_build-ios-kmp.yml
+++ b/.github/workflows/_build-ios-kmp.yml
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/_build-ios-native.yml
+++ b/.github/workflows/_build-ios-native.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app

--- a/.github/workflows/_build-ios-rn.yml
+++ b/.github/workflows/_build-ios-rn.yml
@@ -19,15 +19,15 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup Ruby (for CocoaPods)
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/publish-android-library.yml
+++ b/.github/workflows/publish-android-library.yml
@@ -17,13 +17,13 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Display version
         run: echo "Publishing version ${{ inputs.version }}"
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-ios-cocoapods.yml
+++ b/.github/workflows/publish-ios-cocoapods.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/publish-kmp-library.yml
+++ b/.github/workflows/publish-kmp-library.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Display version
         run: echo "Publishing version ${{ inputs.version }}"
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-rn-stable.yml
+++ b/.github/workflows/publish-rn-stable.yml
@@ -29,10 +29,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/publish-web-haptics.yml
+++ b/.github/workflows/publish-web-haptics.yml
@@ -30,10 +30,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

GitHub now emits the deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected

This bumps the actions whose runtime is Node.js 20 to their v5 releases (which run on Node.js 24) across all workflows:

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `actions/setup-java@v4` → `@v5`

It also aligns the two RN build workflows' `node-version` from `'20'` to `'24'`, matching the rest of the workflows (`deploy-docs`, `publish-rn-stable`, `publish-web-haptics`).

## Notes

- `ruby/setup-ruby@v1`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4` are already on Node 24 runtimes and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)