### PR TITLE
docs: fix broken README banner image (/blob/ → /raw/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/software-mansion/pulsar/blob/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
+  <img src="https://github.com/software-mansion/pulsar/raw/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
 </p>
 
 A haptic feedback SDK for iOS, Android, React Native, Kotlin Multiplatform, Flutter, and the Web. Pulsar provides ready-to-use haptic presets, a pattern composer for custom haptic sequences, and a real-time composer for gesture-driven feedback.

--- a/flutter/pulsar/README.md
+++ b/flutter/pulsar/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/software-mansion/pulsar/blob/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
+  <img src="https://github.com/software-mansion/pulsar/raw/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
 </p>
 
 A haptic feedback SDK for Flutter. Pulsar gives you 150+ ready-to-play presets, a pattern composer for fully custom sequences, and a realtime composer for gesture-driven feedback — all behind a single Dart-friendly API that bridges to native CoreHaptics on iOS and the platform vibrator on Android.

--- a/react-native/react-native-pulsar/README.md
+++ b/react-native/react-native-pulsar/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/software-mansion/pulsar/blob/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
+  <img src="https://github.com/software-mansion/pulsar/raw/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
 </p>
 
 A haptic feedback SDK for React Native. Pulsar provides ready-to-use haptic presets, a pattern composer for custom haptic sequences, and a real-time composer for gesture-driven feedback.

--- a/web/Pulsar/README.md
+++ b/web/Pulsar/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/software-mansion/pulsar/blob/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
+  <img src="https://github.com/software-mansion/pulsar/raw/main/docs/src/assets/og.png" alt="Pulsar - Rich and ready-to use haptics library" />
 </p>
 
 # pulsar-haptics


### PR DESCRIPTION
## What

Switch the README banner image URL from GitHub's `/blob/` form to `/raw/` across all framework READMEs.

## Why

The banner referenced the `og.png` asset via `https://github.com/software-mansion/pulsar/blob/main/docs/src/assets/og.png`. A `/blob/` URL returns the GitHub **web page** (`content-type: text/html`), not the image. Verified with `curl`:

- `/blob/...` → `content-type: text/html`
- `/raw/...`  → `content-type: image/png` ✅

This breaks the banner on **pub.dev** (the Flutter `pulsar_haptics` package), because pub.dev embeds the `<img src>` as-is and does not rewrite GitHub blob URLs. npm happens to rewrite blob→raw automatically (via its markdown sanitizer), so React Native rendered fine — but `/raw/` is correct and portable for every renderer.

## Changes

Updated banner URL in:
- `README.md`
- `flutter/pulsar/README.md` (the one actually broken on pub.dev)
- `react-native/react-native-pulsar/README.md`
- `web/Pulsar/README.md`

`iOS/Pulsar/README.md` and `Android/Pulsar/README.md` already used `/raw/` and were left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)