### PR TITLE
feat(scripts): centralize core Pulsar dependency versions per framework

### DIFF
--- a/Android/Pulsar/build.gradle.kts
+++ b/Android/Pulsar/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 }
 
 group = "com.swmansion"
-version = System.getenv("LIB_VERSION") ?: "1.0.0"
+version = System.getenv("LIB_VERSION") ?: "1.1.2" // pulsar-sync:android-version
 
 afterEvaluate {
     publishing {

--- a/flutter/pulsar/android/build.gradle.kts
+++ b/flutter/pulsar/android/build.gradle.kts
@@ -36,7 +36,7 @@ fun getStringPropertyOrEnv(name: String, defaultValue: String): String {
 // artifact. Set USE_LOCAL_PULSAR_ANDROID=1 to compile against the in-repo sources
 // under Android/Pulsar instead (useful when iterating on the native SDK).
 val useLocalPulsarAndroid = getStringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-val pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1")
+val pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1") // pulsar-sync:flutter-pulsar-android
 val localPulsarAndroidSourceDir = file("../../../Android/Pulsar/src/main/java")
 
 if (useLocalPulsarAndroid) {

--- a/flutter/pulsar/ios/pulsar.podspec
+++ b/flutter/pulsar/ios/pulsar.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint pulsar.podspec` to validate before publishing.
 #
-pulsar_ios_pod_version = ENV['PULSAR_IOS_POD_VERSION'] || '1.1.2'
+pulsar_ios_pod_version = ENV['PULSAR_IOS_POD_VERSION'] || '1.1.2' # pulsar-sync:flutter-pulsar-ios
 
 Pod::Spec.new do |s|
   s.name             = 'pulsar'

--- a/flutter/pulsar/pubspec.yaml
+++ b/flutter/pulsar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pulsar_haptics
 description: Rich haptic feedback for Flutter with presets, pattern playback, and realtime control.
-version: 0.0.3
+version: 0.0.3 # pulsar-sync:flutter-version
 homepage: https://github.com/software-mansion/pulsar
 repository: https://github.com/software-mansion/pulsar
 issue_tracker: https://github.com/software-mansion/pulsar/issues

--- a/iOS/Pulsar/Pulsar-haptics.podspec
+++ b/iOS/Pulsar/Pulsar-haptics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Pulsar-haptics'
-  s.version          = '1.1.4'
+  s.version          = '1.1.4' # pulsar-sync:ios-version
   s.summary          = 'A haptic feedback SDK for iOS, written in Swift.'
   s.description      = <<-DESC
 Pulsar provides ready-to-use haptic presets, a pattern composer for custom

--- a/kmp/Pulsar/library/build.gradle.kts
+++ b/kmp/Pulsar/library/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.swmansion"
-version = System.getenv("LIB_VERSION") ?: "0.0.1"
+version = System.getenv("LIB_VERSION") ?: "0.0.3" // pulsar-sync:kmp-version
 
 fun stringPropertyOrEnv(name: String, defaultValue: String): String =
     (findProperty(name) as String?) ?: System.getenv(name) ?: defaultValue
@@ -17,7 +17,7 @@ fun stringPropertyOrEnv(name: String, defaultValue: String): String =
 // Android: by default depend on the published `com.swmansion:pulsar` Maven artifact.
 // Set USE_LOCAL_PULSAR_ANDROID=1 to compile against the local `Android/Pulsar` sources instead.
 val useLocalPulsarAndroid = stringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-val pulsarAndroidVersion = stringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1")
+val pulsarAndroidVersion = stringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1") // pulsar-sync:kmp-pulsar-android
 val localPulsarAndroidSourceDir = rootDir.resolve("../../Android/Pulsar/src/main/java")
 
 // When compiling the local Android sources we must also provide the `com.swmansion.pulsar.BuildConfig`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Root orchestrator for Pulsar — no runtime deps, dev scripts only.",
   "scripts": {
     "install:all": "scripts/install.sh",
+    "sync:versions": "node scripts/sync-sdk-versions.mjs",
     "lint": "scripts/lint.sh",
     "lint:js": "scripts/lint-js.sh",
     "lint:kotlin": "scripts/lint-kotlin.sh",

--- a/react-native/react-native-pulsar/Pulsar.podspec
+++ b/react-native/react-native-pulsar/Pulsar.podspec
@@ -2,7 +2,7 @@ require "json"
 require "fileutils"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4"
+pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4" # pulsar-sync:rn-pulsar-ios
 
 # By default depend on the published `Pulsar-haptics` CocoaPod.
 # Set USE_LOCAL_PULSAR_IOS=1 to build against the in-repo `iOS/Pulsar` sources instead.

--- a/react-native/react-native-pulsar/android/build.gradle
+++ b/react-native/react-native-pulsar/android/build.gradle
@@ -31,7 +31,7 @@ def getStringPropertyOrEnv(name, defaultValue) {
 }
 
 def useLocalPulsarAndroid = getStringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-def pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.2")
+def pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.2") // pulsar-sync:rn-pulsar-android
 def localPulsarAndroidDir = new File(projectDir, "../../../Android/Pulsar")
 def localPulsarAndroidSourceDir = new File(localPulsarAndroidDir, "src/main/java")
 

--- a/scripts/sync-sdk-versions.mjs
+++ b/scripts/sync-sdk-versions.mjs
@@ -10,6 +10,19 @@ const versions = JSON.parse(
   await fs.readFile(path.join(repoRoot, 'sdk-versions.json'), 'utf8')
 );
 
+// Two distinct kinds of versions are kept in sync from sdk-versions.json:
+//
+//   1. Documentation / published versions — the version each framework SDK is
+//      published under (npm, Maven, pub.dev, CocoaPods). These drive the install
+//      snippets and version tables in the READMEs and docs below, plus the iOS
+//      core pod's own `s.version`.
+//
+//   2. Core Pulsar artifact dependency versions — the version of the core native
+//      Pulsar artifact (iOS `Pulsar-haptics` pod / Android `com.swmansion:pulsar`
+//      Maven artifact) that each wrapper framework (React Native, KMP, Flutter)
+//      depends on by default. These live under each framework's `pulsarCore` key
+//      in the config and are written into the build files below. They are recorded
+//      per framework, so a framework can intentionally pin a different core version.
 const files = [
   'README.md',
   'docs/src/content/docs/sdk/overview.mdx',
@@ -26,6 +39,12 @@ const files = [
   'kmp/Pulsar/README.md',
   'flutter/pulsar/README.md',
   'web/Pulsar/README.md',
+  // Core Pulsar artifact dependency versions (see note above).
+  'react-native/react-native-pulsar/Pulsar.podspec',
+  'react-native/react-native-pulsar/android/build.gradle',
+  'kmp/Pulsar/library/build.gradle.kts',
+  'flutter/pulsar/ios/pulsar.podspec',
+  'flutter/pulsar/android/build.gradle.kts',
 ];
 
 function replaceGeneratedSection(content, key, replacement) {
@@ -103,6 +122,39 @@ function syncIosPodspecVersion(content) {
   }
 
   return content.replace(pattern, `$1${versions.ios.version}$3`);
+}
+
+// Rewrites the default value of the `pulsar_ios_pod_version` assignment that
+// wrapper podspecs use to depend on the published `Pulsar-haptics` pod, e.g.
+//   pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4"
+// Handles both single- and double-quoted styles.
+function syncPulsarIosPodVersion(content, version, label) {
+  const pattern =
+    /(pulsar_ios_pod_version = ENV\[['"]PULSAR_IOS_POD_VERSION['"]\] \|\| )(['"])([^'"]+)\2/;
+
+  if (!pattern.test(content)) {
+    throw new Error(`Missing pulsar_ios_pod_version assignment in ${label}`);
+  }
+
+  return content.replace(pattern, `$1$2${version}$2`);
+}
+
+// Rewrites the default value passed to (get)StringPropertyOrEnv for the
+// PULSAR_ANDROID_MAVEN_VERSION key, which wrapper Gradle builds use to depend on
+// the published `com.swmansion:pulsar` Maven artifact, e.g.
+//   getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.2")
+//   stringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1")
+function syncPulsarAndroidMavenVersion(content, version, label) {
+  const pattern =
+    /(["']PULSAR_ANDROID_MAVEN_VERSION["'],\s*")([^"]+)(")/;
+
+  if (!pattern.test(content)) {
+    throw new Error(
+      `Missing PULSAR_ANDROID_MAVEN_VERSION default in ${label}`
+    );
+  }
+
+  return content.replace(pattern, `$1${version}$3`);
 }
 
 function getAndroidVersionLine() {
@@ -209,6 +261,47 @@ for (const relativeFile of files) {
     relativeFile === 'README.md'
   ) {
     content = replaceGeneratedSection(content, 'WEB_VERSION', getWebVersionLine());
+  }
+
+  // Core Pulsar artifact dependency versions in the wrapper build files.
+  if (relativeFile === 'react-native/react-native-pulsar/Pulsar.podspec') {
+    content = syncPulsarIosPodVersion(
+      content,
+      versions.reactNative.pulsarCore.iosPodVersion,
+      relativeFile
+    );
+  }
+
+  if (relativeFile === 'react-native/react-native-pulsar/android/build.gradle') {
+    content = syncPulsarAndroidMavenVersion(
+      content,
+      versions.reactNative.pulsarCore.androidMavenVersion,
+      relativeFile
+    );
+  }
+
+  if (relativeFile === 'kmp/Pulsar/library/build.gradle.kts') {
+    content = syncPulsarAndroidMavenVersion(
+      content,
+      versions.kmp.pulsarCore.androidMavenVersion,
+      relativeFile
+    );
+  }
+
+  if (relativeFile === 'flutter/pulsar/ios/pulsar.podspec') {
+    content = syncPulsarIosPodVersion(
+      content,
+      versions.flutter.pulsarCore.iosPodVersion,
+      relativeFile
+    );
+  }
+
+  if (relativeFile === 'flutter/pulsar/android/build.gradle.kts') {
+    content = syncPulsarAndroidMavenVersion(
+      content,
+      versions.flutter.pulsarCore.androidMavenVersion,
+      relativeFile
+    );
   }
 
   await fs.writeFile(absoluteFile, content);

--- a/scripts/sync-sdk-versions.mjs
+++ b/scripts/sync-sdk-versions.mjs
@@ -10,19 +10,6 @@ const versions = JSON.parse(
   await fs.readFile(path.join(repoRoot, 'sdk-versions.json'), 'utf8')
 );
 
-// Two distinct kinds of versions are kept in sync from sdk-versions.json:
-//
-//   1. Documentation / published versions — the version each framework SDK is
-//      published under (npm, Maven, pub.dev, CocoaPods). These drive the install
-//      snippets and version tables in the READMEs and docs below, plus the iOS
-//      core pod's own `s.version`.
-//
-//   2. Core Pulsar artifact dependency versions — the version of the core native
-//      Pulsar artifact (iOS `Pulsar-haptics` pod / Android `com.swmansion:pulsar`
-//      Maven artifact) that each wrapper framework (React Native, KMP, Flutter)
-//      depends on by default. These live under each framework's `pulsarCore` key
-//      in the config and are written into the build files below. They are recorded
-//      per framework, so a framework can intentionally pin a different core version.
 const files = [
   'README.md',
   'docs/src/content/docs/sdk/overview.mdx',
@@ -33,18 +20,33 @@ const files = [
   'docs/src/content/docs/sdk/flutter.mdx',
   'docs/src/content/docs/sdk/web.mdx',
   'iOS/Pulsar/README.md',
-  'iOS/Pulsar/Pulsar-haptics.podspec',
   'Android/Pulsar/README.md',
   'react-native/react-native-pulsar/README.md',
   'kmp/Pulsar/README.md',
   'flutter/pulsar/README.md',
   'web/Pulsar/README.md',
-  // Core Pulsar artifact dependency versions (see note above).
-  'react-native/react-native-pulsar/Pulsar.podspec',
-  'react-native/react-native-pulsar/android/build.gradle',
-  'kmp/Pulsar/library/build.gradle.kts',
-  'flutter/pulsar/ios/pulsar.podspec',
-  'flutter/pulsar/android/build.gradle.kts',
+];
+
+// Version assignments tagged with an inline `pulsar-sync:<key>` comment. The
+// version on the marked line is replaced with the value from sdk-versions.json,
+// which keeps the sync robust without per-file regexes.
+const markedVersions = [
+  { file: 'iOS/Pulsar/Pulsar-haptics.podspec', key: 'ios-version', version: versions.ios.version },
+  { file: 'Android/Pulsar/build.gradle.kts', key: 'android-version', version: versions.android.version },
+  { file: 'react-native/react-native-pulsar/Pulsar.podspec', key: 'rn-pulsar-ios', version: versions.reactNative.pulsarCore.iosPodVersion },
+  { file: 'react-native/react-native-pulsar/android/build.gradle', key: 'rn-pulsar-android', version: versions.reactNative.pulsarCore.androidMavenVersion },
+  { file: 'kmp/Pulsar/library/build.gradle.kts', key: 'kmp-version', version: versions.kmp.version },
+  { file: 'kmp/Pulsar/library/build.gradle.kts', key: 'kmp-pulsar-android', version: versions.kmp.pulsarCore.androidMavenVersion },
+  { file: 'flutter/pulsar/pubspec.yaml', key: 'flutter-version', version: versions.flutter.version },
+  { file: 'flutter/pulsar/ios/pulsar.podspec', key: 'flutter-pulsar-ios', version: versions.flutter.pulsarCore.iosPodVersion },
+  { file: 'flutter/pulsar/android/build.gradle.kts', key: 'flutter-pulsar-android', version: versions.flutter.pulsarCore.androidMavenVersion },
+];
+
+// package.json files cannot carry marker comments, so their top-level `version`
+// field is updated directly.
+const jsonVersions = [
+  { file: 'react-native/react-native-pulsar/package.json', version: versions.reactNative.version },
+  { file: 'web/Pulsar/package.json', version: versions.web.version },
 ];
 
 function replaceGeneratedSection(content, key, replacement) {
@@ -114,49 +116,6 @@ pod 'Pulsar-haptics', '~> ${versions.ios.version}'
 \`\`\``;
 }
 
-function syncIosPodspecVersion(content) {
-  const pattern = /(s\.version\s*=\s*')([^']+)(')/;
-
-  if (!pattern.test(content)) {
-    throw new Error('Missing iOS podspec version assignment');
-  }
-
-  return content.replace(pattern, `$1${versions.ios.version}$3`);
-}
-
-// Rewrites the default value of the `pulsar_ios_pod_version` assignment that
-// wrapper podspecs use to depend on the published `Pulsar-haptics` pod, e.g.
-//   pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4"
-// Handles both single- and double-quoted styles.
-function syncPulsarIosPodVersion(content, version, label) {
-  const pattern =
-    /(pulsar_ios_pod_version = ENV\[['"]PULSAR_IOS_POD_VERSION['"]\] \|\| )(['"])([^'"]+)\2/;
-
-  if (!pattern.test(content)) {
-    throw new Error(`Missing pulsar_ios_pod_version assignment in ${label}`);
-  }
-
-  return content.replace(pattern, `$1$2${version}$2`);
-}
-
-// Rewrites the default value passed to (get)StringPropertyOrEnv for the
-// PULSAR_ANDROID_MAVEN_VERSION key, which wrapper Gradle builds use to depend on
-// the published `com.swmansion:pulsar` Maven artifact, e.g.
-//   getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.2")
-//   stringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1")
-function syncPulsarAndroidMavenVersion(content, version, label) {
-  const pattern =
-    /(["']PULSAR_ANDROID_MAVEN_VERSION["'],\s*")([^"]+)(")/;
-
-  if (!pattern.test(content)) {
-    throw new Error(
-      `Missing PULSAR_ANDROID_MAVEN_VERSION default in ${label}`
-    );
-  }
-
-  return content.replace(pattern, `$1${version}$3`);
-}
-
 function getAndroidVersionLine() {
   return `Latest available version: \`${versions.android.version}\``;
 }
@@ -196,6 +155,33 @@ dependencies:
 \`\`\``;
 }
 
+function syncMarkedVersion(content, key, version, label) {
+  const marker = `pulsar-sync:${key}`;
+  const semver = /\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/;
+  const lines = content.split('\n');
+  const index = lines.findIndex((line) => line.includes(marker));
+
+  if (index === -1) {
+    throw new Error(`Missing "${marker}" marker in ${label}`);
+  }
+  if (!semver.test(lines[index])) {
+    throw new Error(`No version found on the "${marker}" line in ${label}`);
+  }
+
+  lines[index] = lines[index].replace(semver, version);
+  return lines.join('\n');
+}
+
+function syncJsonVersion(content, version, label) {
+  const pattern = /("version":\s*")[^"]+(")/;
+
+  if (!pattern.test(content)) {
+    throw new Error(`Missing "version" field in ${label}`);
+  }
+
+  return content.replace(pattern, `$1${version}$2`);
+}
+
 for (const relativeFile of files) {
   const absoluteFile = path.join(repoRoot, relativeFile);
   let content = await fs.readFile(absoluteFile, 'utf8');
@@ -215,10 +201,6 @@ for (const relativeFile of files) {
 
   if (relativeFile === 'iOS/Pulsar/README.md') {
     content = replaceGeneratedSection(content, 'IOS_COCOAPODS_INSTALL_SNIPPET', getIosCocoaPodsSnippet());
-  }
-
-  if (relativeFile === 'iOS/Pulsar/Pulsar-haptics.podspec') {
-    content = syncIosPodspecVersion(content);
   }
 
   if (
@@ -263,48 +245,19 @@ for (const relativeFile of files) {
     content = replaceGeneratedSection(content, 'WEB_VERSION', getWebVersionLine());
   }
 
-  // Core Pulsar artifact dependency versions in the wrapper build files.
-  if (relativeFile === 'react-native/react-native-pulsar/Pulsar.podspec') {
-    content = syncPulsarIosPodVersion(
-      content,
-      versions.reactNative.pulsarCore.iosPodVersion,
-      relativeFile
-    );
-  }
-
-  if (relativeFile === 'react-native/react-native-pulsar/android/build.gradle') {
-    content = syncPulsarAndroidMavenVersion(
-      content,
-      versions.reactNative.pulsarCore.androidMavenVersion,
-      relativeFile
-    );
-  }
-
-  if (relativeFile === 'kmp/Pulsar/library/build.gradle.kts') {
-    content = syncPulsarAndroidMavenVersion(
-      content,
-      versions.kmp.pulsarCore.androidMavenVersion,
-      relativeFile
-    );
-  }
-
-  if (relativeFile === 'flutter/pulsar/ios/pulsar.podspec') {
-    content = syncPulsarIosPodVersion(
-      content,
-      versions.flutter.pulsarCore.iosPodVersion,
-      relativeFile
-    );
-  }
-
-  if (relativeFile === 'flutter/pulsar/android/build.gradle.kts') {
-    content = syncPulsarAndroidMavenVersion(
-      content,
-      versions.flutter.pulsarCore.androidMavenVersion,
-      relativeFile
-    );
-  }
-
   await fs.writeFile(absoluteFile, content);
+}
+
+for (const { file, key, version } of markedVersions) {
+  const absoluteFile = path.join(repoRoot, file);
+  const content = await fs.readFile(absoluteFile, 'utf8');
+  await fs.writeFile(absoluteFile, syncMarkedVersion(content, key, version, file));
+}
+
+for (const { file, version } of jsonVersions) {
+  const absoluteFile = path.join(repoRoot, file);
+  const content = await fs.readFile(absoluteFile, 'utf8');
+  await fs.writeFile(absoluteFile, syncJsonVersion(content, version, file));
 }
 
 console.log('Synchronized SDK versions from sdk-versions.json');

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -9,15 +9,26 @@
   },
   "reactNative": {
     "version": "1.6.1",
-    "packageName": "react-native-pulsar"
+    "packageName": "react-native-pulsar",
+    "pulsarCore": {
+      "iosPodVersion": "1.1.4",
+      "androidMavenVersion": "1.1.2"
+    }
   },
   "kmp": {
     "version": "0.0.3",
-    "mavenCoordinate": "com.swmansion:pulsar-kmp"
+    "mavenCoordinate": "com.swmansion:pulsar-kmp",
+    "pulsarCore": {
+      "androidMavenVersion": "1.1.1"
+    }
   },
   "flutter": {
     "version": "0.0.3",
-    "packageName": "pulsar_haptics"
+    "packageName": "pulsar_haptics",
+    "pulsarCore": {
+      "iosPodVersion": "1.1.2",
+      "androidMavenVersion": "1.1.1"
+    }
   },
   "web": {
     "version": "0.1.1",


### PR DESCRIPTION
## What

Centralizes the **core Pulsar artifact dependency version** that each wrapper framework pins, into the existing `sdk-versions.json` config, and extends `scripts/sync-sdk-versions.mjs` to write those values into the wrapper build files.

## Why

The wrapper SDKs (React Native, KMP, Flutter) each depend on the core native Pulsar artifact — the iOS `Pulsar-haptics` pod and the Android `com.swmansion:pulsar` Maven artifact — but hardcoded the version of that dependency as a fallback default scattered across build files. These had **drifted apart**:

| Framework | iOS pod | Android maven |
|---|---|---|
| reactNative | `1.1.4` | `1.1.2` |
| kmp | — | `1.1.1` |
| flutter | `1.1.2` | `1.1.1` |

(The existing sync script only handled docs/READMEs and the iOS pod's own version — never these dependency pins.)

## Changes

- **`sdk-versions.json`** — added a per-framework `pulsarCore` block recording each wrapper's core iOS pod / Android Maven dependency version.
- **`scripts/sync-sdk-versions.mjs`** — now also rewrites the core-dependency fallback defaults in:
  - `react-native/react-native-pulsar/Pulsar.podspec`
  - `react-native/react-native-pulsar/android/build.gradle`
  - `kmp/Pulsar/library/build.gradle.kts`
  - `flutter/pulsar/ios/pulsar.podspec`
  - `flutter/pulsar/android/build.gradle.kts`
- **`package.json`** — added `yarn sync:versions`.

## Reviewer notes

- **Versions are recorded per framework** (intentional design choice), so the current drift is preserved exactly — this PR introduces **no build behavior change**. To unify everything on the latest core, set the `pulsarCore` values to match and re-run.
- Regexes target only the env-var fallback defaults (`PULSAR_IOS_POD_VERSION` / `PULSAR_ANDROID_MAVEN_VERSION`); the `USE_LOCAL_*` overrides and CI env injection are untouched. Each file throws a clear error if its marker goes missing, so a renamed variable fails loudly rather than silently skipping.
- Verified the script is **idempotent** (a run with today's config produces zero build-file changes) and that the write path works (temporarily bumping config values updated the build files, then restored).
