### PR TITLE
feat(figma): private/public toggle for live-preview share links

### DIFF
--- a/docs/server/src/figma-projects.ts
+++ b/docs/server/src/figma-projects.ts
@@ -50,12 +50,19 @@ export async function ensureFigmaProjectsTable(): Promise<void> {
       token TEXT PRIMARY KEY,
       config TEXT NOT NULL,
       revision BIGINT NOT NULL DEFAULT 0,
+      is_public BOOLEAN NOT NULL DEFAULT TRUE,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )`,
   );
   await getPool().query(
     'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS revision BIGINT NOT NULL DEFAULT 0',
+  );
+  // is_public is additive too: already-deployed tables pick it up here and
+  // existing rows default to public (the pre-feature behaviour — anyone with
+  // the link could view), so the migration doesn't silently hide live shares.
+  await getPool().query(
+    'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT TRUE',
   );
 }
 
@@ -103,7 +110,17 @@ function schedulePurge(): void {
 export interface FigmaProjectSnapshot {
   config: string;
   revision: number;
+  // When false the share link is revoked: GET refuses to serve the config so
+  // anyone holding the token can no longer view the preview. Owners flip this
+  // from the plugin; sharing again re-publishes (sets it back to true).
+  isPublic: boolean;
 }
+
+// Result of toggling a project's visibility. `not_found` mirrors update's shape
+// so the route can reuse the 404 path.
+export type FigmaProjectVisibilityResult =
+  | { kind: 'ok'; isPublic: boolean }
+  | { kind: 'not_found' };
 
 // `conflict` carries the current server snapshot so the caller can reconcile.
 export type FigmaProjectUpdateResult =
@@ -153,12 +170,28 @@ export async function updateFigmaProject(
   return { kind: 'conflict', current };
 }
 
+// Flip a project's share-link visibility. Touches updated_at (so toggling keeps
+// the row alive under the TTL purge) but deliberately leaves `revision` alone —
+// visibility isn't part of the config, so this must not provoke a spurious
+// optimistic-concurrency conflict on the owner's next config PUT.
+export async function setFigmaProjectVisibility(
+  token: string,
+  isPublic: boolean,
+): Promise<FigmaProjectVisibilityResult> {
+  const result = await getPool().query<{ is_public: boolean }>(
+    'UPDATE figma_projects SET is_public = $1, updated_at = NOW() WHERE token = $2 RETURNING is_public',
+    [isPublic, token],
+  );
+  if (result.rowCount === 0) return { kind: 'not_found' };
+  return { kind: 'ok', isPublic: result.rows[0].is_public };
+}
+
 export async function getFigmaProject(token: string): Promise<FigmaProjectSnapshot | null> {
-  const result = await getPool().query<{ config: string; revision: string }>(
-    'SELECT config, revision FROM figma_projects WHERE token = $1',
+  const result = await getPool().query<{ config: string; revision: string; is_public: boolean }>(
+    'SELECT config, revision, is_public FROM figma_projects WHERE token = $1',
     [token],
   );
   const row = result.rows[0];
   if (!row) return null;
-  return { config: row.config, revision: Number(row.revision) };
+  return { config: row.config, revision: Number(row.revision), isPublic: row.is_public };
 }

--- a/docs/server/src/middleware.ts
+++ b/docs/server/src/middleware.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 
 export function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
   res.header(
     'Access-Control-Allow-Headers',
     'Origin, X-Requested-With, Content-Type, Accept, Authorization',

--- a/docs/server/src/routes.ts
+++ b/docs/server/src/routes.ts
@@ -1,6 +1,11 @@
 import { Router, Request, Response } from 'express';
 import { ConnectionManager } from './connection-manager';
-import { createFigmaProject, getFigmaProject, updateFigmaProject } from './figma-projects';
+import {
+  createFigmaProject,
+  getFigmaProject,
+  setFigmaProjectVisibility,
+  updateFigmaProject,
+} from './figma-projects';
 
 interface BroadcastBody {
   message: string;
@@ -13,6 +18,12 @@ interface FigmaProjectBody {
   // Optimistic-concurrency base: the client's last-synced revision. When set,
   // the update applies only if the server is still at it (else 409).
   baseRevision?: number | null;
+}
+
+interface FigmaVisibilityBody {
+  // true → anyone with the link can view; false → the link is revoked and GET
+  // refuses to serve the config.
+  isPublic: boolean;
 }
 
 export function getRoutes(connectionManager: ConnectionManager): Router {
@@ -115,6 +126,34 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
     },
   );
 
+  // Toggle a project's share-link visibility. Separate from PUT (config sync) so
+  // a background autosync can never accidentally re-expose a link the owner made
+  // private — only this explicit call changes who can view.
+  router.patch(
+    '/figma-project/:token/visibility',
+    async (req: Request<{ token: string }, {}, FigmaVisibilityBody>, res: Response) => {
+      const { token } = req.params;
+      const { isPublic } = req.body ?? {};
+      if (typeof isPublic !== 'boolean') {
+        return res
+          .status(400)
+          .json({ success: false, error: 'isPublic must be a boolean' });
+      }
+      try {
+        const result = await setFigmaProjectVisibility(token, isPublic);
+        if (result.kind === 'not_found') {
+          return res.status(404).json({ success: false, error: 'Project not found' });
+        }
+        return res.json({ success: true, isPublic: result.isPublic });
+      } catch (err) {
+        console.error('setFigmaProjectVisibility failed:', err);
+        res
+          .status(500)
+          .json({ success: false, error: 'Failed to update figma project visibility' });
+      }
+    },
+  );
+
   // Fetch a project's config + revision by token.
   router.get('/figma-project/:token', async (req: Request<{ token: string }>, res: Response) => {
     const { token } = req.params;
@@ -123,13 +162,19 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
       if (snapshot === null) {
         return res.status(404).json({ success: false, error: 'Project not found' });
       }
+      // Private link: the row exists but the owner revoked access. Refuse to
+      // serve the config to anyone holding the token (403, distinct from the
+      // 404 "no such project" so the preview can show a tailored message).
+      if (!snapshot.isPublic) {
+        return res.status(403).json({ success: false, error: 'private' });
+      }
       let parsed: unknown = snapshot.config;
       try {
         parsed = JSON.parse(snapshot.config);
       } catch {
         // not JSON — return the raw string
       }
-      res.json({ success: true, config: parsed, revision: snapshot.revision });
+      res.json({ success: true, config: parsed, revision: snapshot.revision, isPublic: true });
     } catch (err) {
       console.error('getFigmaProject failed:', err);
       res.status(500).json({ success: false, error: 'Failed to fetch figma project' });

--- a/docs/server/tests/figma-projects.test.ts
+++ b/docs/server/tests/figma-projects.test.ts
@@ -3,6 +3,7 @@ import {
   createFigmaProject,
   getFigmaProject,
   updateFigmaProject,
+  setFigmaProjectVisibility,
   purgeExpiredFigmaProjects,
   ensureFigmaProjectsTable,
 } from '../src/figma-projects';
@@ -24,7 +25,7 @@ describe('figma-projects (in-memory pg)', () => {
       // beforeEach already ran ensureFigmaProjectsTable; a basic round-trip
       // confirms the table + columns exist.
       const { token } = await createFigmaProject('{}');
-      expect(await getFigmaProject(token)).toEqual({ config: '{}', revision: 0 });
+      expect(await getFigmaProject(token)).toEqual({ config: '{}', revision: 0, isPublic: true });
     });
 
     it('migration (ADD COLUMN IF NOT EXISTS) is safe to re-run', async () => {
@@ -48,7 +49,7 @@ describe('figma-projects (in-memory pg)', () => {
       expect(revision).toBe(0);
 
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"hello":"world"}', revision: 0 });
+      expect(snap).toEqual({ config: '{"hello":"world"}', revision: 0, isPublic: true });
     });
 
     it('returns revision as a JS number, not a bigint string', async () => {
@@ -71,7 +72,7 @@ describe('figma-projects (in-memory pg)', () => {
       expect(res).toEqual({ kind: 'ok', revision: 1 });
 
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"v":2}', revision: 1 });
+      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
     });
 
     it('returns not_found for a missing token', async () => {
@@ -93,16 +94,47 @@ describe('figma-projects (in-memory pg)', () => {
       await updateFigmaProject(token, '{"v":2}');
       // Now push against the stale base 0.
       const res = await updateFigmaProject(token, '{"v":3}', 0);
-      expect(res).toEqual({ kind: 'conflict', current: { config: '{"v":2}', revision: 1 } });
+      expect(res).toEqual({
+        kind: 'conflict',
+        current: { config: '{"v":2}', revision: 1, isPublic: true },
+      });
 
       // The conflicting write must NOT have been applied.
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"v":2}', revision: 1 });
+      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
     });
 
     it('returns not_found when the token no longer exists', async () => {
       const res = await updateFigmaProject('ghost', '{}', 3);
       expect(res).toEqual({ kind: 'not_found' });
+    });
+  });
+
+  describe('setFigmaProjectVisibility', () => {
+    it('new projects are public by default', async () => {
+      const { token } = await createFigmaProject('{}');
+      const snap = await getFigmaProject(token);
+      expect(snap!.isPublic).toBe(true);
+    });
+
+    it('flips a project to private and back without touching the revision', async () => {
+      const { token } = await createFigmaProject('{"v":1}');
+      // Move the revision off 0 so we can prove a visibility toggle leaves it.
+      await updateFigmaProject(token, '{"v":2}');
+
+      const off = await setFigmaProjectVisibility(token, false);
+      expect(off).toEqual({ kind: 'ok', isPublic: false });
+      const priv = await getFigmaProject(token);
+      expect(priv).toEqual({ config: '{"v":2}', revision: 1, isPublic: false });
+
+      const on = await setFigmaProjectVisibility(token, true);
+      expect(on).toEqual({ kind: 'ok', isPublic: true });
+      const pub = await getFigmaProject(token);
+      expect(pub).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
+    });
+
+    it('returns not_found for a missing token', async () => {
+      expect(await setFigmaProjectVisibility('ghost', false)).toEqual({ kind: 'not_found' });
     });
   });
 

--- a/docs/server/tests/routes.test.ts
+++ b/docs/server/tests/routes.test.ts
@@ -66,7 +66,7 @@ describe('HTTP routes', () => {
 
       const got = await request(app).get(`/figma-project/${token}`);
       expect(got.status).toBe(200);
-      expect(got.body).toEqual({ success: true, config, revision: 0 });
+      expect(got.body).toEqual({ success: true, config, revision: 0, isPublic: true });
     });
 
     it('stores a non-JSON string config and returns it raw on GET', async () => {
@@ -158,6 +158,71 @@ describe('HTTP routes', () => {
     });
   });
 
+  describe('PATCH /figma-project/:token/visibility', () => {
+    async function create(config: unknown) {
+      const res = await request(app).post('/figma-project').send({ config });
+      return res.body.token as string;
+    }
+
+    it('makes a project private, then GET returns 403 instead of the config', async () => {
+      const token = await create({ v: 1 });
+
+      const patched = await request(app)
+        .patch(`/figma-project/${token}/visibility`)
+        .send({ isPublic: false });
+      expect(patched.status).toBe(200);
+      expect(patched.body).toEqual({ success: true, isPublic: false });
+
+      const got = await request(app).get(`/figma-project/${token}`);
+      expect(got.status).toBe(403);
+      expect(got.body).toEqual({ success: false, error: 'private' });
+    });
+
+    it('re-publishing a private project restores GET access', async () => {
+      const token = await create({ v: 1 });
+      await request(app).patch(`/figma-project/${token}/visibility`).send({ isPublic: false });
+
+      const patched = await request(app)
+        .patch(`/figma-project/${token}/visibility`)
+        .send({ isPublic: true });
+      expect(patched.body).toEqual({ success: true, isPublic: true });
+
+      const got = await request(app).get(`/figma-project/${token}`);
+      expect(got.status).toBe(200);
+      expect(got.body).toEqual({ success: true, config: { v: 1 }, revision: 0, isPublic: true });
+    });
+
+    it('owners can still PUT config to a private project (sync keeps working)', async () => {
+      const token = await create({ v: 1 });
+      await request(app).patch(`/figma-project/${token}/visibility`).send({ isPublic: false });
+
+      const put = await request(app).put(`/figma-project/${token}`).send({ config: { v: 2 } });
+      expect(put.status).toBe(200);
+      // Still private after a config sync — only the explicit PATCH re-exposes it.
+      const got = await request(app).get(`/figma-project/${token}`);
+      expect(got.status).toBe(403);
+    });
+
+    it('returns 400 when isPublic is missing or not a boolean', async () => {
+      const token = await create({ v: 1 });
+      for (const bad of [undefined, 'true', 1, null]) {
+        const res = await request(app)
+          .patch(`/figma-project/${token}/visibility`)
+          .send({ isPublic: bad });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('isPublic must be a boolean');
+      }
+    });
+
+    it('returns 404 for an unknown token', async () => {
+      const res = await request(app)
+        .patch('/figma-project/ghost/visibility')
+        .send({ isPublic: false });
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ success: false, error: 'Project not found' });
+    });
+  });
+
   describe('server errors', () => {
     // Drop the table so the next query throws, exercising the 500 catch paths.
     async function breakSchema() {
@@ -185,6 +250,19 @@ describe('HTTP routes', () => {
       const res = await request(app).put('/figma-project/anything').send({ config: { a: 1 } });
       expect(res.status).toBe(500);
       expect(res.body).toEqual({ success: false, error: 'Failed to update figma project' });
+      expect(res.body).not.toHaveProperty('detail');
+    });
+
+    it('PATCH visibility returns a generic 500 when the query fails', async () => {
+      await breakSchema();
+      const res = await request(app)
+        .patch('/figma-project/anything/visibility')
+        .send({ isPublic: false });
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({
+        success: false,
+        error: 'Failed to update figma project visibility',
+      });
       expect(res.body).not.toHaveProperty('detail');
     });
   });

--- a/figma/AGENT_CONTEXT.md
+++ b/figma/AGENT_CONTEXT.md
@@ -419,18 +419,45 @@ discrete + continuous arrays. It's not an icon — never replace it with an
 
 ## Backend (docs/server)
 
-Express + PostgreSQL. Three routes that matter here: `POST /figma-project`,
-`PUT /figma-project/:token`, `GET /figma-project/:token`. Schema:
+Express + PostgreSQL. Four routes that matter here: `POST /figma-project`,
+`PUT /figma-project/:token`, `GET /figma-project/:token`, and
+`PATCH /figma-project/:token/visibility`. Schema:
 
 ```sql
 CREATE TABLE figma_projects (
   token TEXT PRIMARY KEY,
   config TEXT NOT NULL,         -- JSON-serialized PreviewPayload
   revision BIGINT NOT NULL DEFAULT 0,  -- monotonic, bumped on every PUT
+  is_public BOOLEAN NOT NULL DEFAULT TRUE,  -- share-link visibility (see below)
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 ```
+
+### Share-link visibility (`is_public`)
+
+The plugin's Live preview tab has a public/private toggle. `is_public` is the
+server-side source of truth (added via `ALTER TABLE … ADD COLUMN IF NOT EXISTS`,
+defaulting `TRUE` so pre-feature rows stay viewable):
+
+- `POST` always creates public (`is_public = TRUE`).
+- `GET` returns **403 `{ error: 'private' }`** when `is_public` is false — the
+  config is never served for a revoked link, even to a token holder. When public
+  it adds `isPublic: true` to the body. The preview app maps 403 → a dedicated
+  "This preview is private" empty state (distinct from 404 → "no design loaded").
+- `PATCH …/visibility` body `{ isPublic: boolean }` flips the flag. It touches
+  `updated_at` (keeps the TTL fresh) but **leaves `revision` alone** — visibility
+  isn't config, so toggling must not provoke an optimistic-concurrency conflict
+  on the owner's next `PUT`.
+- `PUT` (config sync) **never** changes `is_public`. This is deliberate: a
+  background autosync of a private file keeps the server config fresh without
+  silently re-exposing the link. Only `PATCH` and an explicit share re-open it.
+
+Plugin side: any explicit share action (open / copy link / copy token / QR) calls
+`PATCH …/visibility { isPublic: true }` after publishing, so "share again" always
+re-opens a privated link and flips the toggle back on. The visibility is cached
+per-file in `clientStorage` (`ProjectCache.isPublic`, default true) to seed the
+toggle on cold start, then reconciled against the server.
 
 ### Optimistic concurrency (`revision`)
 

--- a/figma/preview/src/App.tsx
+++ b/figma/preview/src/App.tsx
@@ -32,11 +32,15 @@ export default function App() {
   // and "no payload at all".
   const [payload, setPayload] = useState<PreviewPayload | null>(null);
   const [payloadLoaded, setPayloadLoaded] = useState(false);
+  // Set when the server reports the share link was made private (403). Drives a
+  // dedicated empty state distinct from "no design loaded".
+  const [isPrivate, setIsPrivate] = useState(false);
   useEffect(() => {
     let cancelled = false;
-    readPayload().then((p) => {
+    readPayload().then((res) => {
       if (cancelled) return;
-      setPayload(p);
+      setPayload(res.status === 'ok' ? res.payload : null);
+      setIsPrivate(res.status === 'private');
       setPayloadLoaded(true);
     });
     return () => {
@@ -94,12 +98,16 @@ export default function App() {
       }
       return;
     }
+    if (isPrivate) {
+      setStatus('This preview link is private.');
+      return;
+    }
     setStatus(
       payload?.fileKey
         ? 'Loading prototype…'
         : 'Waiting for a design — open one from the Pulsar plugin.'
     );
-  }, [payloadLoaded, payload]);
+  }, [payloadLoaded, payload, isPrivate]);
   const [currentNodeId, setCurrentNodeId] = useState(presentedId);
   // Sync currentNodeId when the payload arrives later (async token fetch). The
   // useState initializer above only runs once with whatever presentedId was on
@@ -223,6 +231,27 @@ export default function App() {
   const isMobile = useIsMobile();
   // On mobile we always run fullscreen (content fills the screen, no chrome).
   const fullscreen = isFullscreen || isMobile;
+
+  // The owner revoked this share link. Don't leak that a design ever existed —
+  // just explain the link is private and how to regain access.
+  if (isPrivate) {
+    return (
+      <>
+        <Header status={status} count={0} onEnterFullscreen={enterFullscreen} />
+        <main className="main">
+          <div className="frame-wrap">
+            <div className="empty">
+              <div className="big">This preview is private</div>
+              <div>
+                The owner turned off sharing for this link. Ask them to share the
+                preview again to regain access.
+              </div>
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
 
   if (!payload?.fileKey) {
     return (

--- a/figma/preview/src/lib/payload.ts
+++ b/figma/preview/src/lib/payload.ts
@@ -24,32 +24,46 @@ function getTokenFromUrl(): string | null {
   return null;
 }
 
+// Outcome of loading the payload, so the UI can distinguish the empty states:
+//   - 'ok'       → we have a payload to render.
+//   - 'private'  → the owner revoked the share link (server replied 403).
+//   - 'no-token' → no ?token= in the URL (the bare preview app).
+//   - 'missing'  → token present but the project is gone / unreadable (404 etc.).
+export type PayloadResult =
+  | { status: 'ok'; payload: PreviewPayload }
+  | { status: 'private' }
+  | { status: 'no-token' }
+  | { status: 'missing' };
+
 // Fetch the preview payload from the server using the `?token=` query param.
-export async function readPayload(): Promise<PreviewPayload | null> {
+export async function readPayload(): Promise<PayloadResult> {
   if (!API_SERVER_URL) {
     console.error('VITE_API_SERVER_URL is not set. Copy .env.example to .env.local.');
-    return null;
+    return { status: 'missing' };
   }
   const token = getTokenFromUrl();
-  if (!token) return null;
+  if (!token) return { status: 'no-token' };
   try {
     const res = await fetch(
       `${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}`,
     );
-    if (!res.ok) return null;
+    // 403 = the owner made this preview private. Surface it distinctly so the UI
+    // can explain the link was revoked rather than showing "no design loaded".
+    if (res.status === 403) return { status: 'private' };
+    if (!res.ok) return { status: 'missing' };
     const data = (await res.json()) as { success: boolean; config?: PreviewPayload | string };
-    if (!data.success || !data.config) return null;
+    if (!data.success || !data.config) return { status: 'missing' };
     // Server returns the parsed object when storage was JSON; fall back to
     // parsing if it handed back a raw string for any reason.
     if (typeof data.config === 'string') {
       try {
-        return JSON.parse(data.config) as PreviewPayload;
+        return { status: 'ok', payload: JSON.parse(data.config) as PreviewPayload };
       } catch {
-        return null;
+        return { status: 'missing' };
       }
     }
-    return data.config;
+    return { status: 'ok', payload: data.config };
   } catch {
-    return null;
+    return { status: 'missing' };
   }
 }

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -87,6 +87,10 @@ async function loadToken(): Promise<string | null> {
 type ProjectCache = {
   config: unknown;
   baseRevision: number | null;
+  // Cached share-link visibility (public/private toggle). Optional so caches
+  // written before this field existed read back as undefined; callers treat
+  // that as `true` (public), matching the pre-feature behaviour.
+  isPublic?: boolean;
   // Wall-clock of the last write, used to pick the oldest entry to evict.
   lastAccess: number;
 };
@@ -154,10 +158,19 @@ async function evictOldestProjectCache(exceptKey: string): Promise<boolean> {
 async function setProjectCache(
   fileKey: string,
   config: unknown,
-  baseRevision: number | null
+  baseRevision: number | null,
+  isPublic?: boolean
 ): Promise<void> {
   const key = PROJECT_CACHE_PREFIX + fileKey;
-  const entry: ProjectCache = { config, baseRevision, lastAccess: Date.now() };
+  // Preserve the previously-cached visibility when the caller doesn't pass one
+  // (e.g. a config-only sync), so a routine cache write can't silently flip a
+  // private link back to public. Default to public for brand-new caches.
+  let visibility = isPublic;
+  if (visibility === undefined) {
+    const existing = await getProjectCache(fileKey);
+    visibility = existing?.isPublic ?? true;
+  }
+  const entry: ProjectCache = { config, baseRevision, isPublic: visibility, lastAccess: Date.now() };
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
@@ -514,7 +527,9 @@ figma.ui.onmessage = async (msg: UiToMain) => {
         fileKey: msg.fileKey,
         token,
         config: cache ? cache.config : null,
-        baseRevision: cache ? cache.baseRevision : null
+        baseRevision: cache ? cache.baseRevision : null,
+        // Default to public for legacy caches with no stored visibility.
+        isPublic: cache?.isPublic ?? true
       });
       break;
     }
@@ -527,6 +542,21 @@ figma.ui.onmessage = async (msg: UiToMain) => {
         await setProjectCache(msg.fileKey, msg.config, msg.baseRevision);
       } catch (err) {
         console.error('Failed to cache figma project config:', err);
+      }
+      break;
+    case 'persist-project-visibility':
+      // Update only the visibility flag on the cached entry, leaving the cached
+      // config/revision untouched. Best-effort like the rest of the cache.
+      try {
+        const existing = await getProjectCache(msg.fileKey);
+        await setProjectCache(
+          msg.fileKey,
+          existing?.config ?? null,
+          existing?.baseRevision ?? null,
+          msg.isPublic
+        );
+      } catch (err) {
+        console.error('Failed to cache figma project visibility:', err);
       }
       break;
     case 'request-selection':

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -117,6 +117,10 @@ export type UiToMain =
   | { type: 'get-project'; fileKey: string }
   | { type: 'persist-project-token'; fileKey: string; token: string }
   | { type: 'persist-project-cache'; fileKey: string; config: unknown; baseRevision: number | null }
+  // Persist just the share-link visibility for a file (the public/private
+  // toggle), without rewriting the cached config. Keyed by fileKey like the
+  // rest of the per-file project state.
+  | { type: 'persist-project-visibility'; fileKey: string; isPublic: boolean }
   | { type: 'request-preview-data'; purpose: PreviewPurpose }
   | { type: 'request-bound-list' }
   | { type: 'focus-node'; nodeId: string }
@@ -148,6 +152,10 @@ export type MainToUi =
       token: string | null;
       config: unknown | null;
       baseRevision: number | null;
+      // Last-known share-link visibility for this file. Defaults to true (public)
+      // for files shared before this field existed. The server is the source of
+      // truth; this is the cached value used to seed the toggle on cold start.
+      isPublic: boolean;
     }
   // The Figma document changed. The UI debounces this into a background
   // auto-sync so the server snapshot stays fresh as the designer edits.

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -116,19 +116,56 @@ async function updateProject(
   return { kind: 'ok', revision: data.revision ?? 0 };
 }
 
-// GET the stored config + revision for a token. null on 404.
-async function fetchProject(token: string): Promise<{ config: unknown; revision: number } | null> {
+// Outcome of a GET: the stored snapshot, a revoked (private) link, or a missing
+// row. The plugin is the link's owner, so it still keeps the token on 'private'
+// (the user can re-share to re-open it) — only 'missing' means forget the token.
+type FetchResult =
+  | { kind: 'ok'; config: unknown; revision: number; isPublic: boolean }
+  | { kind: 'private' }
+  | { kind: 'missing' };
+
+// GET the stored config + revision for a token.
+async function fetchProject(token: string): Promise<FetchResult> {
   const res = await fetch(`${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}`);
-  if (res.status === 404) return null;
+  if (res.status === 404) return { kind: 'missing' };
+  // 403 = the row exists but its link was made private. The owner still holds
+  // the token; treat it as a known-private project rather than a lost one.
+  if (res.status === 403) return { kind: 'private' };
   const data = (await res.json().catch(() => null)) as
-    | { success: boolean; config?: unknown; revision?: number; error?: string; detail?: string }
+    | {
+        success: boolean;
+        config?: unknown;
+        revision?: number;
+        isPublic?: boolean;
+        error?: string;
+        detail?: string;
+      }
     | null;
   if (!res.ok) {
     const msg = data?.error ?? `Server responded ${res.status}`;
     throw new Error(data?.detail ? `${msg} (${data.detail})` : msg);
   }
   if (!data?.success) throw new Error(data?.error || 'Fetch failed');
-  return { config: data.config ?? null, revision: data.revision ?? 0 };
+  return {
+    kind: 'ok',
+    config: data.config ?? null,
+    revision: data.revision ?? 0,
+    isPublic: data.isPublic ?? true
+  };
+}
+
+// PATCH a token's share-link visibility (public ⇄ private). Returns whether the
+// server accepted the change. Separate from updateProject so a config sync and
+// a visibility toggle never get conflated.
+async function setProjectVisibility(token: string, isPublic: boolean): Promise<boolean> {
+  const res = await fetch(`${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}/visibility`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isPublic })
+  });
+  if (!res.ok) return false;
+  const data = (await res.json().catch(() => null)) as { success?: boolean } | null;
+  return !!data?.success;
 }
 
 // Deterministic JSON: keys sorted recursively so two structurally-equal
@@ -171,6 +208,9 @@ function copyToClipboard(text: string): boolean {
 export default function App() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [hapticsToken, setHapticsToken] = useState<string | null>(null);
+  // Live link to the paired phone (PhonePanel reports this). Broadcasting only
+  // makes sense while the phone is actually connected, not merely paired.
+  const [phoneConnected, setPhoneConnected] = useState(false);
 
   // --- Per-file server-sync state ---------------------------------------
   // The file we're editing. Tokens + cached config are keyed by this so a
@@ -191,6 +231,11 @@ export default function App() {
   // Debounce timer for background auto-save.
   const autosyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
+  // Share-link visibility for the current file. true = anyone with the link can
+  // view; false = the link is revoked server-side until the user shares again.
+  // Defaults to public (the historical behaviour) and is reconciled with the
+  // server on cold start and on every explicit share.
+  const [isPublic, setIsPublic] = useState(true);
 
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [tab, setTab] = useState<Tab>('presets');
@@ -249,10 +294,14 @@ export default function App() {
     token: string | null;
     config: unknown | null;
     baseRevision: number | null;
+    isPublic: boolean;
   }) => {
     fileKeyRef.current = m.fileKey;
     tokenRef.current = m.token;
     baseRevisionRef.current = m.baseRevision;
+    // Seed the toggle from the cached value; the server-fetch branch below
+    // reconciles it with the source of truth when there's a token to check.
+    setIsPublic(m.isPublic);
     if (m.config != null) {
       lastSyncedJsonRef.current = stableStringify(m.config);
       setSyncStatus(m.token ? 'synced' : 'idle');
@@ -260,15 +309,25 @@ export default function App() {
       setSyncStatus('syncing');
       try {
         const got = await fetchProject(m.token);
-        if (got) {
+        if (got.kind === 'ok') {
           baseRevisionRef.current = got.revision;
           lastSyncedJsonRef.current = stableStringify(got.config);
+          setIsPublic(got.isPublic);
+          send({ type: 'persist-project-visibility', fileKey: m.fileKey, isPublic: got.isPublic });
           send({
             type: 'persist-project-cache',
             fileKey: m.fileKey,
             config: got.config,
             baseRevision: got.revision
           });
+          setSyncStatus('synced');
+        } else if (got.kind === 'private') {
+          // The link is revoked. Keep the token (the user can re-share to
+          // re-open it) and reflect the private state in the toggle. We can't
+          // read the server config while private, so leave lastSyncedJson empty
+          // — the next autosync will re-publish the live document's bindings.
+          setIsPublic(false);
+          send({ type: 'persist-project-visibility', fileKey: m.fileKey, isPublic: false });
           setSyncStatus('synced');
         } else {
           // Token no longer exists server-side — forget it; nothing is shared.
@@ -356,10 +415,10 @@ export default function App() {
       const p = presetById.get(m.presetId);
       if (!p) return;
       if (settings.soundInEdit) playPreset(p.id, p.data).catch(() => {});
-      if (hapticsToken) broadcastToPhone(hapticsToken, p.data.name);
+      if (hapticsToken && phoneConnected) broadcastToPhone(hapticsToken, p.data.name);
     });
     return off;
-  }, [settings.soundInEdit, hapticsToken, presetById]);
+  }, [settings.soundInEdit, hapticsToken, phoneConnected, presetById]);
 
   const [shareQr, setShareQr] = useState<string | null>(null);
 
@@ -544,6 +603,14 @@ export default function App() {
         // Beyond the sync itself, share actions also need a URL / QR / clipboard.
         if (purpose === 'autosync' || purpose === 'sync') return;
 
+        // Any explicit share re-opens the link to the public: if the user had
+        // made it private, handing the link out again necessarily makes it
+        // viewable, so flip the toggle back on. Optimistic + best-effort — the
+        // server is the source of truth, reconciled on the next cold start.
+        setIsPublic(true);
+        send({ type: 'persist-project-visibility', fileKey, isPublic: true });
+        void setProjectVisibility(token, true).catch(() => {});
+
         // Strip any existing query/hash so we don't duplicate or stack tokens
         // when the user has manually visited the preview before.
         const base = resolvePreviewBaseUrl(settings.previewBaseUrlOverride).replace(/[?#].*$/, '');
@@ -612,6 +679,40 @@ export default function App() {
     send({ type: 'request-preview-data', purpose: 'sync' });
   };
 
+  // Flip the share-link visibility. Optimistic: update the toggle + local cache
+  // immediately, then PATCH the server. On failure, roll the toggle back and
+  // tell the user so the UI never claims a state the server didn't accept.
+  const setVisibility = (next: boolean) => {
+    const token = tokenRef.current;
+    const fileKey = fileKeyRef.current;
+    if (!token) return; // nothing shared yet — nothing to make private/public
+    setIsPublic(next);
+    send({ type: 'persist-project-visibility', fileKey, isPublic: next });
+    void (async () => {
+      let ok = false;
+      try {
+        ok = await setProjectVisibility(token, next);
+      } catch {
+        ok = false;
+      }
+      if (!ok) {
+        setIsPublic(!next);
+        send({ type: 'persist-project-visibility', fileKey, isPublic: !next });
+        send({
+          type: 'notify',
+          message: 'Could not update the preview’s visibility. Please try again.'
+        });
+        return;
+      }
+      send({
+        type: 'notify',
+        message: next
+          ? 'Preview link is public — anyone with the link can view it.'
+          : 'Preview link is now private — the link won’t work until you share again.'
+      });
+    })();
+  };
+
   const filtered = useMemo(() => {
     const base = applyFilter(allPresets, filter);
     return favouritesOnly ? base.filter((e) => favourites.has(e.id)) : base;
@@ -620,7 +721,7 @@ export default function App() {
 
   const playEntry = (e: CatalogEntry) => {
     stopAll();
-    if (hapticsToken) broadcastToPhone(hapticsToken, e.data.name);
+    if (hapticsToken && phoneConnected) broadcastToPhone(hapticsToken, e.data.name);
     if (settings.soundInEdit) playPreset(e.id, e.data).catch(() => {});
   };
 
@@ -662,7 +763,7 @@ export default function App() {
     if (entry) {
       stopAll();
       playPreset(entry.id, entry.data).catch(() => {});
-      if (hapticsToken) broadcastToPhone(hapticsToken, entry.data.name);
+      if (hapticsToken && phoneConnected) broadcastToPhone(hapticsToken, entry.data.name);
     }
     send({ type: 'focus-node', nodeId: item.nodeId });
   };
@@ -750,7 +851,11 @@ export default function App() {
                 onUpdate={updateCustomPreset}
                 onRemove={removeCustomPreset}
               />
-              <PhonePanel token={hapticsToken} onTokenChange={setHapticsToken} />
+              <PhonePanel
+                token={hapticsToken}
+                onTokenChange={setHapticsToken}
+                onConnectedChange={setPhoneConnected}
+              />
             </div>
           </div>
           <div className="row" style={{ padding: '4px 8px', gap: 6, marginTop: 8 }}>
@@ -826,9 +931,11 @@ export default function App() {
               onClose={() => setOpenId(null)}
               onPlay={() => playEntry(openEntry)}
               onPlayOnPhone={() =>
-                hapticsToken && broadcastToPhone(hapticsToken, openEntry.data.name)
+                hapticsToken &&
+                phoneConnected &&
+                broadcastToPhone(hapticsToken, openEntry.data.name)
               }
-              canPlayOnPhone={!!hapticsToken}
+              canPlayOnPhone={!!hapticsToken && phoneConnected}
               onBind={() => bindEntry(openEntry)}
             />
           </div>
@@ -849,6 +956,9 @@ export default function App() {
           onChange={setSettings}
           syncStatus={syncStatus}
           onSyncNow={syncNow}
+          isPublic={isPublic}
+          isShared={syncStatus !== 'idle'}
+          onToggleVisibility={setVisibility}
           onShowLivePreview={showInLivePreview}
           onCopyShareLink={copyShareLink}
           onCopyShareToken={copyShareToken}

--- a/figma/src/ui/assets/icon-globe.svg
+++ b/figma/src/ui/assets/icon-globe.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-globe"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#001A72"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+  <path d="M2 12h20" />
+</svg>

--- a/figma/src/ui/assets/icon-lock.svg
+++ b/figma/src/ui/assets/icon-lock.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-lock"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#001A72"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+</svg>

--- a/figma/src/ui/assets/icon-refresh.svg
+++ b/figma/src/ui/assets/icon-refresh.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-refresh-cw"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#001A72"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+  <path d="M21 3v5h-5" />
+  <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+  <path d="M8 16H3v5" />
+</svg>

--- a/figma/src/ui/components/LivePreviewPanel.tsx
+++ b/figma/src/ui/components/LivePreviewPanel.tsx
@@ -5,6 +5,8 @@ import iconLink from '../assets/icon-link.svg';
 import iconQrCode from '../assets/icon-qr-code.svg';
 import iconKey from '../assets/icon-key.svg';
 import iconClose from '../assets/icon-close.svg';
+import iconGlobe from '../assets/icon-globe.svg';
+import iconLock from '../assets/icon-lock.svg';
 
 // Live preview tab. Share paths with clear visual hierarchy:
 //   - Primary CTA: open the preview in the browser (most direct, taps the
@@ -36,6 +38,9 @@ const SYNC_META: Record<SyncStatus, { label: string; dot: string; pulse?: boolea
 export default function LivePreviewPanel({
   syncStatus,
   onSyncNow,
+  isPublic,
+  isShared,
+  onToggleVisibility,
   onShowLivePreview,
   onCopyShareLink,
   onCopyShareToken,
@@ -47,6 +52,12 @@ export default function LivePreviewPanel({
   onChange: (next: Settings) => void;
   syncStatus: SyncStatus;
   onSyncNow: () => void;
+  // Whether the share link is currently public (anyone with the link can view).
+  isPublic: boolean;
+  // Whether this file has been shared yet (has a server token). The visibility
+  // toggle is meaningless — and disabled — until then.
+  isShared: boolean;
+  onToggleVisibility: (next: boolean) => void;
   onShowLivePreview: () => void;
   onCopyShareLink: () => void;
   onCopyShareToken: () => void;
@@ -84,6 +95,50 @@ export default function LivePreviewPanel({
         >
           Sync now
         </button>
+      </div>
+
+      {/* Share-link visibility. When public, anyone with the link can open the
+          preview; flip it off to revoke access without losing the share token.
+          Any share action below re-opens it. Disabled until the file has been
+          shared at least once (no server row to gate yet). */}
+      <div className={`preview-visibility-row${isShared ? '' : ' disabled'}`}>
+        <img
+          src={isPublic ? iconGlobe : iconLock}
+          alt=""
+          width={16}
+          height={16}
+          style={{ flexShrink: 0, marginTop: 1 }}
+        />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 600, fontSize: 'var(--fs-sm)' }}>
+            {isPublic ? 'Anyone with the link can view' : 'Link is private'}
+          </div>
+          <p
+            className="muted"
+            style={{ margin: '2px 0 0', fontSize: 'var(--fs-xs)', lineHeight: 1.45 }}
+          >
+            {isShared
+              ? isPublic
+                ? 'Turn off to revoke the link. Sharing again re-opens it.'
+                : 'The share link won’t work until you share the preview again.'
+              : 'Share the preview first to control who can access the link.'}
+          </p>
+        </div>
+        <input
+          type="checkbox"
+          className="switch"
+          checked={isPublic}
+          disabled={!isShared}
+          onChange={(e) => onToggleVisibility(e.target.checked)}
+          title={
+            isShared
+              ? isPublic
+                ? 'Make the share link private'
+                : 'Make the share link public'
+              : 'Share the preview first'
+          }
+          aria-label="Anyone with the link can view"
+        />
       </div>
 
       {/* Primary action — full-width, icon-prefixed. */}

--- a/figma/src/ui/components/LivePreviewPanel.tsx
+++ b/figma/src/ui/components/LivePreviewPanel.tsx
@@ -7,6 +7,7 @@ import iconKey from '../assets/icon-key.svg';
 import iconClose from '../assets/icon-close.svg';
 import iconGlobe from '../assets/icon-globe.svg';
 import iconLock from '../assets/icon-lock.svg';
+import iconRefresh from '../assets/icon-refresh.svg';
 
 // Live preview tab. Share paths with clear visual hierarchy:
 //   - Primary CTA: open the preview in the browser (most direct, taps the
@@ -88,12 +89,19 @@ export default function LivePreviewPanel({
           <span>{sync.label}</span>
         </span>
         <button
-          className="ghost preview-sync-now"
+          className="ghost icon preview-sync-now"
           onClick={onSyncNow}
           disabled={syncStatus === 'syncing'}
           title="Push the current design to the server now"
+          aria-label="Sync now"
         >
-          Sync now
+          <img
+            src={iconRefresh}
+            alt=""
+            width={16}
+            height={16}
+            className={syncStatus === 'syncing' ? 'preview-sync-spin' : undefined}
+          />
         </button>
       </div>
 

--- a/figma/src/ui/components/PhonePanel.tsx
+++ b/figma/src/ui/components/PhonePanel.tsx
@@ -7,22 +7,47 @@ import iconQr from '../assets/icon-qr-code.svg';
 const API_SERVER_URL = 'https://pulsar-server.swmansion.com';
 const SOCKET_SERVER_URL = 'wss://pulsar-server.swmansion.com';
 
-type Status = 'idle' | 'requesting' | 'awaiting-phone' | 'connected' | 'error';
+// Keep the sender socket alive so the server's heartbeat sweep doesn't reap it
+// while the phone is away. Matches the docs Connection component's interval.
+const PING_INTERVAL_MS = 25_000;
+
+// Pairing flow for a phone that hasn't been linked yet. Once a token exists the
+// panel is `paired` and this no longer drives the UI — the live `connected`
+// flag does. Kept separate so a phone dropping out (`peer_disconnected`) flips
+// the indicator off without discarding the pairing and forcing a re-scan.
+type Phase = 'idle' | 'requesting' | 'awaiting-phone' | 'error';
 
 export default function PhonePanel({
   token,
-  onTokenChange
+  onTokenChange,
+  onConnectedChange
 }: {
   token: string | null;
   onTokenChange: (t: string | null) => void;
+  // Reports the live link to the phone (distinct from being paired). The parent
+  // gates "play on phone" on this so we don't broadcast into a dead channel.
+  onConnectedChange?: (connected: boolean) => void;
 }) {
   const [code, setCode] = useState<string | null>(null);
-  const [status, setStatus] = useState<Status>(token ? 'connected' : 'idle');
+  const [phase, setPhase] = useState<Phase>('idle');
+  // Live link to the phone. Paired (token != null) but `connected === false`
+  // means the phone is away — the server keeps our socket and will push
+  // `connection_restored` when it returns.
+  const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
-  const wsRef = useRef<WebSocket | null>(null);
 
-  useEffect(() => () => wsRef.current?.close(), []);
+  const wsRef = useRef<WebSocket | null>(null);
+  // The token our current socket is bound to. Lets the token effect below tell
+  // "restored from storage" (open a socket) apart from "just paired" (the
+  // pairing socket already owns it — don't reopen and churn the connection).
+  const boundTokenRef = useRef<string | null>(null);
+
+  const paired = token != null;
+
+  useEffect(() => {
+    onConnectedChange?.(connected);
+  }, [connected, onConnectedChange]);
 
   useEffect(() => {
     if (!code) return;
@@ -35,65 +60,102 @@ export default function PhonePanel({
       .catch(() => setQrDataUrl(null));
   }, [code]);
 
-  // If we already have a token, try to reconnect (server sends connection_restored
-  // when the phone is still paired).
-  useEffect(() => {
-    if (!token) return;
-    const ws = new WebSocket(
-      `${SOCKET_SERVER_URL}/?type=sender&action=reuse_connection&token=${encodeURIComponent(token)}`
-    );
+  // Open a sender socket and wire up the shared message handling + keepalive.
+  // `params` selects new_connection (pairing) vs reuse_connection (restore).
+  const openSocket = (params: string) => {
+    wsRef.current?.close();
+    const ws = new WebSocket(`${SOCKET_SERVER_URL}/?type=sender${params}`);
     wsRef.current = ws;
+
+    const ping = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'ping' }));
+    }, PING_INTERVAL_MS);
+    ws.addEventListener('close', () => clearInterval(ping));
+
     ws.onmessage = (e) => {
       try {
         const msg = JSON.parse(e.data);
-        if (msg.type === 'connection_restored') setStatus('connected');
-        if (msg.type === 'peer_disconnected') setStatus('idle');
+        switch (msg.type) {
+          // Fresh pairing completed — claim the token before handing it up so
+          // the token effect sees the socket already bound and doesn't reopen.
+          case 'connection_established':
+            if (msg.token) {
+              boundTokenRef.current = msg.token;
+              onTokenChange(msg.token);
+            }
+            setConnected(true);
+            setCode(null);
+            setError(null);
+            break;
+          // Phone came back on a still-paired channel.
+          case 'connection_restored':
+            setConnected(true);
+            setError(null);
+            break;
+          // Phone went away. Stay paired — the server holds our socket and will
+          // send connection_restored when it returns.
+          case 'peer_disconnected':
+            setConnected(false);
+            break;
+        }
       } catch {}
     };
-    ws.onerror = () => setStatus('error');
-    return () => ws.close();
+    ws.onerror = () => {
+      setConnected(false);
+      if (!paired) {
+        setError('WebSocket error');
+        setPhase('error');
+      }
+    };
+    return ws;
+  };
+
+  // Persistent connection for an already-paired phone (restored from storage).
+  // Skipped right after pairing, where the pairing socket already owns the token
+  // (boundTokenRef), so we don't tear down a healthy connection.
+  useEffect(() => {
+    if (!token) {
+      boundTokenRef.current = null;
+      return;
+    }
+    if (boundTokenRef.current === token) return;
+    boundTokenRef.current = token;
+    openSocket(`&action=reuse_connection&token=${encodeURIComponent(token)}`);
   }, [token]);
+
+  useEffect(
+    () => () => {
+      wsRef.current?.close();
+      wsRef.current = null;
+    },
+    []
+  );
 
   const startPairing = async () => {
     setError(null);
-    setStatus('requesting');
+    setPhase('requesting');
     try {
       const r = await fetch(`${API_SERVER_URL}/create-channel`);
       const j = await r.json();
       if (!j.success) throw new Error('Server refused channel creation');
       const newCode: string = j.code;
       setCode(newCode);
-      setStatus('awaiting-phone');
-      const ws = new WebSocket(
-        `${SOCKET_SERVER_URL}/?type=sender&action=new_connection&code=${newCode}`
-      );
-      wsRef.current = ws;
-      ws.onmessage = (e) => {
-        try {
-          const msg = JSON.parse(e.data);
-          if (msg.type === 'connection_established' && msg.token) {
-            onTokenChange(msg.token);
-            setStatus('connected');
-          }
-          if (msg.type === 'peer_disconnected') setStatus('idle');
-        } catch {}
-      };
-      ws.onerror = () => {
-        setStatus('error');
-        setError('WebSocket error');
-      };
+      setPhase('awaiting-phone');
+      openSocket(`&action=new_connection&code=${newCode}`);
     } catch (e) {
       setError((e as Error).message);
-      setStatus('error');
+      setPhase('error');
     }
   };
 
   const disconnect = () => {
     wsRef.current?.close();
     wsRef.current = null;
+    boundTokenRef.current = null;
+    setConnected(false);
     onTokenChange(null);
     setCode(null);
-    setStatus('idle');
+    setPhase('idle');
   };
 
   return (
@@ -103,8 +165,10 @@ export default function PhonePanel({
           <img src={iconSmartphone} alt="" />
         </span>
         <span className="acc-title">Phone</span>
-        {status === 'connected' && (
-          <span className="tag active" style={{ margin: 0 }}>Connected</span>
+        {paired && (
+          <span className={`tag ${connected ? 'active' : ''}`} style={{ margin: 0 }}>
+            {connected ? 'Connected' : 'Offline'}
+          </span>
         )}
         <span className="acc-chevron" aria-hidden="true">
           <img src={iconChevron} alt="" />
@@ -112,87 +176,91 @@ export default function PhonePanel({
       </summary>
 
       <div className="col acc-body" style={{ gap: 8 }}>
-        {status === 'idle' && (
+        {paired ? (
           <div className="phone-card">
             <span className="phone-card-ic">
               <img src={iconSmartphone} alt="" />
             </span>
             <div className="phone-card-main">
               <div className="phone-card-title">
-                <span className="status-dot" />
-                Not connected
+                <span className={`status-dot ${connected ? 'ok' : 'err'}`} />
+                {connected ? 'Connected' : 'Phone offline'}
               </div>
               <p className="phone-card-text">
-                Pair the Pulsar app to feel real haptics on your device while you preview a preset.
-              </p>
-              <button className="primary preset-action-btn" onClick={startPairing}>
-                <img src={iconQr} alt="" width={14} height={14} />
-                <span>Pair with phone</span>
-              </button>
-            </div>
-          </div>
-        )}
-
-        {status === 'requesting' && (
-          <div className="phone-card">
-            <span className="phone-card-ic">
-              <img src={iconSmartphone} alt="" />
-            </span>
-            <div className="phone-card-main">
-              <div className="phone-card-title">
-                <span className="status-dot" />
-                Requesting channel…
-              </div>
-            </div>
-          </div>
-        )}
-
-        {status === 'awaiting-phone' && (
-          <div className="phone-await">
-            {qrDataUrl && <img className="phone-qr" src={qrDataUrl} alt="Scan with Pulsar" />}
-            <div className="row" style={{ gap: 8 }}>
-              <span className="muted">Code</span>
-              <span className="mono" style={{ fontWeight: 700, letterSpacing: '0.08em' }}>{code}</span>
-            </div>
-            <p className="phone-card-text" style={{ marginBottom: 0 }}>
-              Open the Pulsar mobile app and scan the QR (or enter the code).
-            </p>
-            <button className="ghost" onClick={disconnect}>Cancel</button>
-          </div>
-        )}
-
-        {status === 'connected' && (
-          <div className="phone-card">
-            <span className="phone-card-ic">
-              <img src={iconSmartphone} alt="" />
-            </span>
-            <div className="phone-card-main">
-              <div className="phone-card-title">
-                <span className="status-dot ok" />
-                Connected
-              </div>
-              <p className="phone-card-text">
-                Your phone will play each preset as you preview it.
+                {connected
+                  ? 'Your phone will play each preset as you preview it.'
+                  : 'Paired, but your phone isn’t reachable. Open the Pulsar app to reconnect.'}
               </p>
               <button className="ghost" onClick={disconnect}>Disconnect</button>
             </div>
           </div>
-        )}
-
-        {status === 'error' && (
-          <div className="phone-card">
-            <span className="phone-card-ic">
-              <img src={iconSmartphone} alt="" />
-            </span>
-            <div className="phone-card-main">
-              <div className="phone-card-title">
-                <span className="status-dot err" />
-                Couldn’t connect
+        ) : (
+          <>
+            {phase === 'idle' && (
+              <div className="phone-card">
+                <span className="phone-card-ic">
+                  <img src={iconSmartphone} alt="" />
+                </span>
+                <div className="phone-card-main">
+                  <div className="phone-card-title">
+                    <span className="status-dot" />
+                    Not connected
+                  </div>
+                  <p className="phone-card-text">
+                    Pair the Pulsar app to feel real haptics on your device while you preview a preset.
+                  </p>
+                  <button className="primary preset-action-btn" onClick={startPairing}>
+                    <img src={iconQr} alt="" width={14} height={14} />
+                    <span>Pair with phone</span>
+                  </button>
+                </div>
               </div>
-              <p className="phone-card-text">{error ?? 'Unknown error.'}</p>
-              <button className="ghost" onClick={startPairing}>Retry</button>
-            </div>
-          </div>
+            )}
+
+            {phase === 'requesting' && (
+              <div className="phone-card">
+                <span className="phone-card-ic">
+                  <img src={iconSmartphone} alt="" />
+                </span>
+                <div className="phone-card-main">
+                  <div className="phone-card-title">
+                    <span className="status-dot" />
+                    Requesting channel…
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {phase === 'awaiting-phone' && (
+              <div className="phone-await">
+                {qrDataUrl && <img className="phone-qr" src={qrDataUrl} alt="Scan with Pulsar" />}
+                <div className="row" style={{ gap: 8 }}>
+                  <span className="muted">Code</span>
+                  <span className="mono" style={{ fontWeight: 700, letterSpacing: '0.08em' }}>{code}</span>
+                </div>
+                <p className="phone-card-text" style={{ marginBottom: 0 }}>
+                  Open the Pulsar mobile app and scan the QR (or enter the code).
+                </p>
+                <button className="ghost" onClick={disconnect}>Cancel</button>
+              </div>
+            )}
+
+            {phase === 'error' && (
+              <div className="phone-card">
+                <span className="phone-card-ic">
+                  <img src={iconSmartphone} alt="" />
+                </span>
+                <div className="phone-card-main">
+                  <div className="phone-card-title">
+                    <span className="status-dot err" />
+                    Couldn’t connect
+                  </div>
+                  <p className="phone-card-text">{error ?? 'Unknown error.'}</p>
+                  <button className="ghost" onClick={startPairing}>Retry</button>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </details>

--- a/figma/src/ui/styles/theme.css
+++ b/figma/src/ui/styles/theme.css
@@ -152,6 +152,25 @@ button.preview-sync-now:disabled {
   cursor: default;
 }
 
+/* Share-link visibility (public/private) toggle. A bordered card matching the
+   sync pill's palette, holding an icon + label/description and the switch. */
+.preview-visibility-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  background: var(--color-blue-10);
+  border: 1px solid var(--color-blue-20);
+}
+.preview-visibility-row.disabled {
+  opacity: 0.55;
+}
+.preview-visibility-row > input.switch {
+  flex-shrink: 0;
+  align-self: center;
+}
+
 /* QR display — mirrors the docs Connection.tsx widget.
    Outer card: white, blue-50 border, signature offset shadow (docs .content).
    Inner box: blue-10 fill, centred prompt + QR, close (×) button in the

--- a/figma/src/ui/styles/theme.css
+++ b/figma/src/ui/styles/theme.css
@@ -144,12 +144,22 @@ button.preview-tertiary {
 }
 button.preview-sync-now {
   flex-shrink: 0;
-  padding: 6px 12px;
-  font-size: var(--fs-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px;
 }
 button.preview-sync-now:disabled {
   opacity: 0.5;
   cursor: default;
+}
+/* Spin the refresh glyph while a sync is in flight, echoing the pill's pulse. */
+.preview-sync-spin {
+  animation: preview-sync-spin 0.9s linear infinite;
+}
+@keyframes preview-sync-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 /* Share-link visibility (public/private) toggle. A bordered card matching the


### PR DESCRIPTION
## What & why

In the Figma plugin's **Live preview** tab, sharing a design publishes it to the server and **anyone with the link can view it** — with no way to revoke access. This adds a per-file **public/private toggle** so a shared preview can be made private again without losing its share token.

- The switch is **on (public) by default**.
- Any explicit share action (**Open in browser / Copy link / Copy share token / QR**) re-opens a privated link and flips the switch back on — sharing the link necessarily makes it viewable.
- Visibility is stored server-side (the source of truth) and respected on every read.

## Behaviour

| State | Switch | Link works? |
|-------|--------|-------------|
| Public (default / after sharing) | on | yes |
| Private (user turned it off) | off | no — `GET` returns `403`, preview shows "This preview is private" |
| Not shared yet | disabled | n/a |

## Server (`docs/server`)

- `figma_projects` gains an **`is_public`** column — `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, defaulting `TRUE` so already-deployed rows stay viewable on migration.
- `GET /figma-project/:token` → **403 `{ error: 'private' }`** when revoked (the config is never served to a token holder); adds `isPublic: true` on public reads.
- New **`PATCH /figma-project/:token/visibility { isPublic }`** flips the flag. It touches `updated_at` (keeps the TTL fresh) but **leaves `revision` alone**, so a toggle can't provoke an optimistic-concurrency conflict on the owner's next config `PUT`.
- **`PUT` (config sync) never changes visibility** — only an explicit share or `PATCH` re-opens a link, so a background autosync of a private file can't silently re-expose it.
- CORS now allows `PATCH`. New unit tests (`figma-projects.test.ts`) + HTTP route tests (`routes.test.ts`).

## Plugin (`figma`)

- **Live preview tab**: a public/private switch (globe / lock icon) with contextual copy; disabled until the file has been shared at least once. The toggle is optimistic with rollback + a notification if the server rejects it.
- Visibility is cached per-file in `clientStorage` (`ProjectCache.isPublic`, default true) to seed the switch on cold start, then reconciled against the server. A **private link keeps its token**, so re-sharing re-opens it.

## Preview app (`figma/preview`)

- `403` maps to a dedicated **"This preview is private"** empty state, distinct from the `404` "no design loaded" state. The fetch result is now a discriminated union (`ok` / `private` / `no-token` / `missing`).

## Verification

- Server: full suite green — **71 tests pass** (new visibility unit + route tests included).
- Typecheck + production build pass for the plugin, the preview app, and the server.
- Plugin UI rendered from the built `dist/ui.html` and exercised across all three states (public / private / not-yet-shared) — switch state, icon, copy, and enabled/disabled all correct; no console errors.

<details>
<summary>Live preview tab — public vs private</summary>

Public: globe icon, switch on, "Anyone with the link can view".
Private: lock icon, switch off, "Link is private — the share link won't work until you share the preview again".
</details>

## Note on scope

This branch also bundles a small, **pre-existing in-progress** change that was already in the working tree: phone-connection live-link state (`PhonePanel.tsx` rewrite + `phoneConnected` gating in `App.tsx`). It is unrelated to the privacy feature but included here per the author's request rather than left dangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)