### PR TITLE
feat(figma): mint stable file id from root pluginData instead of figma.fileKey

### DIFF
--- a/figma/manifest.json
+++ b/figma/manifest.json
@@ -6,7 +6,7 @@
   "capabilities": [],
   "enableProposedApi": false,
   "documentAccess": "dynamic-page",
-  "enablePrivatePluginApi": true,
+  "enablePrivatePluginApi": false,
   "editorType": ["figma"],
   "ui": "dist/ui.html",
   "networkAccess": {

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -39,6 +39,13 @@ const PROJECT_CACHE_PREFIX = 'pulsar:project:';
 const FAVOURITES_KEY = 'pulsar:favourites';
 const CUSTOM_PRESETS_KEY = 'pulsar:customPresets';
 const WINDOW_SIZE_KEY = 'pulsar:windowSize';
+// Stable per-document identifier, stored in the document's root pluginData.
+// Replaces `figma.fileKey`, which is only available with the private plugin API
+// and would block a public Community release. Root pluginData is persisted in
+// the file and synced to every collaborator, so this key is just as stable and
+// shared as fileKey was — it simply lives in our own namespace instead of
+// Figma's global one (which only matters for keying our own server rows).
+const FILE_ID_KEY = 'pulsar:fileId';
 
 const DEFAULT_SIZE = { width: 380, height: 640 };
 // Clamp the persisted size so a stored value can't shrink the UI below a
@@ -73,6 +80,18 @@ figma.clientStorage.getAsync(WINDOW_SIZE_KEY).then((raw) => {
 
 function postToUi(msg: MainToUi) {
   figma.ui.postMessage(msg);
+}
+
+// Resolve the stable per-file key, minting and persisting one on first use.
+// `figma.root` and its pluginData are always available (even under
+// documentAccess: dynamic-page), so this is safe to call synchronously.
+function resolveFileKey(): string {
+  let id = figma.root.getPluginData(FILE_ID_KEY);
+  if (!id) {
+    id = `f${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+    figma.root.setPluginData(FILE_ID_KEY, id);
+  }
+  return id;
 }
 
 async function loadSettings(): Promise<Settings> {
@@ -510,7 +529,7 @@ figma.ui.onmessage = async (msg: UiToMain) => {
         type: 'init',
         settings,
         hapticsToken,
-        fileKey: figma.fileKey ?? null,
+        fileKey: resolveFileKey(),
         favourites,
         customPresets
       });
@@ -586,7 +605,7 @@ figma.ui.onmessage = async (msg: UiToMain) => {
       postToUi({
         type: 'preview-data',
         purpose: msg.purpose,
-        fileKey: figma.fileKey ?? null,
+        fileKey: resolveFileKey(),
         presentNodeId: present ? present.id : null,
         presentNodeBox: present ? boxOf(present) : null,
         bindings,

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -39,12 +39,8 @@ const PROJECT_CACHE_PREFIX = 'pulsar:project:';
 const FAVOURITES_KEY = 'pulsar:favourites';
 const CUSTOM_PRESETS_KEY = 'pulsar:customPresets';
 const WINDOW_SIZE_KEY = 'pulsar:windowSize';
-// Stable per-document identifier, stored in the document's root pluginData.
-// Replaces `figma.fileKey`, which is only available with the private plugin API
-// and would block a public Community release. Root pluginData is persisted in
-// the file and synced to every collaborator, so this key is just as stable and
-// shared as fileKey was — it simply lives in our own namespace instead of
-// Figma's global one (which only matters for keying our own server rows).
+// Stable per-document id stored in root pluginData; replaces `figma.fileKey`,
+// which needs the private plugin API. Synced to all collaborators.
 const FILE_ID_KEY = 'pulsar:fileId';
 
 const DEFAULT_SIZE = { width: 380, height: 640 };
@@ -83,8 +79,6 @@ function postToUi(msg: MainToUi) {
 }
 
 // Resolve the stable per-file key, minting and persisting one on first use.
-// `figma.root` and its pluginData are always available (even under
-// documentAccess: dynamic-page), so this is safe to call synchronously.
 function resolveFileKey(): string {
   let id = figma.root.getPluginData(FILE_ID_KEY);
   if (!id) {

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -37,8 +37,9 @@ export interface BindingMeta {
 export type Settings = {
   soundInEdit: boolean;
   compactLayout: boolean;
-  // Optional manual file-key override, used when figma.fileKey is unavailable
-  // (e.g. the plugin is not private / enablePrivatePluginApi is off).
+  // Optional manual file-key override. The main thread now always mints a stable
+  // key from root pluginData, so this is a secondary fallback only consulted when
+  // that key is somehow absent (kept for back-compat and manual cross-file pairing).
   fileKeyOverride: string;
   // Optional override for the live-preview app base URL. Empty string uses the
   // built-in default (vite-dev → localhost:5173, prod → docs.swmansion.com).
@@ -134,9 +135,9 @@ export type MainToUi =
       type: 'init';
       settings: Settings;
       hapticsToken: string | null;
-      // Current document's file key (figma.fileKey), or null when unavailable
-      // (e.g. enablePrivatePluginApi off). Lets the UI request this file's
-      // project state immediately on load.
+      // Stable per-document key minted by the main thread (root pluginData),
+      // or null in legacy paths. Lets the UI request this file's project state
+      // immediately on load.
       fileKey: string | null;
       favourites: string[];
       customPresets: CatalogEntry[];

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -37,9 +37,8 @@ export interface BindingMeta {
 export type Settings = {
   soundInEdit: boolean;
   compactLayout: boolean;
-  // Optional manual file-key override. The main thread now always mints a stable
-  // key from root pluginData, so this is a secondary fallback only consulted when
-  // that key is somehow absent (kept for back-compat and manual cross-file pairing).
+  // Optional manual file-key override. Secondary fallback only consulted when the
+  // main thread's minted key is absent; also allows manual cross-file pairing.
   fileKeyOverride: string;
   // Optional override for the live-preview app base URL. Empty string uses the
   // built-in default (vite-dev → localhost:5173, prod → docs.swmansion.com).
@@ -135,9 +134,7 @@ export type MainToUi =
       type: 'init';
       settings: Settings;
       hapticsToken: string | null;
-      // Stable per-document key minted by the main thread (root pluginData),
-      // or null in legacy paths. Lets the UI request this file's project state
-      // immediately on load.
+      // Stable per-document key minted by the main thread (root pluginData).
       fileKey: string | null;
       favourites: string[];
       customPresets: CatalogEntry[];


### PR DESCRIPTION
## Why

`figma.fileKey` is gated behind the **private plugin API** (`enablePrivatePluginApi: true`), and a plugin with that flag set **cannot be published publicly to the Figma Community** — only as an org-private plugin. It was the *only* private API the plugin used; everything else (`clientStorage`, `currentPage`, `getNodeByIdAsync`, `findAllWithCriteria`, `viewport`, `openExternal`, `notify`, etc.) is standard public API.

## What

- Add `resolveFileKey()` in the main thread: reads a stable id from the document's **root pluginData**, minting and persisting one on first use.
- Swap both `figma.fileKey ?? null` reads (`init`, `request-preview-data`) for `resolveFileKey()`.
- Flip `enablePrivatePluginApi` → `false` in `manifest.json`.
- Refresh now-stale comments.

Root pluginData is stored in the file and syncs to every collaborator, so the key is just as stable and shared as `fileKey` was — it just lives in our own namespace instead of Figma's global one, which is fine since it only keys our own preview-server rows. `fileKeyOverride` is retained as a secondary fallback.

## Notes

- Existing files (pre-0.1.0, dev-only) keyed by the old `figma.fileKey` will mint a fresh id and create a new server row on first open — acceptable at this stage.
- `npm run typecheck` and `npm run build` both pass.
