### PR TITLE
fix(docs): canonical, figma-preview noindex & trailing-slash links (SEO)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -94,6 +94,10 @@ export default defineConfig({
       },
     }),
     react(),
-    sitemap(),
+    sitemap({
+      // figma-preview is a headless embed surface (noindex) — keep it out of
+      // the sitemap so we don't invite Google to index it.
+      filter: (page) => !page.includes('/figma-preview'),
+    }),
   ],
 });

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -9,6 +9,9 @@ import { articles } from './src/data/articles.ts';
 export default defineConfig({
   site: 'https://docs.swmansion.com/',
   base: BASE_PATH,
+  // GitHub Pages 301-redirects directory URLs to their trailing-slash form, so
+  // emit and link to that canonical form everywhere to avoid redirect hops.
+  trailingSlash: 'always',
   vite: {
     css: {
       modules: {

--- a/docs/src/components/landing/Preset/Preset.tsx
+++ b/docs/src/components/landing/Preset/Preset.tsx
@@ -52,7 +52,7 @@ export function Preset(preset: PresetConfig) {
         <div className={`${style.toast} ${isExiting ? style.toastExit : style.toastEnter}`} role="status">
           <span>
             To play haptics on your phone, visit the{' '}
-            <a href={`${BASE_PATH}/presets-playground`}>Presets Playground</a>
+            <a href={`${BASE_PATH}/presets-playground/`}>Presets Playground</a>
             {' '}where you can connect your device.
           </span>
           <button

--- a/docs/src/components/landing/SdkSection/SdkSection.tsx
+++ b/docs/src/components/landing/SdkSection/SdkSection.tsx
@@ -40,7 +40,7 @@ export function SdkSection({ className }: { className?: string }) {
         />
         <Button
           label="See all of them"
-          url={`${BASE_PATH}/sdk/overview`}
+          url={`${BASE_PATH}/sdk/overview/`}
           onClick={() => window.posthog?.capture('sdk_section_viewed')}
         />
       </div>

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -78,14 +78,14 @@ export function TopBanner() {
         <div className={styles.buttonHolder}>
           <Button
             label="Preset playground"
-            url={`${BASE_PATH}/presets-playground`}
+            url={`${BASE_PATH}/presets-playground/`}
             className={styles.fullWidth}
             onClick={() => window.posthog?.capture('preset_playground_cta_clicked')}
           />
           <Button
             label="Read the docs"
             variant="filled"
-            url={`${BASE_PATH}/getting-started`}
+            url={`${BASE_PATH}/getting-started/`}
             className={styles.fullWidth}
             onClick={() => window.posthog?.capture('docs_cta_clicked')}
           />

--- a/docs/src/components/landing/TopBar/TopBar.tsx
+++ b/docs/src/components/landing/TopBar/TopBar.tsx
@@ -26,9 +26,9 @@ export function TopBar() {
           <span>Pulsar</span>
         </div>
         <div className={styles.menuItems}>
-          <a href={`${BASE_PATH}/presets-playground`}>Presets</a>
-          <a href={`${BASE_PATH}/getting-started`}>Getting started</a>
-          <a href={`${BASE_PATH}/sdk/overview`}>Docs</a>
+          <a href={`${BASE_PATH}/presets-playground/`}>Presets</a>
+          <a href={`${BASE_PATH}/getting-started/`}>Getting started</a>
+          <a href={`${BASE_PATH}/sdk/overview/`}>Docs</a>
         </div>
         <a href="https://github.com/software-mansion/pulsar" target="_blank">
           <img className={styles.gitLogo} src={logoGitHub.src} alt="GitHub" />
@@ -55,13 +55,13 @@ export function TopBar() {
               />
             </div>
             <nav className={styles.mobileMenuItems}>
-              <a href={`${BASE_PATH}/presets-playground`} onClick={closeMenu}>
+              <a href={`${BASE_PATH}/presets-playground/`} onClick={closeMenu}>
                 Presets
               </a>
-              <a href={`${BASE_PATH}/getting-started`} onClick={closeMenu}>
+              <a href={`${BASE_PATH}/getting-started/`} onClick={closeMenu}>
                 Getting started
               </a>
-              <a href={`${BASE_PATH}/sdk/overview`} onClick={closeMenu}>
+              <a href={`${BASE_PATH}/sdk/overview/`} onClick={closeMenu}>
                 Docs
               </a>
             </nav>

--- a/docs/src/components/landing/VisitComposer/VisitComposer.tsx
+++ b/docs/src/components/landing/VisitComposer/VisitComposer.tsx
@@ -25,7 +25,7 @@ export function VisitComposer({ className }: VisitComposerProps) {
           </div>
           <img src={screenshot.src} />
           <br />
-          <a className={styles.link} href={`${BASE_PATH}/presets-playground`}>Visit our composer</a>
+          <a className={styles.link} href={`${BASE_PATH}/presets-playground/`}>Visit our composer</a>
         </div>
       </div>
     </div>

--- a/docs/src/components/landing/VisitPlayground/VisitPlayground.tsx
+++ b/docs/src/components/landing/VisitPlayground/VisitPlayground.tsx
@@ -29,7 +29,7 @@ export function VisitPlayground({ className }: { className?: string }) {
         />
         <Button
           label="Connect your phone"
-          url={`${BASE_PATH}/presets-playground`}
+          url={`${BASE_PATH}/presets-playground/`}
           className={commonStyles.spaceTopSmall}
           onClick={() => window.posthog?.capture('connect_phone_cta_clicked')}
         />

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -49,7 +49,7 @@ These docs double as an interactive playground. Pair your phone with the browser
 
 <LinkCard
   title="Browse preset playground"
-  href={`${BASE_PATH}/presets-playground`}
+  href={`${BASE_PATH}/presets-playground/`}
   description="Explore the full preset library with live haptic previews. Pair PulsarApp with your browser "
 />
 
@@ -58,29 +58,29 @@ These docs double as an interactive playground. Pair your phone with the browser
 <CardGrid>
   <LinkCard
     title="React Native SDK"
-    href={`${BASE_PATH}/sdk/react-native`}
+    href={`${BASE_PATH}/sdk/react-native/`}
     description="Presets, pattern composer, and real-time haptics via a Turbo Module. Works with Reanimated worklets."
   />
   <LinkCard
     title="iOS SDK"
-    href={`${BASE_PATH}/sdk/ios`}
+    href={`${BASE_PATH}/sdk/ios/`}
     description="Swift Package built on Core Haptics. Supports transient events, continuous envelopes, and audio simulation."
   />
   <LinkCard
     title="Android SDK"
-    href={`${BASE_PATH}/sdk/android`}
+    href={`${BASE_PATH}/sdk/android/`}
     description="Kotlin library with VibrationEffect support and graceful fallbacks for older devices."
   />
 </CardGrid>
 
-New to haptics? Read the <a href={`${BASE_PATH}/sdk/overview`}>SDK overview</a> first. It covers discrete vs. continuous haptics, preloading, and caching.
+New to haptics? Read the <a href={`${BASE_PATH}/sdk/overview/`}>SDK overview</a> first. It covers discrete vs. continuous haptics, preloading, and caching.
 
 ## Go deeper
 
 <CardGrid>
   <LinkCard
     title="SDK overview"
-    href={`${BASE_PATH}/sdk/overview`}
+    href={`${BASE_PATH}/sdk/overview/`}
     description="Core concepts: types of haptics, preloading, and caching."
   />
 </CardGrid>

--- a/docs/src/pages/figma-preview.astro
+++ b/docs/src/pages/figma-preview.astro
@@ -7,6 +7,9 @@ import Preview from '../components/preview/Preview.astro';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {/* Headless embed surface (loaded inside Figma with a ?token= param) — keep
+        it out of search results entirely. Also excluded from the sitemap. */}
+    <meta name="robots" content="noindex" />
     <title>Pulsar Figma Preview</title>
   </head>
   <body>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -35,6 +35,10 @@ import arrowIcon from '../assets/landing-page/arrow.svg';
     />
     <meta name="keywords" content="haptic feedback android, haptic feedback android, react native haptic feedback, ios haptics, react native haptics, ios haptic feedback, haptics feedback, android haptic feedback, haptic feedback react native, swiftui haptic feedback, haptics" />
     <title>Pulsar: Haptic Feedback Library for Swift, Kotlin & React Native</title>
+    {/* Self-referencing canonical so tracking-param variants (e.g. ?ref=...)
+        consolidate to the clean root URL. Starlight pages get this automatically;
+        this hand-rolled landing page needs it set explicitly. */}
+    <link rel="canonical" href={new URL(`${BASE_PATH}/`, Astro.site).href} />
     <link rel="icon" type="image/svg+xml" href={`${BASE_PATH}/logo.svg`} />
     <link rel="preload" as="image" type="image/svg+xml" href={swmLogo.src} />
     <link rel="preload" as="image" type="image/svg+xml" href={starIcon.src} />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -74,7 +74,7 @@ Presets that you can hear and feel with Live Preview." />
         subtitle="Don't spend time creating your own patterns. Just use ours and enjoy the benefits of having haptics in your app by using presets."
       />
       <PresetsList client:load />
-      <Button label="See all presets" url={`${BASE_PATH}/presets-playground`} />
+      <Button label="See all presets" url={`${BASE_PATH}/presets-playground/`} />
       <VisitComposer className={commonStyle.spaceTopMedium} />
     </BasicLayout>
 
@@ -96,7 +96,7 @@ Presets that you can hear and feel with Live Preview." />
 
 <script is:inline define:vars={{ basePath: BASE_PATH }}>
   document.addEventListener('DOMContentLoaded', function () {
-    var seeAllBtn = document.querySelector(`a[href="${basePath}/presets-playground"]`);
+    var seeAllBtn = document.querySelector(`a[href="${basePath}/presets-playground/"]`);
     if (seeAllBtn) {
       seeAllBtn.addEventListener('click', function () {
         window.posthog?.capture('see_all_presets_clicked');


### PR DESCRIPTION
Follow-up to #79 — covers the remaining Google Search Console issues. (The sitemap, 404-link fix, and blog-draft removal already landed in #79.)

## Issues & fixes

| GSC issue | Fix |
|---|---|
| **Duplicate, no user-declared canonical** (`/pulsar/?ref=…`) | The hand-rolled landing page emitted no canonical → added self-referencing `<link rel="canonical">` to the clean root URL |
| **Page with redirect** (4 pages) | Internal links omitted trailing slashes, so GitHub Pages 301-redirected them → `trailingSlash: 'always'` + trailing slashes on every internal link |
| (proactive) figma-preview had no canonical | It's a headless embed surface → `noindex` + excluded from the sitemap |

## Changes

- **Self-referencing canonical** on `index.astro` so tracking-param variants (`?ref=…`) consolidate to `https://docs.swmansion.com/pulsar/`.
- **`trailingSlash: 'always'`** + trailing slashes on all internal links (`TopBar`, `TopBanner`, `SdkSection`, `VisitComposer`, `VisitPlayground`, `Preset`, `getting-started.mdx`, `index.astro`). Updated the PostHog click-tracking `querySelector` to match the new href.
- **`noindex` + sitemap-exclude** the `figma-preview` embed page.

## Verification

`astro build`, then inspected `dist/`:
- Root emits `<link rel="canonical" href="https://docs.swmansion.com/pulsar/">`.
- `figma-preview` is `noindex` and absent from `sitemap-0.xml`.
- Every internal route `href` ends with `/` — zero redirect hops remain; analytics selector matches the rendered anchor.

After merge + deploy, re-run **Validate Fix** in Search Console for the "Duplicate" and "Page with redirect" issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)