### PR TITLE
fix(figma): restore in-app haptics + full-screen toggle in srcdoc embed

### DIFF
--- a/figma/preview/src/App.tsx
+++ b/figma/preview/src/App.tsx
@@ -5,6 +5,7 @@ import { normalizeId } from './lib/ids';
 import { useFigmaMessages } from './lib/useFigmaMessages';
 import { useFullscreen } from './lib/useFullscreen';
 import { useIsMobile } from './lib/useIsMobile';
+import { getHostBridge, isAppHost as detectAppHost } from './lib/hostBridge';
 import { playPreset, stopAll } from './audio/player';
 import { Header } from './components/Header';
 import { PrototypeView } from './components/PrototypeView';
@@ -130,7 +131,7 @@ export default function App() {
   }, []);
 
   // When the preview is loaded inside the PulsarApp WebView the
-  // `window.ReactNativeWebView` global is injected by react-native-webview.
+  // `window.ReactNativeWebView` bridge is injected by react-native-webview.
   // That single check is authoritative: if it's present we postMessage the
   // preset payload to the native host (which plays the real device haptic via
   // react-native-pulsar); if it isn't, we fall back to the in-page audio
@@ -140,10 +141,11 @@ export default function App() {
   // `?host=app` URL param, but that's redundant with the bridge check and
   // broke whenever someone hardcoded the preview URL in PulsarApp for local
   // dev.)
-  const isAppHost = useMemo(
-    () => typeof (window as any).ReactNativeWebView !== 'undefined',
-    []
-  );
+  //
+  // The bridge may live on `window` (preview served directly) or on
+  // `window.parent` (the docs /figma-preview page embeds us in an <iframe
+  // srcdoc>); getHostBridge/detectAppHost resolve either — see lib/hostBridge.
+  const isAppHost = useMemo(() => detectAppHost(), []);
 
   // When running inside the PulsarApp WebView the preview already fills the
   // WebView (mobile → implicit fullscreen), but the app's bottom tab bar still
@@ -154,7 +156,7 @@ export default function App() {
     setNavBarHidden((prev) => {
       const next = !prev;
       try {
-        (window as any).ReactNativeWebView?.postMessage(
+        getHostBridge()?.postMessage(
           JSON.stringify({ type: 'set-tab-bar-hidden', hidden: next })
         );
       } catch {
@@ -170,7 +172,9 @@ export default function App() {
       if (!data) return;
       if (isAppHost) {
         try {
-          (window as any).ReactNativeWebView.postMessage(
+          const bridge = getHostBridge();
+          if (!bridge) throw new Error('host bridge unavailable');
+          bridge.postMessage(
             JSON.stringify({
               type: 'play-preset',
               presetName: data.name,

--- a/figma/preview/src/lib/hostBridge.ts
+++ b/figma/preview/src/lib/hostBridge.ts
@@ -1,0 +1,38 @@
+// Bridge to the native PulsarApp host (react-native-webview).
+//
+// react-native-webview injects `window.ReactNativeWebView` into the *top-level*
+// WebView document only. The docs `/figma-preview` page embeds this app inside
+// an `<iframe srcdoc>` (see docs/src/components/preview/Preview.astro), so when
+// running there the bridge lives on `window.parent`, not `window`. A srcdoc
+// iframe inherits its parent's origin, so reaching up one level is same-origin
+// and allowed — this mirrors how `getTokenFromUrl` (lib/payload.ts) forwards
+// the parent's query string into the embed.
+
+interface ReactNativeWebView {
+  postMessage(message: string): void;
+}
+
+// Resolve the native bridge from this window or the parent (srcdoc embed),
+// returning undefined when neither is reachable (plain web, cross-origin parent).
+export function getHostBridge(): ReactNativeWebView | undefined {
+  const own = (window as any).ReactNativeWebView as ReactNativeWebView | undefined;
+  if (own) return own;
+  try {
+    if (window.parent !== window) {
+      const parentBridge = (window.parent as any).ReactNativeWebView as
+        | ReactNativeWebView
+        | undefined;
+      if (parentBridge) return parentBridge;
+    }
+  } catch {
+    // Cross-origin parent — no reachable bridge.
+  }
+  return undefined;
+}
+
+// True when running inside the PulsarApp WebView (directly or via the srcdoc
+// embed). Authoritative signal for routing taps to native haptics and showing
+// the in-app-only nav-bar toggle.
+export function isAppHost(): boolean {
+  return getHostBridge() !== undefined;
+}


### PR DESCRIPTION
## Problem

In **PulsarApp**, opening **Figma Live Preview** no longer fires device haptics on tap, and the in-app full-screen (nav-bar) toggle button is missing. Both worked when first implemented.

## Root cause

The preview app gates two app-only features on `isAppHost`:

- bridged **haptics** — `play()` posts `play-preset` to `window.ReactNativeWebView` so the native host plays the real device haptic; otherwise it falls back to the silent in-page audio generator.
- the **`nav-toggle`** button — only rendered when `isAppHost` is true.

`isAppHost` checked `typeof window.ReactNativeWebView !== 'undefined'`. Since [#60](https://github.com/software-mansion/pulsar/pull/60) the docs `/figma-preview` page embeds the app inside an **`<iframe srcdoc>`** (`docs/src/components/preview/Preview.astro`). react-native-webview injects its bridge **only into the top-level WebView document**, never the iframe — so inside PulsarApp `isAppHost` was always `false`. Taps produced no device haptic (silent audio fallback) and the toggle button never rendered. That single false flag explains both symptoms.

## Fix

A srcdoc iframe inherits its parent's origin, so reaching up one level is same-origin — the same trick `getTokenFromUrl` already uses to forward the parent's `?token=`. New `figma/preview/src/lib/hostBridge.ts` resolves the bridge from `window` **or** `window.parent`; `App.tsx` routes `isAppHost` detection and both `postMessage` calls through it.

No native (`PulsarApp`) changes needed — the fix is entirely in the preview app, and the docs build rebuilds the embed from this source on every deploy.

## Verification

- `tsc --noEmit` and `build:embed` both pass.
- In-browser srcdoc harness exercising the exact mechanism:
  - iframe's own `ReactNativeWebView` → `undefined` (reproduces the bug)
  - helper detects the parent-injected bridge → `isAppHost` true
  - a `postMessage` from the iframe reaches the bridge → haptics path restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)