### PR TITLE
ci(docs): redeploy docs when figma/preview or web/Pulsar change

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,10 +6,6 @@ on:
       - main
     paths:
       - 'docs/**'
-      # The docs build embeds the standalone figma/preview app (built from these
-      # sources by the prebuild step), and that app depends on web/Pulsar's
-      # pulsar-haptics build. Changes here must redeploy the docs, otherwise the
-      # embed silently keeps serving stale code.
       - 'figma/preview/**'
       - 'web/Pulsar/**'
       - '.github/workflows/deploy-docs.yml'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - 'docs/**'
+      # The docs build embeds the standalone figma/preview app (built from these
+      # sources by the prebuild step), and that app depends on web/Pulsar's
+      # pulsar-haptics build. Changes here must redeploy the docs, otherwise the
+      # embed silently keeps serving stale code.
+      - 'figma/preview/**'
+      - 'web/Pulsar/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

The **Deploy Docs** workflow only triggers on pushes touching `docs/**`:

```yaml
on:
  push:
    branches: [main]
    paths:
      - 'docs/**'
```

But the docs build's `prebuild` step (`docs/scripts/build-figma-preview.mjs`) bundles the standalone **`figma/preview`** app into the `<iframe srcdoc>` embed, and that app depends on **`web/Pulsar`**'s `pulsar-haptics` build. So a change to the embed source that doesn't also touch `docs/**` merges to `main` **without ever redeploying the docs** — the live site keeps serving a stale embed.

This just bit us: [#70](https://github.com/software-mansion/pulsar/pull/70) (the figma-preview host-bridge fix) changed only `figma/preview/src/**`, merged cleanly, but never triggered a docs deploy, so production kept serving the old, broken embed.

## Fix

Add the embed-source paths (and the workflow file itself) to the `push.paths` filter so embed-affecting changes auto-deploy:

```yaml
    paths:
      - 'docs/**'
      - 'figma/preview/**'
      - 'web/Pulsar/**'
      - '.github/workflows/deploy-docs.yml'
```

`workflow_dispatch` remains for manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)