### PR TITLE
fix(web): remove unused line-segment helper breaking figma-preview build

### DIFF
--- a/web/Pulsar/src/builtin-presets.ts
+++ b/web/Pulsar/src/builtin-presets.ts
@@ -1,6 +1,5 @@
 import type {
   HapticContinuousSegment,
-  HapticLineSegment,
   HapticPattern,
   HapticPulseSegment,
 } from "./types.ts";
@@ -22,19 +21,6 @@ const p = (
   duration,
   intensity,
   frequency,
-});
-
-const l = (
-  timestamp: number,
-  duration: number,
-  intensity: Array<[number, number]>,
-  frequency: Array<[number, number]>,
-): HapticLineSegment => ({
-  type: "line",
-  timestamp,
-  duration,
-  intensity: intensity.map(([time, value]) => ({ time, value })),
-  frequency: frequency.map(([time, value]) => ({ time, value })),
 });
 
 const taps = (start: number, count: number, gap: number, duration: number): HapticContinuousSegment[] => {


### PR DESCRIPTION
## Problem

The figma-preview build was failing in CI ([run 27541378559](https://github.com/software-mansion/pulsar/actions/runs/27541378559/job/81403765744)):

```
src/builtin-presets.ts(27,7): error TS6133: 'l' is declared but its value is never read.
```

## Cause

The `l` (line segment) helper in `web/Pulsar/src/builtin-presets.ts` — and its `HapticLineSegment` type import — became orphaned after the preset filtering in #81 removed all presets that used line segments. The `tsc` step of `npm run build` rejects unused declarations.

## Fix

Remove the unused `l` helper and the now-unused `HapticLineSegment` import.

## Verification

`npm ci && npm run build` in `web/Pulsar` now completes cleanly through all three build steps (vite, vite react, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)