### PR TITLE
fix(figma): keep plugin UI light so Figma dark window doesn't bleed through

### DIFF
--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -822,8 +822,6 @@ export default function App() {
         display: 'flex',
         flexDirection: 'column',
         height: '100vh',
-        // Opaque light fill so Figma's native window background (dark in dark
-        // mode) never shows through the plugin surface.
         background: 'var(--bg)'
       }}
     >

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -817,7 +817,16 @@ export default function App() {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        // Opaque light fill so Figma's native window background (dark in dark
+        // mode) never shows through the plugin surface.
+        background: 'var(--bg)'
+      }}
+    >
       <div
         className="row"
         style={{ padding: '8px 10px 0', gap: 0, borderBottom: '1px solid var(--border)' }}

--- a/figma/src/ui/styles/theme.css
+++ b/figma/src/ui/styles/theme.css
@@ -29,16 +29,13 @@
   --fs-xl: 20px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0b1226;
-    --surface: #131d3a;
-    --text: #e7efff;
-    --muted: #95a8d4;
-    --border: #28365e;
-    --shadow-card: -3px 3px 0 var(--color-blue-50);
-  }
-}
+/* The plugin UI is built entirely around the light Pulsar palette. Figma renders
+   the plugin in an iframe whose host window adopts the editor's theme, so when
+   Figma is in dark mode its near-black window background shows through any
+   surface we leave transparent. Rather than maintain a separate dark palette for
+   every component, we pin the plugin to its light theme and paint an opaque
+   background on the root surfaces below so the native dark window never bleeds
+   in. (Intentionally not honouring prefers-color-scheme.) */
 
 * {
   box-sizing: border-box;
@@ -53,6 +50,7 @@ body,
   font-family: var(--font-sans);
   font-size: var(--fs-sm);
   color: var(--text);
+  /* Opaque light fill — covers Figma's native (possibly dark) window chrome. */
   background: var(--bg);
   -webkit-font-smoothing: antialiased;
 }

--- a/figma/src/ui/styles/theme.css
+++ b/figma/src/ui/styles/theme.css
@@ -29,14 +29,6 @@
   --fs-xl: 20px;
 }
 
-/* The plugin UI is built entirely around the light Pulsar palette. Figma renders
-   the plugin in an iframe whose host window adopts the editor's theme, so when
-   Figma is in dark mode its near-black window background shows through any
-   surface we leave transparent. Rather than maintain a separate dark palette for
-   every component, we pin the plugin to its light theme and paint an opaque
-   background on the root surfaces below so the native dark window never bleeds
-   in. (Intentionally not honouring prefers-color-scheme.) */
-
 * {
   box-sizing: border-box;
 }
@@ -50,7 +42,6 @@ body,
   font-family: var(--font-sans);
   font-size: var(--fs-sm);
   color: var(--text);
-  /* Opaque light fill — covers Figma's native (possibly dark) window chrome. */
   background: var(--bg);
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
## Problem

The Figma plugin UI is built entirely around the light Pulsar palette (blue-10 fills, blue-50 borders, navy text). `theme.css` carried a `@media (prefers-color-scheme: dark)` block that flipped `--bg`/`--surface`/`--text`/etc. to a dark navy palette when the Figma editor was in dark mode. Because the components were never designed for that palette, the result looked broken and Figma's near-black native window background bled through any surface left transparent — including the root container, which had no background of its own.

## Fix

- Drop the dark-mode palette override in `theme.css` — the plugin now always renders in its light theme regardless of the editor/system theme.
- Paint an explicit opaque `var(--bg)` background on the root `App` container so Figma's native window background can never show through the plugin surface.

## Verification

- `npm run typecheck` passes.
- Ran the UI via Vite with the browser emulating `prefers-color-scheme: dark`: `--bg` stays `#fbfeff` and both `body` and the root App div compute to the light fill `rgb(251, 254, 255)`. UI renders fully in the light theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)