### PR TITLE
docs: make preset Usage code tabs horizontally scrollable on mobile

### DIFF
--- a/docs/src/content/docs/components/CodeTabs/CodeTabs.module.scss
+++ b/docs/src/content/docs/components/CodeTabs/CodeTabs.module.scss
@@ -3,6 +3,31 @@
   margin-top: 5px;
   .tabsHeader {
     display: flex;
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+    transition: scrollbar-color 0.3s;
+    &:hover {
+      scrollbar-color: var(--color-blue-30, #b0b0b0) transparent;
+    }
+    &::-webkit-scrollbar {
+      height: 6px; /* Horizontal scrollbar height */
+      background-color: transparent;
+    }
+    &::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: transparent;
+      border-radius: 3px;
+      transition: background-color 0.3s;
+    }
+    &:hover::-webkit-scrollbar-thumb {
+      background-color: var(--color-blue-30, #b0b0b0); /* Visible on hover */
+    }
 
     .tab {
       padding: 8px 32px;
@@ -12,6 +37,7 @@
       cursor: pointer;
       transition: all 0.2s ease;
       border-bottom: 2px solid var(--color-blue-10);
+      white-space: nowrap;
 
       &:hover {
       }


### PR DESCRIPTION
## What & why

The `CodeTabs` component used in the presets playground \"Usage\" accordions rendered its tab header with `display: flex` and no overflow handling. On narrow (mobile) viewports the later tabs overflowed past the right edge of the screen with **no way to scroll to them** — the **Flutter** tab added in [#64](https://github.com/software-mansion/pulsar/pull/64) was effectively unclickable on mobile (it rendered entirely off-screen).

## Change

Applied the same scrollable-header pattern already used by the `Tabs` component (the tags-description modal in the docs):

- `overflow-x: auto` + `max-width: 100%` on the tab header so it scrolls horizontally
- `white-space: nowrap` on the header and on each tab to disable word wrapping
- A subtle scrollbar that is transparent by default and appears on hover (WebKit + Firefox)

Only `docs/.../CodeTabs/CodeTabs.module.scss` changes — no markup/logic changes.

## Screenshots (375px mobile)

### Before — Flutter (and React Native) off-screen, unreachable
<img src="https://raw.githubusercontent.com/software-mansion/pulsar/assets/codetabs-scrollable-mobile-shots/pr-assets/before-flutter-offscreen.png" width="320" />

### After — header scrolls, no wrapping
<img src="https://raw.githubusercontent.com/software-mansion/pulsar/assets/codetabs-scrollable-mobile-shots/pr-assets/after-scrollable-tabs.png" width="320" />

### After — scrolled to the Flutter tab, now selectable
<img src="https://raw.githubusercontent.com/software-mansion/pulsar/assets/codetabs-scrollable-mobile-shots/pr-assets/after-flutter-reachable.png" width="320" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)