### PR TITLE
fix(docs): make landing hero ring animations compositor-driven (fix mobile jank)

### DIFF
--- a/docs/src/components/landing/TopBanner/TopBanner.module.scss
+++ b/docs/src/components/landing/TopBanner/TopBanner.module.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use 'sass:list';
 
 .banner {
   border: solid 2px var(--color-blue-50);
@@ -140,8 +141,6 @@
         pointer-events: none;
         transform-origin: center;
         will-change: transform, opacity;
-        // Base opacity for the faint resting rings (was the circles'
-        // opacity="0.1" attribute). Animated states override this.
         opacity: 0.1;
       }
     }
@@ -292,11 +291,6 @@
 
 .svgWave {
   z-index: 0;
-  // The wrapper must stay transparent: the color classes (.red/.yellow/.green)
-  // set background-color and are applied to this element too, but only the
-  // .banner background should show that color (and it fades via .banner's
-  // transition). Without this the wrapper would snap to the new color a few
-  // frames before the banner finishes its transition.
   background-color: transparent;
   circle {
     transition: all 0.2s;
@@ -304,15 +298,8 @@
 }
 
 // --------------------------------------------------
-// Ring animations
-//
-// Motion (transform + opacity) is animated on the .ring <svg> roots so it runs
-// entirely on the compositor — no per-frame layout/paint. Stroke-width, which
-// cannot be composited, stays on the inner <circle> and is kept in lockstep
-// with the motion via identical duration / delay / timing-function.
+// wave animation
 // --------------------------------------------------
-
-// wave ----------------------------------------------
 $wave-delays: 0s, 0.5s, 1s, 1.5s, 2s;
 
 .wave .ring {
@@ -324,7 +311,7 @@ $wave-delays: 0s, 0.5s, 1s, 1.5s, 2s;
 @for $i from 1 through 5 {
   .wave .ring:nth-child(#{$i}) {
     animation-name: wave-#{$i};
-    animation-delay: nth($wave-delays, $i);
+    animation-delay: list.nth($wave-delays, $i);
   }
 }
 
@@ -346,7 +333,9 @@ $wave-delays: 0s, 0.5s, 1s, 1.5s, 2s;
 @include waveGenerator('4');
 @include waveGenerator('5');
 
-// heartbeat -----------------------------------------
+// --------------------------------------------------
+// heartbeat animation
+// --------------------------------------------------
 $heartbeat-delays: 0.32s, 0.24s, 0.16s, 0.08s, 0s;
 
 .heartbeat .ring {
@@ -363,7 +352,7 @@ $heartbeat-delays: 0.32s, 0.24s, 0.16s, 0.08s, 0s;
 }
 
 @for $i from 1 through 5 {
-  $delay: nth($heartbeat-delays, $i);
+  $delay: list.nth($heartbeat-delays, $i);
   .heartbeat .ring:nth-child(#{$i}) {
     animation-name: heartbeat-motion-#{$i};
     animation-delay: $delay;
@@ -423,7 +412,9 @@ $heartbeat-delays: 0.32s, 0.24s, 0.16s, 0.08s, 0s;
 @include heartbeatGenerator('4');
 @include heartbeatGenerator('5');
 
-// sonar ---------------------------------------------
+// --------------------------------------------------
+// sonar animation
+// --------------------------------------------------
 $sonar-delays: 1.12s, 0.84s, 0.56s, 0.28s, 0s;
 
 .sonar .ring {
@@ -440,7 +431,7 @@ $sonar-delays: 1.12s, 0.84s, 0.56s, 0.28s, 0s;
 }
 
 @for $i from 1 through 5 {
-  $delay: nth($sonar-delays, $i);
+  $delay: list.nth($sonar-delays, $i);
   .sonar .ring:nth-child(#{$i}) {
     animation-name: sonar-motion-#{$i};
     animation-delay: $delay;
@@ -485,7 +476,9 @@ $sonar-delays: 1.12s, 0.84s, 0.56s, 0.28s, 0s;
 @include sonarGenerator('4');
 @include sonarGenerator('5');
 
-// quake ---------------------------------------------
+// --------------------------------------------------
+// quake animation
+// --------------------------------------------------
 $quake-durations: 0.07s, 0.09s, 0.06s, 0.11s, 0.08s;
 
 .quake .ring {
@@ -504,7 +497,7 @@ $quake-durations: 0.07s, 0.09s, 0.06s, 0.11s, 0.08s;
 @for $i from 1 through 5 {
   .quake .ring:nth-child(#{$i}) {
     animation-name: quake-#{$i};
-    animation-duration: nth($quake-durations, $i);
+    animation-duration: list.nth($quake-durations, $i);
   }
 }
 

--- a/docs/src/components/landing/TopBanner/TopBanner.module.scss
+++ b/docs/src/components/landing/TopBanner/TopBanner.module.scss
@@ -119,14 +119,30 @@
       max-width: 100%;
     }
 
-    svg {
+    .svgWave {
       pointer-events: none;
       transform: translateX(5%) translateY(-15%);
       position: absolute;
+      width: 1000px;
+      height: 1000px;
 
       @media (max-width: 1000px) {
         transform: translateX(0%) translateY(-50%);
         width: 1300px;
+        height: 1300px;
+      }
+
+      .ring {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        transform-origin: center;
+        will-change: transform, opacity;
+        // Base opacity for the faint resting rings (was the circles'
+        // opacity="0.1" attribute). Animated states override this.
+        opacity: 0.1;
       }
     }
 
@@ -276,40 +292,40 @@
 
 .svgWave {
   z-index: 0;
+  // The wrapper must stay transparent: the color classes (.red/.yellow/.green)
+  // set background-color and are applied to this element too, but only the
+  // .banner background should show that color (and it fades via .banner's
+  // transition). Without this the wrapper would snap to the new color a few
+  // frames before the banner finishes its transition.
+  background-color: transparent;
   circle {
     transition: all 0.2s;
   }
 }
 
 // --------------------------------------------------
-// wave animation
+// Ring animations
+//
+// Motion (transform + opacity) is animated on the .ring <svg> roots so it runs
+// entirely on the compositor — no per-frame layout/paint. Stroke-width, which
+// cannot be composited, stays on the inner <circle> and is kept in lockstep
+// with the motion via identical duration / delay / timing-function.
 // --------------------------------------------------
-.wave circle {
+
+// wave ----------------------------------------------
+$wave-delays: 0s, 0.5s, 1s, 1.5s, 2s;
+
+.wave .ring {
   animation-duration: 4s;
   animation-timing-function: ease-out;
   animation-iteration-count: infinite;
-  transform-box: fill-box;
-  transform-origin: center;
 }
 
-.wave circle:nth-child(1) {
-  animation-name: wave-1;
-}
-.wave circle:nth-child(2) {
-  animation-name: wave-2;
-  animation-delay: 0.5s;
-}
-.wave circle:nth-child(3) {
-  animation-name: wave-3;
-  animation-delay: 1s;
-}
-.wave circle:nth-child(4) {
-  animation-name: wave-4;
-  animation-delay: 1.5s;
-}
-.wave circle:nth-child(5) {
-  animation-name: wave-5;
-  animation-delay: 2s;
+@for $i from 1 through 5 {
+  .wave .ring:nth-child(#{$i}) {
+    animation-name: wave-#{$i};
+    animation-delay: nth($wave-delays, $i);
+  }
 }
 
 @mixin waveGenerator($prefix) {
@@ -330,42 +346,36 @@
 @include waveGenerator('4');
 @include waveGenerator('5');
 
-// --------------------------------------------------
-// heartbeat animation
-// --------------------------------------------------
-.heartbeat circle {
-  stroke-width: 1;
+// heartbeat -----------------------------------------
+$heartbeat-delays: 0.32s, 0.24s, 0.16s, 0.08s, 0s;
+
+.heartbeat .ring {
   opacity: 0.1;
   animation-duration: 1.2s;
   animation-timing-function: ease-out;
   animation-iteration-count: infinite;
-  transform-box: fill-box;
-  transform-origin: center;
+}
+.heartbeat .ring circle {
+  stroke-width: 1;
+  animation-duration: 1.2s;
+  animation-timing-function: ease-out;
+  animation-iteration-count: infinite;
 }
 
-.heartbeat circle:nth-child(1) {
-  animation-name: heartbeat-1;
-  animation-delay: 0.32s;
-}
-.heartbeat circle:nth-child(2) {
-  animation-name: heartbeat-2;
-  animation-delay: 0.24s;
-}
-.heartbeat circle:nth-child(3) {
-  animation-name: heartbeat-3;
-  animation-delay: 0.16s;
-}
-.heartbeat circle:nth-child(4) {
-  animation-name: heartbeat-4;
-  animation-delay: 0.08s;
-}
-.heartbeat circle:nth-child(5) {
-  animation-name: heartbeat-5;
-  animation-delay: 0s;
+@for $i from 1 through 5 {
+  $delay: nth($heartbeat-delays, $i);
+  .heartbeat .ring:nth-child(#{$i}) {
+    animation-name: heartbeat-motion-#{$i};
+    animation-delay: $delay;
+  }
+  .heartbeat .ring:nth-child(#{$i}) circle {
+    animation-name: heartbeat-stroke-#{$i};
+    animation-delay: $delay;
+  }
 }
 
 @mixin heartbeatGenerator($prefix) {
-  @keyframes heartbeat-#{$prefix} {
+  @keyframes heartbeat-motion-#{$prefix} {
     0% {
       transform: scale(1);
       opacity: 0.1;
@@ -373,12 +383,10 @@
     14% {
       transform: scale(1.08);
       opacity: 0.25;
-      stroke-width: 2;
     }
     28% {
       transform: scale(0.97);
       opacity: 0.15;
-      stroke-width: 1;
     }
     42% {
       transform: scale(1.04);
@@ -393,6 +401,20 @@
       opacity: 0.12;
     }
   }
+  @keyframes heartbeat-stroke-#{$prefix} {
+    0% {
+      stroke-width: 1;
+    }
+    14% {
+      stroke-width: 2;
+    }
+    28% {
+      stroke-width: 1;
+    }
+    100% {
+      stroke-width: 1;
+    }
+  }
 }
 
 @include heartbeatGenerator('1');
@@ -401,55 +423,57 @@
 @include heartbeatGenerator('4');
 @include heartbeatGenerator('5');
 
-// --------------------------------------------------
-// sonar animation
-// --------------------------------------------------
-.sonar circle {
-  stroke-width: 1.2;
+// sonar ---------------------------------------------
+$sonar-delays: 1.12s, 0.84s, 0.56s, 0.28s, 0s;
+
+.sonar .ring {
   opacity: 0;
   animation-timing-function: ease-out;
   animation-iteration-count: infinite;
   animation-duration: 2.8s;
-  transform-box: fill-box;
-  transform-origin: center;
+}
+.sonar .ring circle {
+  stroke-width: 1.2;
+  animation-timing-function: ease-out;
+  animation-iteration-count: infinite;
+  animation-duration: 2.8s;
 }
 
-.sonar circle:nth-child(1) {
-  animation-name: sonar-1;
-  animation-delay: 1.12s;
-}
-.sonar circle:nth-child(2) {
-  animation-name: sonar-2;
-  animation-delay: 0.84s;
-}
-.sonar circle:nth-child(3) {
-  animation-name: sonar-3;
-  animation-delay: 0.56s;
-}
-.sonar circle:nth-child(4) {
-  animation-name: sonar-4;
-  animation-delay: 0.28s;
-}
-.sonar circle:nth-child(5) {
-  animation-name: sonar-5;
-  animation-delay: 0s;
+@for $i from 1 through 5 {
+  $delay: nth($sonar-delays, $i);
+  .sonar .ring:nth-child(#{$i}) {
+    animation-name: sonar-motion-#{$i};
+    animation-delay: $delay;
+  }
+  .sonar .ring:nth-child(#{$i}) circle {
+    animation-name: sonar-stroke-#{$i};
+    animation-delay: $delay;
+  }
 }
 
 @mixin sonarGenerator($prefix) {
-  @keyframes sonar-#{$prefix} {
+  @keyframes sonar-motion-#{$prefix} {
     0% {
       opacity: 0;
       transform: scale(0.2);
-      stroke-width: 3;
     }
     12% {
       opacity: 0.45;
       transform: scale(1);
-      stroke-width: 1.2;
     }
     100% {
       opacity: 0;
       transform: scale(1.2);
+    }
+  }
+  @keyframes sonar-stroke-#{$prefix} {
+    0% {
+      stroke-width: 3;
+    }
+    12% {
+      stroke-width: 1.2;
+    }
+    100% {
       stroke-width: 0.3;
     }
   }
@@ -461,44 +485,27 @@
 @include sonarGenerator('4');
 @include sonarGenerator('5');
 
-// --------------------------------------------------
-// quake animation
-// --------------------------------------------------
-.quake circle {
-  stroke-width: 1;
+// quake ---------------------------------------------
+$quake-durations: 0.07s, 0.09s, 0.06s, 0.11s, 0.08s;
+
+.quake .ring {
   opacity: 0.1;
-  animation-duration: 0.1s;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
-  transform-box: fill-box;
-  transform-origin: center;
 }
 
-.quake circle:nth-child(odd) {
+.quake .ring:nth-child(odd) {
   animation-direction: alternate;
 }
-.quake circle:nth-child(even) {
+.quake .ring:nth-child(even) {
   animation-direction: alternate-reverse;
 }
-.quake circle:nth-child(1) {
-  animation-name: quake-1;
-  animation-duration: 0.07s;
-}
-.quake circle:nth-child(2) {
-  animation-name: quake-2;
-  animation-duration: 0.09s;
-}
-.quake circle:nth-child(3) {
-  animation-name: quake-3;
-  animation-duration: 0.06s;
-}
-.quake circle:nth-child(4) {
-  animation-name: quake-4;
-  animation-duration: 0.11s;
-}
-.quake circle:nth-child(5) {
-  animation-name: quake-5;
-  animation-duration: 0.08s;
+
+@for $i from 1 through 5 {
+  .quake .ring:nth-child(#{$i}) {
+    animation-name: quake-#{$i};
+    animation-duration: nth($quake-durations, $i);
+  }
 }
 
 @mixin quakeGenerator($prefix) {

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -176,65 +176,38 @@ export function TopBanner() {
           </div>
         </div>
 
-        <svg
+        {/*
+          Each ring is its own <svg> layer so the animations run purely on the
+          compositor (transform + opacity on the svg root) instead of animating
+          SVG sub-element geometry, which forces a full style/layout/paint pass
+          every frame and janks on mobile GPUs.
+        */}
+        <div
           className={`${styles.svgWave} ${colorClass} ${backgroundAnimation}`}
-          width="1000"
-          height="1000"
-          viewBox="0 0 1200 1200"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
         >
-          <circle
-            opacity="0.1"
-            cx="600"
-            cy="600"
-            r="500"
-            fill="#87CCE8"
-            stroke="#2B85AB"
-            strokeMiterlimit="16"
-            strokeDasharray="8 8"
-          />
-          <circle
-            opacity="0.1"
-            cx="600"
-            cy="600"
-            r="400"
-            fill="#87CCE8"
-            stroke="#2B85AB"
-            strokeMiterlimit="16"
-            strokeDasharray="8 8"
-          />
-          <circle
-            opacity="0.1"
-            cx="600"
-            cy="600"
-            r="300"
-            fill="#87CCE8"
-            stroke="#2B85AB"
-            strokeMiterlimit="16"
-            strokeDasharray="8 8"
-          />
-          <circle
-            opacity="0.1"
-            cx="600"
-            cy="600"
-            r="200"
-            fill="#87CCE8"
-            stroke="#2B85AB"
-            strokeMiterlimit="16"
-            strokeDasharray="8 8"
-          />
-          <circle
-            opacity="0.1"
-            cx="600"
-            cy="600"
-            r="100"
-            fill="#87CCE8"
-            stroke="#2B85AB"
-            strokeMiterlimit="16"
-            strokeDasharray="8 8"
-          />
-        </svg>
+          {[500, 400, 300, 200, 100].map((r) => (
+            <svg
+              key={r}
+              className={styles.ring}
+              width="1000"
+              height="1000"
+              viewBox="0 0 1200 1200"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="600"
+                cy="600"
+                r={r}
+                fill="#87CCE8"
+                stroke="#2B85AB"
+                strokeMiterlimit="16"
+                strokeDasharray="8 8"
+              />
+            </svg>
+          ))}
+        </div>
       </div>
 
       <SoundBar />

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -176,12 +176,6 @@ export function TopBanner() {
           </div>
         </div>
 
-        {/*
-          Each ring is its own <svg> layer so the animations run purely on the
-          compositor (transform + opacity on the svg root) instead of animating
-          SVG sub-element geometry, which forces a full style/layout/paint pass
-          every frame and janks on mobile GPUs.
-        */}
         <div
           className={`${styles.svgWave} ${colorClass} ${backgroundAnimation}`}
           aria-hidden="true"


### PR DESCRIPTION
## What & why

The landing hero phone has four emoji buttons, each triggering a different ring animation (wave / sonar / quake / heartbeat) drawn behind the phone. These were **laggy on phones but smooth on desktop**.

### Root cause (verified via Chrome DevTools traces, mobile viewport + 4× CPU throttle)
- The main thread stayed at ~119 fps even on the worst animation — **not** a JS/main-thread-blocking issue.
- The animations targeted **SVG sub-elements** (`<circle>` `transform` / `opacity` / `stroke-width`), which Blink **cannot composite**. So every frame ran the full render pipeline — `Layout` + `UpdateLayoutTree` + `Paint` firing ~240×/sec. A composited animation triggers *none* of these per frame.
- `will-change` / `contain` on SVG sub-elements does nothing (confirmed — Layout stayed at 239/sec).
- `stroke-width` (sonar/heartbeat) made it ~6× worse by re-tessellating the dashed strokes each frame.
- On mobile the SVG is forced to `width: 1300px` (vs 1000px desktop), enlarging the per-frame raster on a weaker GPU. Desktop's CPU/GPU absorbs all this; a phone can't → dropped frames.

## What changed

Restructured the single `<svg>` of 5 animated `<circle>`s into a wrapper `<div>` holding **5 independent `<svg>` ring layers**:
- `transform` + `opacity` now animate on the **`<svg>` roots** (compositable, with `will-change: transform, opacity`).
- `stroke-width` stays on the inner `<circle>` for sonar/heartbeat (not compositable), kept in lockstep with the motion via identical `duration` / `delay` / `timing-function`.
- Kept the wrapper `background-color: transparent` — the color classes (`.red`/`.yellow`/`.green`) are applied to the wrapper too, but only `.banner`'s background should show the color (it fades via `.banner`'s transition). Without this the wrapper snapped to the new color a few frames before the banner finished transitioning on each switch.

### Verified results (4× throttle, mobile)

| | Layout/s | Per-frame Layout cost |
|---|---|---|
| wave / quake (transform+opacity only) | 240 → **0** | 136ms → **0** (fully GPU-composited) |
| heartbeat | 206 → 66 | 840ms → **35ms** (24× less); style recalc 5× less |

## Visual behavior

Unchanged. Verified all four states (wave/sonar/quake/heartbeat) plus their colors and particle effects (stars/confetti/angels) render identically on mobile, and the desktop layout is intact. No console errors.

## Reviewer notes
- Takeaway worth keeping in mind for this page: only animate `transform`/`opacity` on HTML elements or `<svg>` **roots** — never `transform`/`stroke-width` on SVG sub-elements.
- The residual per-frame paint on sonar/heartbeat is the genuinely non-compositable `stroke-width` modulation, now confined to small per-ring layers instead of re-rastering the whole 1300px SVG. The always-running default (wave) is now fully composited.