### PR TITLE
fix(posthog): disable analytics in development

### DIFF
--- a/PulsarApp/src/config/posthog.ts
+++ b/PulsarApp/src/config/posthog.ts
@@ -5,6 +5,10 @@ const apiKey: string | undefined = POSTHOG_CONFIG.apiKey
 const host: string | undefined = POSTHOG_CONFIG.host
 const isPostHogConfigured = Boolean(apiKey && apiKey !== 'phc_your_api_key_here')
 
+// Only send events when configured AND not running in development, so dev
+// builds don't pollute production analytics.
+const isPostHogActive = isPostHogConfigured && !__DEV__
+
 if (__DEV__) {
   console.log('PostHog config:', {
     apiKey: apiKey ? 'SET' : 'NOT SET',
@@ -33,8 +37,8 @@ export const posthog = new PostHog(apiKey || 'placeholder_key', {
   // PostHog API host
   host,
 
-  // Disable PostHog if API key is not configured
-  disabled: !isPostHogConfigured,
+  // Disable PostHog if API key is not configured or in development
+  disabled: !isPostHogActive,
 
   // Capture app lifecycle events:
   // - Application Installed, Application Updated
@@ -58,4 +62,4 @@ export const posthog = new PostHog(apiKey || 'placeholder_key', {
   fetchRetryDelay: 3000,
 })
 
-export const isPostHogEnabled = isPostHogConfigured
+export const isPostHogEnabled = isPostHogActive

--- a/PulsarApp/src/config/posthog.ts
+++ b/PulsarApp/src/config/posthog.ts
@@ -5,8 +5,6 @@ const apiKey: string | undefined = POSTHOG_CONFIG.apiKey
 const host: string | undefined = POSTHOG_CONFIG.host
 const isPostHogConfigured = Boolean(apiKey && apiKey !== 'phc_your_api_key_here')
 
-// Only send events when configured AND not running in development, so dev
-// builds don't pollute production analytics.
 const isPostHogActive = isPostHogConfigured && !__DEV__
 
 if (__DEV__) {


### PR DESCRIPTION
## What

Gate PostHog event capture behind a `__DEV__` check so the mobile app no longer sends analytics to PostHog when running in development.

## Why

The only kill-switch in `PulsarApp/src/config/posthog.ts` was `disabled: !isPostHogConfigured`, which is driven solely by whether an API key is set. Since the key is hardcoded in `src/config/public.ts`, `isPostHogConfigured` was always `true`, so dev builds were sending events straight to the production PostHog instance (`us.i.posthog.com`) — polluting production analytics.

## Changes

- Add `isPostHogActive = isPostHogConfigured && !__DEV__`.
- Use `disabled: !isPostHogActive` so PostHog no-ops in development.
- Export `isPostHogEnabled` from `isPostHogActive` so downstream gating stays consistent.
- Keep `isPostHogConfigured` separate so the "API key not configured" warning only fires when the key is genuinely missing — not on every dev run.

## Notes for reviewers

- Production builds are unchanged (`__DEV__` is `false`), so capture behaves exactly as before in release.
- The web/docs app already opts out by default via consent and is not touched.