### PR TITLE
fix(figma): make preview share token read-only; keep a private edit token

### DIFF
--- a/docs/server/src/figma-projects.ts
+++ b/docs/server/src/figma-projects.ts
@@ -43,11 +43,12 @@ export async function __closePoolForTests(): Promise<void> {
 }
 
 // Create the table once at startup (see server.ts). ADD COLUMN IF NOT EXISTS
-// lets older deployments pick up `revision` without a manual migration.
+// lets older deployments pick up new columns without a manual migration.
 export async function ensureFigmaProjectsTable(): Promise<void> {
   await getPool().query(
     `CREATE TABLE IF NOT EXISTS figma_projects (
       token TEXT PRIMARY KEY,
+      public_token TEXT,
       config TEXT NOT NULL,
       revision BIGINT NOT NULL DEFAULT 0,
       is_public BOOLEAN NOT NULL DEFAULT TRUE,
@@ -64,6 +65,23 @@ export async function ensureFigmaProjectsTable(): Promise<void> {
   await getPool().query(
     'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT TRUE',
   );
+  // Read-only share token, distinct from the secret edit `token`. Backfill
+  // pre-split rows to `token` so links already in the wild keep resolving.
+  await getPool().query(
+    'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS public_token TEXT',
+  );
+  await getPool().query(
+    'UPDATE figma_projects SET public_token = token WHERE public_token IS NULL',
+  );
+  // Index for the public read lookup. Swallow failures — pg-mem (tests) lacks
+  // CREATE INDEX IF NOT EXISTS, and it's an optimisation, not a correctness need.
+  try {
+    await getPool().query(
+      'CREATE INDEX IF NOT EXISTS figma_projects_public_token_idx ON figma_projects (public_token)',
+    );
+  } catch (err) {
+    console.warn('skipping public_token index creation:', err);
+  }
 }
 
 function generateToken(): string {
@@ -110,10 +128,11 @@ function schedulePurge(): void {
 export interface FigmaProjectSnapshot {
   config: string;
   revision: number;
-  // When false the share link is revoked: GET refuses to serve the config so
-  // anyone holding the token can no longer view the preview. Owners flip this
-  // from the plugin; sharing again re-publishes (sets it back to true).
+  // When false the share link is revoked: the public read route refuses to
+  // serve the config. The owner read (by edit token) ignores this flag.
   isPublic: boolean;
+  // Read-only share token, returned to the owner to build share links/QRs.
+  publicToken: string;
 }
 
 // Result of toggling a project's visibility. `not_found` mirrors update's shape
@@ -130,14 +149,15 @@ export type FigmaProjectUpdateResult =
 
 export async function createFigmaProject(
   config: string,
-): Promise<{ token: string; revision: number }> {
+): Promise<{ token: string; publicToken: string; revision: number }> {
   const token = generateToken();
+  const publicToken = generateToken();
   const result = await getPool().query<{ revision: string }>(
-    'INSERT INTO figma_projects (token, config, revision) VALUES ($1, $2, 0) RETURNING revision',
-    [token, config],
+    'INSERT INTO figma_projects (token, public_token, config, revision) VALUES ($1, $2, $3, 0) RETURNING revision',
+    [token, publicToken, config],
   );
   schedulePurge();
-  return { token, revision: Number(result.rows[0]?.revision ?? 0) };
+  return { token, publicToken, revision: Number(result.rows[0]?.revision ?? 0) };
 }
 
 // Bump a project's config + revision. When `baseRevision` is given the update
@@ -186,12 +206,47 @@ export async function setFigmaProjectVisibility(
   return { kind: 'ok', isPublic: result.rows[0].is_public };
 }
 
+// Look up a project by its secret edit token (owner operations + owner read).
 export async function getFigmaProject(token: string): Promise<FigmaProjectSnapshot | null> {
-  const result = await getPool().query<{ config: string; revision: string; is_public: boolean }>(
-    'SELECT config, revision, is_public FROM figma_projects WHERE token = $1',
+  const result = await getPool().query<{
+    config: string;
+    revision: string;
+    is_public: boolean;
+    public_token: string;
+  }>(
+    'SELECT config, revision, is_public, public_token FROM figma_projects WHERE token = $1',
     [token],
   );
   const row = result.rows[0];
   if (!row) return null;
-  return { config: row.config, revision: Number(row.revision), isPublic: row.is_public };
+  return {
+    config: row.config,
+    revision: Number(row.revision),
+    isPublic: row.is_public,
+    publicToken: row.public_token,
+  };
+}
+
+// Look up a project by its read-only public token (the share path; the route
+// layer enforces is_public on top of this).
+export async function getFigmaProjectByPublicToken(
+  publicToken: string,
+): Promise<FigmaProjectSnapshot | null> {
+  const result = await getPool().query<{
+    config: string;
+    revision: string;
+    is_public: boolean;
+    public_token: string;
+  }>(
+    'SELECT config, revision, is_public, public_token FROM figma_projects WHERE public_token = $1',
+    [publicToken],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  return {
+    config: row.config,
+    revision: Number(row.revision),
+    isPublic: row.is_public,
+    publicToken: row.public_token,
+  };
 }

--- a/docs/server/src/routes.ts
+++ b/docs/server/src/routes.ts
@@ -3,6 +3,7 @@ import { ConnectionManager } from './connection-manager';
 import {
   createFigmaProject,
   getFigmaProject,
+  getFigmaProjectByPublicToken,
   setFigmaProjectVisibility,
   updateFigmaProject,
 } from './figma-projects';
@@ -57,7 +58,8 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
     });
   });
 
-  // Create a project row; returns its token + revision.
+  // Create a project row. Returns the secret edit `token` plus a read-only
+  // `publicToken` for share links.
   router.post(
     '/figma-project',
     async (req: Request<{}, {}, FigmaProjectBody>, res: Response) => {
@@ -67,8 +69,8 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
       }
       const serialized = typeof config === 'string' ? config : JSON.stringify(config);
       try {
-        const { token, revision } = await createFigmaProject(serialized);
-        res.json({ success: true, token, revision });
+        const { token, publicToken, revision } = await createFigmaProject(serialized);
+        res.json({ success: true, token, publicToken, revision });
       } catch (err) {
         console.error('createFigmaProject failed:', err);
         res.status(500).json({ success: false, error: 'Failed to create figma project' });
@@ -154,7 +156,38 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
     },
   );
 
-  // Fetch a project's config + revision by token.
+  // Public, read-only share route (the preview app + PulsarApp WebView read
+  // here). Registered before `/:token` so the `public` segment isn't captured as
+  // a token param. Never writes; honours visibility (403 when revoked).
+  router.get(
+    '/figma-project/public/:publicToken',
+    async (req: Request<{ publicToken: string }>, res: Response) => {
+      const { publicToken } = req.params;
+      try {
+        const snapshot = await getFigmaProjectByPublicToken(publicToken);
+        if (snapshot === null) {
+          return res.status(404).json({ success: false, error: 'Project not found' });
+        }
+        // Revoked link: 403 (distinct from 404) so the preview can tailor its message.
+        if (!snapshot.isPublic) {
+          return res.status(403).json({ success: false, error: 'private' });
+        }
+        let parsed: unknown = snapshot.config;
+        try {
+          parsed = JSON.parse(snapshot.config);
+        } catch {
+          // not JSON — return the raw string
+        }
+        res.json({ success: true, config: parsed, revision: snapshot.revision, isPublic: true });
+      } catch (err) {
+        console.error('getFigmaProject (public) failed:', err);
+        res.status(500).json({ success: false, error: 'Failed to fetch figma project' });
+      }
+    },
+  );
+
+  // Owner read by the secret edit token (plugin cold-start reconcile). Returns
+  // the config regardless of visibility and hands back the publicToken.
   router.get('/figma-project/:token', async (req: Request<{ token: string }>, res: Response) => {
     const { token } = req.params;
     try {
@@ -162,19 +195,19 @@ export function getRoutes(connectionManager: ConnectionManager): Router {
       if (snapshot === null) {
         return res.status(404).json({ success: false, error: 'Project not found' });
       }
-      // Private link: the row exists but the owner revoked access. Refuse to
-      // serve the config to anyone holding the token (403, distinct from the
-      // 404 "no such project" so the preview can show a tailored message).
-      if (!snapshot.isPublic) {
-        return res.status(403).json({ success: false, error: 'private' });
-      }
       let parsed: unknown = snapshot.config;
       try {
         parsed = JSON.parse(snapshot.config);
       } catch {
         // not JSON — return the raw string
       }
-      res.json({ success: true, config: parsed, revision: snapshot.revision, isPublic: true });
+      res.json({
+        success: true,
+        config: parsed,
+        revision: snapshot.revision,
+        isPublic: snapshot.isPublic,
+        publicToken: snapshot.publicToken,
+      });
     } catch (err) {
       console.error('getFigmaProject failed:', err);
       res.status(500).json({ success: false, error: 'Failed to fetch figma project' });

--- a/docs/server/src/server.ts
+++ b/docs/server/src/server.ts
@@ -23,9 +23,11 @@ function start() {
   console.log('\n📍 HTTP endpoints:');
   console.log(`   GET  http://localhost:${PORT}/create-channel`);
   console.log(`   POST http://localhost:${PORT}/broadcast`);
-  console.log(`   POST http://localhost:${PORT}/figma-project`);
-  console.log(`   PUT  http://localhost:${PORT}/figma-project/:token`);
-  console.log(`   GET  http://localhost:${PORT}/figma-project/:token`);
+  console.log(`   POST  http://localhost:${PORT}/figma-project`);
+  console.log(`   PUT   http://localhost:${PORT}/figma-project/:token            (owner edit token)`);
+  console.log(`   PATCH http://localhost:${PORT}/figma-project/:token/visibility (owner edit token)`);
+  console.log(`   GET   http://localhost:${PORT}/figma-project/:token            (owner edit token)`);
+  console.log(`   GET   http://localhost:${PORT}/figma-project/public/:token     (read-only share)`);
   console.log('\n🔌 WebSocket (pairing):');
   console.log(`   ws://localhost:${PORT}/?type=sender|receiver&action=new_connection&code=<code>`);
   console.log(`   ws://localhost:${PORT}/?type=sender|receiver&action=reuse_connection&token=<token>`);

--- a/docs/server/tests/figma-projects.test.ts
+++ b/docs/server/tests/figma-projects.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import {
   createFigmaProject,
   getFigmaProject,
+  getFigmaProjectByPublicToken,
   updateFigmaProject,
   setFigmaProjectVisibility,
   purgeExpiredFigmaProjects,
-  ensureFigmaProjectsTable,
 } from '../src/figma-projects';
 import { useInMemoryFigmaDb, closeInMemoryFigmaDb, InMemoryFigmaDb } from './helpers/figmaDb';
 
@@ -24,8 +24,13 @@ describe('figma-projects (in-memory pg)', () => {
     it('creates a usable schema (proven by the suite running against it)', async () => {
       // beforeEach already ran ensureFigmaProjectsTable; a basic round-trip
       // confirms the table + columns exist.
-      const { token } = await createFigmaProject('{}');
-      expect(await getFigmaProject(token)).toEqual({ config: '{}', revision: 0, isPublic: true });
+      const { token, publicToken } = await createFigmaProject('{}');
+      expect(await getFigmaProject(token)).toEqual({
+        config: '{}',
+        revision: 0,
+        isPublic: true,
+        publicToken,
+      });
     });
 
     it('migration (ADD COLUMN IF NOT EXISTS) is safe to re-run', async () => {
@@ -35,21 +40,75 @@ describe('figma-projects (in-memory pg)', () => {
       // CREATE TABLE IF NOT EXISTS over NOW() defaults, but real Postgres can.)
       await expect(
         mem.query(
-          'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS revision BIGINT NOT NULL DEFAULT 0',
+          'ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS public_token TEXT',
         ),
       ).resolves.toBeDefined();
+    });
+
+    it('backfills public_token = token for pre-split (legacy) rows', async () => {
+      // Simulate a row created before public_token existed: drop the column and
+      // insert a row that only has the (then-dual-purpose) `token`.
+      await mem.query('ALTER TABLE figma_projects DROP COLUMN public_token');
+      await mem.query(
+        "INSERT INTO figma_projects (token, config, revision, is_public) VALUES ('legacy-tok', '{\"v\":1}', 0, TRUE)",
+      );
+
+      // Re-apply the additive migration statements directly. (We can't call the
+      // whole ensureFigmaProjectsTable again — pg-mem can't model its leading
+      // CREATE TABLE IF NOT EXISTS over NOW() defaults a second time — so we
+      // exercise the exact ADD COLUMN + backfill SQL it runs.)
+      await mem.query('ALTER TABLE figma_projects ADD COLUMN IF NOT EXISTS public_token TEXT');
+      await mem.query('UPDATE figma_projects SET public_token = token WHERE public_token IS NULL');
+
+      const ownerSnap = await getFigmaProject('legacy-tok');
+      expect(ownerSnap).toEqual({
+        config: '{"v":1}',
+        revision: 0,
+        isPublic: true,
+        publicToken: 'legacy-tok',
+      });
+      // The legacy token now works on the read path too (public_token = token),
+      // so already-distributed share links keep resolving.
+      const publicSnap = await getFigmaProjectByPublicToken('legacy-tok');
+      expect(publicSnap).toEqual({
+        config: '{"v":1}',
+        revision: 0,
+        isPublic: true,
+        publicToken: 'legacy-tok',
+      });
+    });
+
+    it('backfill does not clobber rows that already have a public_token', async () => {
+      // A row created post-split has a distinct public_token; the backfill
+      // UPDATE (… WHERE public_token IS NULL) must leave it untouched.
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
+      expect(publicToken).not.toBe(token);
+
+      await mem.query('UPDATE figma_projects SET public_token = token WHERE public_token IS NULL');
+
+      const snap = await getFigmaProject(token);
+      expect(snap!.publicToken).toBe(publicToken);
     });
   });
 
   describe('createFigmaProject', () => {
-    it('inserts a row and returns a token with revision 0', async () => {
-      const { token, revision } = await createFigmaProject('{"hello":"world"}');
+    it('inserts a row and returns distinct edit + public tokens with revision 0', async () => {
+      const { token, publicToken, revision } = await createFigmaProject('{"hello":"world"}');
       expect(typeof token).toBe('string');
       expect(token.length).toBeGreaterThan(0);
+      expect(typeof publicToken).toBe('string');
+      expect(publicToken.length).toBeGreaterThan(0);
+      // The whole point: the read-only share token is NOT the secret edit token.
+      expect(publicToken).not.toBe(token);
       expect(revision).toBe(0);
 
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"hello":"world"}', revision: 0, isPublic: true });
+      expect(snap).toEqual({
+        config: '{"hello":"world"}',
+        revision: 0,
+        isPublic: true,
+        publicToken,
+      });
     });
 
     it('returns revision as a JS number, not a bigint string', async () => {
@@ -59,24 +118,60 @@ describe('figma-projects (in-memory pg)', () => {
     });
   });
 
-  describe('getFigmaProject', () => {
+  describe('getFigmaProject (by edit token)', () => {
     it('returns null for an unknown token', async () => {
       expect(await getFigmaProject('nope')).toBeNull();
+    });
+
+    it('does NOT resolve when given the public token (edit token only)', async () => {
+      const { publicToken } = await createFigmaProject('{}');
+      expect(await getFigmaProject(publicToken)).toBeNull();
+    });
+  });
+
+  describe('getFigmaProjectByPublicToken (read path)', () => {
+    it('resolves a project by its public token', async () => {
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
+      expect(await getFigmaProjectByPublicToken(publicToken)).toEqual({
+        config: '{"v":1}',
+        revision: 0,
+        isPublic: true,
+        publicToken,
+      });
+      // And it must NOT resolve when given the secret edit token.
+      expect(await getFigmaProjectByPublicToken(token)).toBeNull();
+    });
+
+    it('returns null for an unknown public token', async () => {
+      expect(await getFigmaProjectByPublicToken('nope')).toBeNull();
+    });
+
+    it('still returns the row when private (route layer enforces visibility)', async () => {
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
+      await setFigmaProjectVisibility(token, false);
+      const snap = await getFigmaProjectByPublicToken(publicToken);
+      expect(snap).toEqual({ config: '{"v":1}', revision: 0, isPublic: false, publicToken });
     });
   });
 
   describe('updateFigmaProject — unconditional', () => {
     it('bumps revision and replaces config', async () => {
-      const { token } = await createFigmaProject('{"v":1}');
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
       const res = await updateFigmaProject(token, '{"v":2}');
       expect(res).toEqual({ kind: 'ok', revision: 1 });
 
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
+      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true, publicToken });
     });
 
     it('returns not_found for a missing token', async () => {
       const res = await updateFigmaProject('ghost', '{}');
+      expect(res).toEqual({ kind: 'not_found' });
+    });
+
+    it('returns not_found when given the public token (writes need the edit token)', async () => {
+      const { publicToken } = await createFigmaProject('{"v":1}');
+      const res = await updateFigmaProject(publicToken, '{"v":2}');
       expect(res).toEqual({ kind: 'not_found' });
     });
   });
@@ -89,19 +184,19 @@ describe('figma-projects (in-memory pg)', () => {
     });
 
     it('reports conflict with the current snapshot when baseRevision is stale', async () => {
-      const { token } = await createFigmaProject('{"v":1}');
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
       // Move the server to revision 1.
       await updateFigmaProject(token, '{"v":2}');
       // Now push against the stale base 0.
       const res = await updateFigmaProject(token, '{"v":3}', 0);
       expect(res).toEqual({
         kind: 'conflict',
-        current: { config: '{"v":2}', revision: 1, isPublic: true },
+        current: { config: '{"v":2}', revision: 1, isPublic: true, publicToken },
       });
 
       // The conflicting write must NOT have been applied.
       const snap = await getFigmaProject(token);
-      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
+      expect(snap).toEqual({ config: '{"v":2}', revision: 1, isPublic: true, publicToken });
     });
 
     it('returns not_found when the token no longer exists', async () => {
@@ -118,19 +213,19 @@ describe('figma-projects (in-memory pg)', () => {
     });
 
     it('flips a project to private and back without touching the revision', async () => {
-      const { token } = await createFigmaProject('{"v":1}');
+      const { token, publicToken } = await createFigmaProject('{"v":1}');
       // Move the revision off 0 so we can prove a visibility toggle leaves it.
       await updateFigmaProject(token, '{"v":2}');
 
       const off = await setFigmaProjectVisibility(token, false);
       expect(off).toEqual({ kind: 'ok', isPublic: false });
       const priv = await getFigmaProject(token);
-      expect(priv).toEqual({ config: '{"v":2}', revision: 1, isPublic: false });
+      expect(priv).toEqual({ config: '{"v":2}', revision: 1, isPublic: false, publicToken });
 
       const on = await setFigmaProjectVisibility(token, true);
       expect(on).toEqual({ kind: 'ok', isPublic: true });
       const pub = await getFigmaProject(token);
-      expect(pub).toEqual({ config: '{"v":2}', revision: 1, isPublic: true });
+      expect(pub).toEqual({ config: '{"v":2}', revision: 1, isPublic: true, publicToken });
     });
 
     it('returns not_found for a missing token', async () => {

--- a/docs/server/tests/routes.test.ts
+++ b/docs/server/tests/routes.test.ts
@@ -49,38 +49,81 @@ describe('HTTP routes', () => {
       expect(res.body).toEqual({ success: false, error: 'config is required' });
     });
 
-    it('creates a project and returns token + revision 0', async () => {
+    it('creates a project and returns distinct edit + public tokens, revision 0', async () => {
       const res = await request(app)
         .post('/figma-project')
         .send({ config: { hello: 'world' } });
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(typeof res.body.token).toBe('string');
+      expect(typeof res.body.publicToken).toBe('string');
+      // The share token must never equal the secret edit token.
+      expect(res.body.publicToken).not.toBe(res.body.token);
       expect(res.body.revision).toBe(0);
     });
 
-    it('round-trips an object config back through GET (parsed)', async () => {
+    it('round-trips an object config through the public read route (parsed)', async () => {
       const config = { a: 1, nested: { b: [2, 3] } };
       const created = await request(app).post('/figma-project').send({ config });
-      const token = created.body.token;
+      const publicToken = created.body.publicToken;
 
-      const got = await request(app).get(`/figma-project/${token}`);
+      const got = await request(app).get(`/figma-project/public/${publicToken}`);
       expect(got.status).toBe(200);
       expect(got.body).toEqual({ success: true, config, revision: 0, isPublic: true });
     });
 
-    it('stores a non-JSON string config and returns it raw on GET', async () => {
+    it('stores a non-JSON string config and returns it raw on the public read', async () => {
       const created = await request(app).post('/figma-project').send({ config: 'plain text' });
-      const got = await request(app).get(`/figma-project/${created.body.token}`);
+      const got = await request(app).get(`/figma-project/public/${created.body.publicToken}`);
       expect(got.body.config).toBe('plain text');
     });
   });
 
-  describe('GET /figma-project/:token', () => {
+  describe('GET /figma-project/public/:publicToken (read-only share)', () => {
+    it('returns 404 for an unknown public token', async () => {
+      const res = await request(app).get('/figma-project/public/does-not-exist');
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ success: false, error: 'Project not found' });
+    });
+
+    it('does NOT resolve when given the secret edit token', async () => {
+      const created = await request(app).post('/figma-project').send({ config: { v: 1 } });
+      // Hitting the public route with the *edit* token must look like nothing.
+      const res = await request(app).get(`/figma-project/public/${created.body.token}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /figma-project/:token (owner read by edit token)', () => {
     it('returns 404 for an unknown token', async () => {
       const res = await request(app).get('/figma-project/does-not-exist');
       expect(res.status).toBe(404);
       expect(res.body).toEqual({ success: false, error: 'Project not found' });
+    });
+
+    it('returns the config + publicToken for the owner', async () => {
+      const created = await request(app).post('/figma-project').send({ config: { v: 1 } });
+      const got = await request(app).get(`/figma-project/${created.body.token}`);
+      expect(got.status).toBe(200);
+      expect(got.body).toEqual({
+        success: true,
+        config: { v: 1 },
+        revision: 0,
+        isPublic: true,
+        publicToken: created.body.publicToken,
+      });
+    });
+
+    it('still serves the owner their config when the link is private', async () => {
+      const created = await request(app).post('/figma-project').send({ config: { v: 1 } });
+      const token = created.body.token;
+      await request(app).patch(`/figma-project/${token}/visibility`).send({ isPublic: false });
+
+      // Owner read ignores visibility (no 403 here — that's the public route).
+      const got = await request(app).get(`/figma-project/${token}`);
+      expect(got.status).toBe(200);
+      expect(got.body.isPublic).toBe(false);
+      expect(got.body.config).toEqual({ v: 1 });
     });
   });
 
@@ -95,6 +138,22 @@ describe('HTTP routes', () => {
       const res = await request(app).put(`/figma-project/${token}`).send({ config: { v: 2 } });
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true, revision: 1 });
+    });
+
+    it('a share-token holder CANNOT write (PUT with the public token → 404)', async () => {
+      // The core of the fix: handing out the public token must not grant edits.
+      const created = await request(app).post('/figma-project').send({ config: { v: 1 } });
+      const { token, publicToken } = created.body;
+
+      const res = await request(app)
+        .put(`/figma-project/${publicToken}`)
+        .send({ config: { v: 999 } });
+      expect(res.status).toBe(404);
+
+      // And the project is untouched — still at v:1, revision 0.
+      const got = await request(app).get(`/figma-project/${token}`);
+      expect(got.body.config).toEqual({ v: 1 });
+      expect(got.body.revision).toBe(0);
     });
 
     it('conditional update succeeds when baseRevision matches', async () => {
@@ -159,13 +218,15 @@ describe('HTTP routes', () => {
   });
 
   describe('PATCH /figma-project/:token/visibility', () => {
+    // Returns both tokens: the edit token (for the PATCH/PUT writes) and the
+    // public token (to verify the read-only share route).
     async function create(config: unknown) {
       const res = await request(app).post('/figma-project').send({ config });
-      return res.body.token as string;
+      return { token: res.body.token as string, publicToken: res.body.publicToken as string };
     }
 
-    it('makes a project private, then GET returns 403 instead of the config', async () => {
-      const token = await create({ v: 1 });
+    it('makes a project private, then the public read returns 403', async () => {
+      const { token, publicToken } = await create({ v: 1 });
 
       const patched = await request(app)
         .patch(`/figma-project/${token}/visibility`)
@@ -173,13 +234,27 @@ describe('HTTP routes', () => {
       expect(patched.status).toBe(200);
       expect(patched.body).toEqual({ success: true, isPublic: false });
 
-      const got = await request(app).get(`/figma-project/${token}`);
+      const got = await request(app).get(`/figma-project/public/${publicToken}`);
       expect(got.status).toBe(403);
       expect(got.body).toEqual({ success: false, error: 'private' });
     });
 
-    it('re-publishing a private project restores GET access', async () => {
-      const token = await create({ v: 1 });
+    it('a share-token holder CANNOT change visibility (PATCH with public token → 404)', async () => {
+      const { token, publicToken } = await create({ v: 1 });
+
+      // A viewer tries to revoke the link using the only token they have.
+      const res = await request(app)
+        .patch(`/figma-project/${publicToken}/visibility`)
+        .send({ isPublic: false });
+      expect(res.status).toBe(404);
+
+      // Visibility is unchanged — the public read still works.
+      const got = await request(app).get(`/figma-project/public/${publicToken}`);
+      expect(got.status).toBe(200);
+    });
+
+    it('re-publishing a private project restores public read access', async () => {
+      const { token, publicToken } = await create({ v: 1 });
       await request(app).patch(`/figma-project/${token}/visibility`).send({ isPublic: false });
 
       const patched = await request(app)
@@ -187,24 +262,24 @@ describe('HTTP routes', () => {
         .send({ isPublic: true });
       expect(patched.body).toEqual({ success: true, isPublic: true });
 
-      const got = await request(app).get(`/figma-project/${token}`);
+      const got = await request(app).get(`/figma-project/public/${publicToken}`);
       expect(got.status).toBe(200);
       expect(got.body).toEqual({ success: true, config: { v: 1 }, revision: 0, isPublic: true });
     });
 
     it('owners can still PUT config to a private project (sync keeps working)', async () => {
-      const token = await create({ v: 1 });
+      const { token, publicToken } = await create({ v: 1 });
       await request(app).patch(`/figma-project/${token}/visibility`).send({ isPublic: false });
 
       const put = await request(app).put(`/figma-project/${token}`).send({ config: { v: 2 } });
       expect(put.status).toBe(200);
       // Still private after a config sync — only the explicit PATCH re-exposes it.
-      const got = await request(app).get(`/figma-project/${token}`);
+      const got = await request(app).get(`/figma-project/public/${publicToken}`);
       expect(got.status).toBe(403);
     });
 
     it('returns 400 when isPublic is missing or not a boolean', async () => {
-      const token = await create({ v: 1 });
+      const { token } = await create({ v: 1 });
       for (const bad of [undefined, 'true', 1, null]) {
         const res = await request(app)
           .patch(`/figma-project/${token}/visibility`)

--- a/figma/AGENT_CONTEXT.md
+++ b/figma/AGENT_CONTEXT.md
@@ -262,13 +262,22 @@ a sub-frame.
 
 ## Per-file tokens & live-preview sync
 
-The share token is **per design file**, not global. Storage in `clientStorage`
-(all main-thread, in `src/main/code.ts`):
+Each design file has **two** tokens, not global. **Edit token** = the owner's
+secret; grants write access (PUT config, PATCH visibility) and the owner read.
+Kept only in the plugin, **never** put in a URL. **Public token** = read-only;
+the only thing handed out in share links / QR / deep links. The preview & app
+read through `GET /figma-project/public/:publicToken`, which can view but never
+modify. This is what stops a shared link from letting a viewer edit/delete the
+project. Storage in `clientStorage` (all main-thread, in `src/main/code.ts`):
 
-- `pulsar:previewTokens` → `{ [fileKey]: token }`. Small and **never evicted** —
-  losing it orphans a server row. Replaces the old single `pulsar:previewToken`
-  (which made every file reuse one row); that legacy key is migrated into the
-  map for the first file that asks, then deleted.
+- `pulsar:previewTokens` → `{ [fileKey]: editToken }`. Small and **never
+  evicted** — losing it orphans a server row. Replaces the old single
+  `pulsar:previewToken` (which made every file reuse one row); that legacy key
+  is migrated into the map for the first file that asks, then deleted.
+- `pulsar:previewPublicTokens` → `{ [fileKey]: publicToken }`. The read-only
+  share token, paired by `fileKey`. Also never evicted. Recovered from the
+  server (the owner GET returns it) if missing — e.g. a reinstall, or a legacy
+  share created before the split.
 - `pulsar:project:<fileKey>` → `{ config, baseRevision, lastAccess }`. The
   cached payload + the server revision it synced at. These are the **only**
   thing evicted (oldest `lastAccess` first) when `clientStorage` hits its quota
@@ -419,20 +428,41 @@ discrete + continuous arrays. It's not an icon — never replace it with an
 
 ## Backend (docs/server)
 
-Express + PostgreSQL. Four routes that matter here: `POST /figma-project`,
-`PUT /figma-project/:token`, `GET /figma-project/:token`, and
-`PATCH /figma-project/:token/visibility`. Schema:
+Express + PostgreSQL. Routes that matter here, split by which token they take:
+
+- **Owner (secret edit `token`)** — write + owner read:
+  - `POST /figma-project` → creates a row, returns `{ token, publicToken, revision }`.
+  - `PUT /figma-project/:token` → config sync.
+  - `PATCH /figma-project/:token/visibility` → flip `is_public`.
+  - `GET /figma-project/:token` → owner read. Returns the config **regardless of
+    `is_public`** (the owner always sees their own) plus `publicToken` so the
+    plugin can rebuild share links.
+- **Public (read-only `publicToken`)** — share path:
+  - `GET /figma-project/public/:publicToken` → the **only** read used by the
+    preview app & PulsarApp WebView. Honours `is_public` (403 when revoked) and
+    never grants writes. Registered before the owner `/:token` route so the
+    literal `public` segment isn't captured as a token param.
+
+Schema:
 
 ```sql
 CREATE TABLE figma_projects (
-  token TEXT PRIMARY KEY,
-  config TEXT NOT NULL,         -- JSON-serialized PreviewPayload
+  token TEXT PRIMARY KEY,        -- secret EDIT token (owner only, never shared)
+  public_token TEXT,             -- read-only SHARE token (in links/QR); indexed
+  config TEXT NOT NULL,          -- JSON-serialized PreviewPayload
   revision BIGINT NOT NULL DEFAULT 0,  -- monotonic, bumped on every PUT
   is_public BOOLEAN NOT NULL DEFAULT TRUE,  -- share-link visibility (see below)
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 ```
+
+`public_token` was added via `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, then
+backfilled `public_token = token` for pre-split rows so already-distributed
+share links keep working. (Those legacy links stay writable — their token is
+both edit and public — because the owner still holds that same token; the
+exposure predates the split and can't be closed without breaking the owner. New
+projects get a fresh, distinct, read-only `public_token`.)
 
 ### Share-link visibility (`is_public`)
 
@@ -441,10 +471,12 @@ server-side source of truth (added via `ALTER TABLE … ADD COLUMN IF NOT EXISTS
 defaulting `TRUE` so pre-feature rows stay viewable):
 
 - `POST` always creates public (`is_public = TRUE`).
-- `GET` returns **403 `{ error: 'private' }`** when `is_public` is false — the
-  config is never served for a revoked link, even to a token holder. When public
-  it adds `isPublic: true` to the body. The preview app maps 403 → a dedicated
-  "This preview is private" empty state (distinct from 404 → "no design loaded").
+- The **public** `GET …/public/:publicToken` returns **403 `{ error: 'private' }`**
+  when `is_public` is false — the config is never served for a revoked link to a
+  share-token holder. When public it adds `isPublic: true` to the body. The
+  preview app maps 403 → a dedicated "This preview is private" empty state
+  (distinct from 404 → "no design loaded"). The **owner** `GET /:token` ignores
+  `is_public` (the owner reconciles their own project even while private).
 - `PATCH …/visibility` body `{ isPublic: boolean }` flips the flag. It touches
   `updated_at` (keeps the TTL fresh) but **leaves `revision` alone** — visibility
   isn't config, so toggling must not provoke an optimistic-concurrency conflict

--- a/figma/preview/src/lib/payload.ts
+++ b/figma/preview/src/lib/payload.ts
@@ -44,8 +44,10 @@ export async function readPayload(): Promise<PayloadResult> {
   const token = getTokenFromUrl();
   if (!token) return { status: 'no-token' };
   try {
+    // Read through the public, read-only route. The `?token=` in a share link is
+    // the project's read-only public token; it can view but never modify.
     const res = await fetch(
-      `${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}`,
+      `${API_SERVER_URL}/figma-project/public/${encodeURIComponent(token)}`,
     );
     // 403 = the owner made this preview private. Surface it distinctly so the UI
     // can explain the link was revoked rather than showing "no design loaded".

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -29,6 +29,9 @@ const TOKEN_KEY = 'pulsar:hapticsToken';
 // NEVER evicted to reclaim quota. Replaces the old single global
 // `pulsar:previewToken`, which made every file reuse (and overwrite) one row.
 const PROJECT_TOKENS_KEY = 'pulsar:previewTokens';
+// Per-file read-only share tokens: { [fileKey]: publicToken }. Kept separate
+// from the edit tokens so the share URL never carries the secret. Never evicted.
+const PROJECT_PUBLIC_TOKENS_KEY = 'pulsar:previewPublicTokens';
 // Legacy single global preview token (pre per-file). Migrated lazily into the
 // per-file map for the first file that asks, then deleted.
 const LEGACY_PREVIEW_TOKEN_KEY = 'pulsar:previewToken';
@@ -120,6 +123,24 @@ async function setProjectToken(fileKey: string, token: string): Promise<void> {
   const tokens = await loadProjectTokens();
   tokens[fileKey] = token;
   await figma.clientStorage.setAsync(PROJECT_TOKENS_KEY, tokens);
+}
+
+async function loadProjectPublicTokens(): Promise<Record<string, string>> {
+  const raw = await figma.clientStorage.getAsync(PROJECT_PUBLIC_TOKENS_KEY);
+  return raw && typeof raw === 'object' ? (raw as Record<string, string>) : {};
+}
+
+// Resolve the read-only share token for a file. Null for legacy shares (pre
+// public-token); the plugin recovers it from the server on the next reconcile.
+async function getProjectPublicToken(fileKey: string): Promise<string | null> {
+  const tokens = await loadProjectPublicTokens();
+  return tokens[fileKey] ?? null;
+}
+
+async function setProjectPublicToken(fileKey: string, publicToken: string): Promise<void> {
+  const tokens = await loadProjectPublicTokens();
+  tokens[fileKey] = publicToken;
+  await figma.clientStorage.setAsync(PROJECT_PUBLIC_TOKENS_KEY, tokens);
 }
 
 async function getProjectCache(fileKey: string): Promise<ProjectCache | null> {
@@ -518,14 +539,16 @@ figma.ui.onmessage = async (msg: UiToMain) => {
       break;
     }
     case 'get-project': {
-      const [token, cache] = await Promise.all([
+      const [token, publicToken, cache] = await Promise.all([
         getProjectToken(msg.fileKey),
+        getProjectPublicToken(msg.fileKey),
         getProjectCache(msg.fileKey)
       ]);
       postToUi({
         type: 'project',
         fileKey: msg.fileKey,
         token,
+        publicToken,
         config: cache ? cache.config : null,
         baseRevision: cache ? cache.baseRevision : null,
         // Default to public for legacy caches with no stored visibility.
@@ -534,7 +557,10 @@ figma.ui.onmessage = async (msg: UiToMain) => {
       break;
     }
     case 'persist-project-token':
-      await setProjectToken(msg.fileKey, msg.token);
+      await Promise.all([
+        setProjectToken(msg.fileKey, msg.token),
+        setProjectPublicToken(msg.fileKey, msg.publicToken)
+      ]);
       break;
     case 'persist-project-cache':
       // Cache is best-effort; never let a quota failure crash the handler.

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -115,7 +115,8 @@ export type UiToMain =
   // fileKey so opening the plugin in another design file gets its own token
   // instead of clobbering the first file's shared preview.
   | { type: 'get-project'; fileKey: string }
-  | { type: 'persist-project-token'; fileKey: string; token: string }
+  // Persist this file's tokens: secret edit `token` + read-only `publicToken`.
+  | { type: 'persist-project-token'; fileKey: string; token: string; publicToken: string }
   | { type: 'persist-project-cache'; fileKey: string; config: unknown; baseRevision: number | null }
   // Persist just the share-link visibility for a file (the public/private
   // toggle), without rewriting the cached config. Keyed by fileKey like the
@@ -149,7 +150,11 @@ export type MainToUi =
   | {
       type: 'project';
       fileKey: string;
+      // Secret edit token, or null when the file has never been shared.
       token: string | null;
+      // Read-only share token, or null when unknown (never shared, or a legacy
+      // share the cold-start reconcile hasn't recovered yet).
+      publicToken: string | null;
       config: unknown | null;
       baseRevision: number | null;
       // Last-known share-link visibility for this file. Defaults to true (public)

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -63,22 +63,34 @@ const API_SERVER_URL = 'https://pulsar-server.swmansion.com';
 // project; the client remembers the revision it last synced (its "base") so it
 // can detect when the row changed underneath it and reconcile.
 
-// POST the preview payload to the server and return a fresh token + revision.
-async function createProject(payload: unknown): Promise<{ token: string; revision: number }> {
+// POST the preview payload. Returns the secret edit token, a read-only
+// publicToken for share links, and the revision.
+async function createProject(
+  payload: unknown
+): Promise<{ token: string; publicToken: string; revision: number }> {
   const res = await fetch(`${API_SERVER_URL}/figma-project`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ config: payload })
   });
   const data = (await res.json().catch(() => null)) as
-    | { success: boolean; token?: string; revision?: number; error?: string; detail?: string }
+    | {
+        success: boolean;
+        token?: string;
+        publicToken?: string;
+        revision?: number;
+        error?: string;
+        detail?: string;
+      }
     | null;
   if (!res.ok) {
     const msg = data?.error ?? `Server responded ${res.status}`;
     throw new Error(data?.detail ? `${msg} (${data.detail})` : msg);
   }
-  if (!data?.success || !data.token) throw new Error(data?.error || 'No token returned');
-  return { token: data.token, revision: data.revision ?? 0 };
+  if (!data?.success || !data.token || !data.publicToken) {
+    throw new Error(data?.error || 'No token returned');
+  }
+  return { token: data.token, publicToken: data.publicToken, revision: data.revision ?? 0 };
 }
 
 // Result of a conditional update: applied (new revision), gone (404, caller
@@ -116,20 +128,20 @@ async function updateProject(
   return { kind: 'ok', revision: data.revision ?? 0 };
 }
 
-// Outcome of a GET: the stored snapshot, a revoked (private) link, or a missing
-// row. The plugin is the link's owner, so it still keeps the token on 'private'
-// (the user can re-share to re-open it) — only 'missing' means forget the token.
+// Outcome of an owner GET: the stored snapshot, a revoked (private) link, or a
+// missing row. Only 'missing' means forget the token. ('private' is only
+// reachable against an older server that still 403s the owner read.)
 type FetchResult =
-  | { kind: 'ok'; config: unknown; revision: number; isPublic: boolean }
+  | { kind: 'ok'; config: unknown; revision: number; isPublic: boolean; publicToken: string | null }
   | { kind: 'private' }
   | { kind: 'missing' };
 
-// GET the stored config + revision for a token.
+// GET the owner's project by its secret edit token. Also returns the read-only
+// publicToken so the plugin can (re)learn the share token for a legacy share.
 async function fetchProject(token: string): Promise<FetchResult> {
   const res = await fetch(`${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}`);
   if (res.status === 404) return { kind: 'missing' };
-  // 403 = the row exists but its link was made private. The owner still holds
-  // the token; treat it as a known-private project rather than a lost one.
+  // Only an older (pre-split) server 403s the owner read; treat as private.
   if (res.status === 403) return { kind: 'private' };
   const data = (await res.json().catch(() => null)) as
     | {
@@ -137,6 +149,7 @@ async function fetchProject(token: string): Promise<FetchResult> {
         config?: unknown;
         revision?: number;
         isPublic?: boolean;
+        publicToken?: string;
         error?: string;
         detail?: string;
       }
@@ -150,7 +163,8 @@ async function fetchProject(token: string): Promise<FetchResult> {
     kind: 'ok',
     config: data.config ?? null,
     revision: data.revision ?? 0,
-    isPublic: data.isPublic ?? true
+    isPublic: data.isPublic ?? true,
+    publicToken: data.publicToken ?? null
   };
 }
 
@@ -217,9 +231,11 @@ export default function App() {
   // different design file gets its own server row instead of overwriting the
   // first. Resolved from figma.fileKey (or the file-key override).
   const fileKeyRef = useRef<string>('');
-  // Current file's server token. Kept in a ref so the (rebound) preview-data
-  // and doc-changed handlers always read the latest value.
+  // Current file's secret edit token (write access). Kept in a ref so the
+  // (rebound) preview-data and doc-changed handlers always read the latest value.
   const tokenRef = useRef<string | null>(null);
+  // Current file's read-only share token — what goes into share links/QRs.
+  const publicTokenRef = useRef<string | null>(null);
   // Server revision our local state is based on (for conflict detection).
   const baseRevisionRef = useRef<number | null>(null);
   // stableStringify of the payload we last successfully pushed — lets us skip a
@@ -292,12 +308,14 @@ export default function App() {
   const handleProject = async (m: {
     fileKey: string;
     token: string | null;
+    publicToken: string | null;
     config: unknown | null;
     baseRevision: number | null;
     isPublic: boolean;
   }) => {
     fileKeyRef.current = m.fileKey;
     tokenRef.current = m.token;
+    publicTokenRef.current = m.publicToken;
     baseRevisionRef.current = m.baseRevision;
     // Seed the toggle from the cached value; the server-fetch branch below
     // reconciles it with the source of truth when there's a token to check.
@@ -313,6 +331,16 @@ export default function App() {
           baseRevisionRef.current = got.revision;
           lastSyncedJsonRef.current = stableStringify(got.config);
           setIsPublic(got.isPublic);
+          // Recover/refresh the read-only share token from the server.
+          if (got.publicToken && got.publicToken !== publicTokenRef.current) {
+            publicTokenRef.current = got.publicToken;
+            send({
+              type: 'persist-project-token',
+              fileKey: m.fileKey,
+              token: m.token,
+              publicToken: got.publicToken
+            });
+          }
           send({ type: 'persist-project-visibility', fileKey: m.fileKey, isPublic: got.isPublic });
           send({
             type: 'persist-project-cache',
@@ -332,6 +360,7 @@ export default function App() {
         } else {
           // Token no longer exists server-side — forget it; nothing is shared.
           tokenRef.current = null;
+          publicTokenRef.current = null;
           lastSyncedJsonRef.current = null;
           baseRevisionRef.current = null;
           setSyncStatus('idle');
@@ -513,11 +542,12 @@ export default function App() {
       // allowed — i.e. a background auto-sync of a never-shared file).
       const ensurePublished = async (allowCreate: boolean): Promise<string | null> => {
         const json = stableStringify(payload);
-        const adopt = (t: string, revision: number) => {
+        const adopt = (t: string, publicToken: string, revision: number) => {
           tokenRef.current = t;
+          publicTokenRef.current = publicToken;
           baseRevisionRef.current = revision;
           lastSyncedJsonRef.current = json;
-          send({ type: 'persist-project-token', fileKey, token: t });
+          send({ type: 'persist-project-token', fileKey, token: t, publicToken });
           send({ type: 'persist-project-cache', fileKey, config: payload, baseRevision: revision });
         };
 
@@ -528,7 +558,7 @@ export default function App() {
         if (!token) {
           if (!allowCreate) return null;
           const created = await createProject(payload);
-          adopt(created.token, created.revision);
+          adopt(created.token, created.publicToken, created.revision);
           return created.token;
         }
 
@@ -548,7 +578,7 @@ export default function App() {
             return null;
           }
           const created = await createProject(payload);
-          adopt(created.token, created.revision);
+          adopt(created.token, created.publicToken, created.revision);
           return created.token;
         }
         // Conflict: someone changed the row since our base. The server is the
@@ -570,7 +600,7 @@ export default function App() {
             return null;
           }
           const created = await createProject(payload);
-          adopt(created.token, created.revision);
+          adopt(created.token, created.publicToken, created.revision);
           return created.token;
         }
         // Lost a second race — bail; the next change will retry from the new base.
@@ -611,14 +641,33 @@ export default function App() {
         send({ type: 'persist-project-visibility', fileKey, isPublic: true });
         void setProjectVisibility(token, true).catch(() => {});
 
+        // Everything we hand out carries the read-only public token, never the
+        // edit token. Recover it from the server if not cached (e.g. legacy share).
+        let publicToken = publicTokenRef.current;
+        if (!publicToken) {
+          const got = await fetchProject(token);
+          if (got.kind === 'ok' && got.publicToken) {
+            publicToken = got.publicToken;
+            publicTokenRef.current = publicToken;
+            send({ type: 'persist-project-token', fileKey, token, publicToken });
+          }
+        }
+        if (!publicToken) {
+          send({
+            type: 'notify',
+            message: 'Could not resolve the share link. Try “Sync now” and retry.'
+          });
+          return;
+        }
+
         // Strip any existing query/hash so we don't duplicate or stack tokens
         // when the user has manually visited the preview before.
         const base = resolvePreviewBaseUrl(settings.previewBaseUrlOverride).replace(/[?#].*$/, '');
-        const url = `${base}?token=${encodeURIComponent(token)}`;
+        const url = `${base}?token=${encodeURIComponent(publicToken)}`;
         // The QR is scanned by a phone with PulsarApp installed. Encode the
         // app's deep-link scheme instead of the web URL so it routes straight
         // into the in-app Figma WebView screen.
-        const appDeepLink = `pulsarapp://figma?token=${encodeURIComponent(token)}`;
+        const appDeepLink = `pulsarapp://figma?token=${encodeURIComponent(publicToken)}`;
         if (purpose === 'copy') {
           const ok = copyToClipboard(url);
           send({
@@ -626,10 +675,9 @@ export default function App() {
             message: ok ? 'Share link copied to clipboard.' : 'Could not copy the share link.'
           });
         } else if (purpose === 'copy-token') {
-          // Just the raw token — handy for pasting into other figma-preview URLs
-          // (e.g. a local dev instance), debugging, or sharing the token by itself
-          // without a particular host.
-          const ok = copyToClipboard(token);
+          // Just the raw read-only token — handy for pasting into other
+          // figma-preview URLs (e.g. a local dev instance) or debugging.
+          const ok = copyToClipboard(publicToken);
           send({
             type: 'notify',
             message: ok ? 'Share token copied to clipboard.' : 'Could not copy the share token.'


### PR DESCRIPTION
## Problem

The Figma plugin used a **single token** as both the read key (embedded in the preview share URL) and the write key (`PUT` config / `PATCH` visibility). Handing the preview link to anyone gave them full edit/delete rights over the project.

## Fix

Split the token into two secrets per project:

- **Edit token** (private) — the owner's secret. Grants writes (`PUT`/`PATCH`) and the owner read. Stored only in the plugin's `clientStorage`; **never** put in a URL.
- **Public token** (read-only) — the only token in share links, QR codes and deep links. Reads through `GET /figma-project/public/:publicToken`, which honours visibility (403 when revoked) and can **never** modify the project.

Only the designer who created the project (and holds the edit token) can modify it; anyone with the public token can read only.

## Changes by layer

**Server** (`docs/server`)
- New indexed `public_token` column; `createFigmaProject` generates two distinct tokens.
- `GET /figma-project/public/:publicToken` — read-only share path, enforces `is_public`.
- `GET /figma-project/:token` — owner read by edit token; serves config even when private and returns the `publicToken`.
- `PUT` / `PATCH …/visibility` unchanged — still keyed on the secret edit token.
- `public_token` backfilled `= token` for pre-split rows so already-distributed links keep working.

**Plugin** (`figma/src`) — stores both tokens per file, builds every share URL / deep link / "copy token" from the **public** token, recovers the public token from the server for legacy shares.

**Preview** (`figma/preview`) — reads through the public route. The mobile app needed no change (it forwards whatever token the QR/deep link carries, now the public one).

## Tests

84/84 server tests pass. New coverage proves the security boundary end-to-end:
- A public-token holder gets **404 on `PUT` and `PATCH`** (cannot edit or revoke the link); project verified untouched.
- The public route 404s when handed the edit token; the owner read still serves config while private.
- The migration backfill (and its `WHERE public_token IS NULL` guard) is exercised directly.

## Caveat

Links **already shared before this change** remain writable — their token is both edit and public, and it can't be rotated without breaking the owner who still holds it. Every project created from now on is secure. Documented in `figma/AGENT_CONTEXT.md`.