### PR TITLE
feat(react-native): ship ready-to-use Jest mock for react-native-pulsar

### DIFF
--- a/docs/src/content/docs/sdk/react-native.mdx
+++ b/docs/src/content/docs/sdk/react-native.mdx
@@ -686,3 +686,93 @@ import { Settings, RealtimeComposerStrategy } from 'react-native-pulsar';
 
 Settings.setRealtimeComposerStrategy(RealtimeComposerStrategy.PRIMITIVE_COMPLEX);
 ```
+
+---
+
+## Testing with Jest
+
+`react-native-pulsar` is backed by a TurboModule and relies on `react-native-worklets`. In a Jest environment there is no native module to bind to, so importing the library directly throws (`TurboModuleRegistry.getEnforcing('RNPulsar')` cannot find the native module). To keep tests for components that use Pulsar running on Node, the package ships a ready-to-use mock.
+
+### Ready-to-use mock
+
+The mock lives at `react-native-pulsar/jest-mock`. It replaces the entire public API — `Presets`, `Settings`, the hooks, and the enums — with no-op [`jest.fn()`](https://jestjs.io/docs/mock-functions) implementations, so nothing tries to reach a native module. You don't have to enumerate the 150+ presets yourself: every preset (at any nesting depth, e.g. `Presets.System.Android.effectClick`) is a `jest.fn()` you can assert on.
+
+Wire it up with `jest.mock`, either per test file or globally for the whole suite.
+
+<Tabs>
+  <TabItem label="Per test file">
+    Add this at the top of any test file that imports `react-native-pulsar`:
+
+    ```ts
+    jest.mock('react-native-pulsar', () =>
+      require('react-native-pulsar/jest-mock')
+    );
+    ```
+  </TabItem>
+  <TabItem label="Globally">
+    Register the mock once in a Jest setup file so it applies to every test.
+
+    ```js
+    // jest.setup.js
+    jest.mock('react-native-pulsar', () =>
+      require('react-native-pulsar/jest-mock')
+    );
+    ```
+
+    Then reference that file from your Jest config:
+
+    ```js
+    // jest.config.js
+    module.exports = {
+      preset: 'react-native',
+      setupFiles: ['<rootDir>/jest.setup.js'],
+    };
+    ```
+  </TabItem>
+</Tabs>
+
+### Asserting that haptics fired
+
+Because every export is a `jest.fn()`, you can assert that your component triggered the haptic you expect:
+
+```tsx
+import { render, fireEvent } from '@testing-library/react-native';
+import { Presets } from 'react-native-pulsar';
+import LikeButton from '../LikeButton';
+
+jest.mock('react-native-pulsar', () =>
+  require('react-native-pulsar/jest-mock')
+);
+
+it('plays a success haptic when liked', () => {
+  const { getByRole } = render(<LikeButton />);
+
+  fireEvent.press(getByRole('button'));
+
+  expect(Presets.System.notificationSuccess).toHaveBeenCalledTimes(1);
+});
+```
+
+The hooks are mocked too. `useRealtimeComposer`, `usePatternComposer`, and `useAdaptiveHaptics` each return an object whose methods (`play`, `stop`, `set`, …) are `jest.fn()`s, so components that call them render without errors.
+
+### Customizing return values
+
+The mock ships with sensible defaults — for example `Settings.getHapticsSupportLevel()` returns `HapticSupport.ADVANCED_SUPPORT`, and `isActive()` / `isParsed()` return `false`. Override any of them in a test when you need to exercise a different code path:
+
+```ts
+import { Settings, HapticSupport } from 'react-native-pulsar';
+
+jest.mock('react-native-pulsar', () =>
+  require('react-native-pulsar/jest-mock')
+);
+
+it('falls back when the device has no haptics', () => {
+  (Settings.getHapticsSupportLevel as jest.Mock).mockReturnValue(
+    HapticSupport.NO_SUPPORT
+  );
+
+  // ...assert your fallback UI / behavior
+});
+```
+
+Call `jest.clearAllMocks()` in `afterEach` (or set `clearMocks: true` in your Jest config) to reset call counts between tests.

--- a/react-native/react-native-pulsar/jest-mock.js
+++ b/react-native/react-native-pulsar/jest-mock.js
@@ -1,0 +1,123 @@
+/**
+ * Ready-to-use Jest mock for `react-native-pulsar`.
+ *
+ * `react-native-pulsar` is backed by a TurboModule, so importing it inside a
+ * Jest environment throws (`TurboModuleRegistry.getEnforcing('RNPulsar')`
+ * cannot find the native module, and the hooks rely on `react-native-worklets`).
+ * This mock replaces the whole public API with no-op `jest.fn()`s so tests that
+ * render components using Pulsar can run on Node without a device.
+ *
+ * Usage (see the React Native SDK docs for details):
+ *
+ *   jest.mock('react-native-pulsar', () =>
+ *     require('react-native-pulsar/jest-mock')
+ *   );
+ *
+ * or globally, from a Jest `setupFiles` entry:
+ *
+ *   jest.mock('react-native-pulsar', () =>
+ *     require('react-native-pulsar/jest-mock')
+ *   );
+ */
+
+// Enums are real values (mirrors src/NativeRNPulsar.ts) so comparisons keep
+// working in tests.
+const HapticSupport = {
+  NO_SUPPORT: 0,
+  LIMITED_SUPPORT: 1,
+  STANDARD_SUPPORT: 2,
+  ADVANCED_SUPPORT: 3,
+};
+
+const RealtimeComposerStrategy = {
+  ENVELOPE: 0,
+  PRIMITIVE_TICK: 1,
+  PRIMITIVE_COMPLEX: 2,
+  ENVELOPE_WITH_DISCRETE_PRIMITIVES: 3,
+};
+
+/**
+ * Builds a deeply nested mock that is both callable and traversable. Every leaf
+ * is a stable `jest.fn()`, and intermediate nodes (e.g. `Presets.System`) are
+ * proxies, so any path you reach is a `jest.fn()` you can assert on:
+ *
+ *   Presets.System.impactLight();
+ *   expect(Presets.System.impactLight).toHaveBeenCalled();
+ *
+ * Children are cached per path, so repeated access returns the same mock.
+ */
+function createDeepMock() {
+  const cache = new Map();
+  const target = jest.fn();
+  return new Proxy(target, {
+    get(fn, prop) {
+      if (prop === '__isPulsarMock') {
+        return true;
+      }
+      // `received.calls` is how Jest sniffs for a Jasmine spy. A jest.fn() has
+      // no `calls` of its own, so without this guard the catch-all below would
+      // hand back a truthy callable and Jest would mis-detect every leaf as a
+      // spy, breaking matchers like `toHaveBeenCalledTimes`.
+      if (prop === 'calls') {
+        return undefined;
+      }
+      // Preserve jest.fn() internals (mock, mockReturnValue, _isMockFunction, …)
+      // and symbol access (e.g. Symbol.iterator) so the leaf behaves like a fn.
+      if (typeof prop === 'symbol' || prop in fn) {
+        return fn[prop];
+      }
+      if (!cache.has(prop)) {
+        cache.set(prop, createDeepMock());
+      }
+      return cache.get(prop);
+    },
+  });
+}
+
+// `Presets` has 150+ nested entries; the deep mock covers all of them without
+// having to enumerate every preset name.
+const Presets = createDeepMock();
+
+const Settings = {
+  enableHaptics: jest.fn(),
+  enableSound: jest.fn(),
+  enableCache: jest.fn(),
+  clearCache: jest.fn(),
+  preloadPresets: jest.fn(),
+  stopHaptics: jest.fn(),
+  shutDownEngine: jest.fn(),
+  getHapticsSupportLevel: jest.fn(() => HapticSupport.ADVANCED_SUPPORT),
+  forceHapticsSupportLevel: jest.fn(),
+  enableImpulseCompositionMode: jest.fn(),
+  setRealtimeComposerStrategy: jest.fn(),
+};
+
+const useRealtimeComposer = jest.fn(() => ({
+  start: jest.fn(),
+  set: jest.fn(),
+  playDiscrete: jest.fn(),
+  stop: jest.fn(),
+  isActive: jest.fn(() => false),
+}));
+
+const usePatternComposer = jest.fn(() => ({
+  play: jest.fn(),
+  stop: jest.fn(),
+  parse: jest.fn(),
+  isParsed: jest.fn(() => false),
+}));
+
+const useAdaptiveHaptics = jest.fn(() => ({
+  play: jest.fn(),
+}));
+
+module.exports = {
+  __esModule: true,
+  Presets,
+  Settings,
+  useRealtimeComposer,
+  usePatternComposer,
+  useAdaptiveHaptics,
+  HapticSupport,
+  RealtimeComposerStrategy,
+};

--- a/react-native/react-native-pulsar/jest-mock.js
+++ b/react-native/react-native-pulsar/jest-mock.js
@@ -1,27 +1,12 @@
 /**
- * Ready-to-use Jest mock for `react-native-pulsar`.
- *
- * `react-native-pulsar` is backed by a TurboModule, so importing it inside a
- * Jest environment throws (`TurboModuleRegistry.getEnforcing('RNPulsar')`
- * cannot find the native module, and the hooks rely on `react-native-worklets`).
- * This mock replaces the whole public API with no-op `jest.fn()`s so tests that
- * render components using Pulsar can run on Node without a device.
- *
- * Usage (see the React Native SDK docs for details):
- *
- *   jest.mock('react-native-pulsar', () =>
- *     require('react-native-pulsar/jest-mock')
- *   );
- *
- * or globally, from a Jest `setupFiles` entry:
+ * Ready-to-use Jest mock for `react-native-pulsar`. Replaces the whole public
+ * API with no-op `jest.fn()`s so tests can run on Node without a native module.
  *
  *   jest.mock('react-native-pulsar', () =>
  *     require('react-native-pulsar/jest-mock')
  *   );
  */
 
-// Enums are real values (mirrors src/NativeRNPulsar.ts) so comparisons keep
-// working in tests.
 const HapticSupport = {
   NO_SUPPORT: 0,
   LIMITED_SUPPORT: 1,
@@ -36,33 +21,19 @@ const RealtimeComposerStrategy = {
   ENVELOPE_WITH_DISCRETE_PRIMITIVES: 3,
 };
 
-/**
- * Builds a deeply nested mock that is both callable and traversable. Every leaf
- * is a stable `jest.fn()`, and intermediate nodes (e.g. `Presets.System`) are
- * proxies, so any path you reach is a `jest.fn()` you can assert on:
- *
- *   Presets.System.impactLight();
- *   expect(Presets.System.impactLight).toHaveBeenCalled();
- *
- * Children are cached per path, so repeated access returns the same mock.
- */
+// Deeply nested mock: every leaf (at any depth, e.g. Presets.System.impactLight)
+// is a stable jest.fn(), so any preset path is callable and assertable.
 function createDeepMock() {
   const cache = new Map();
   const target = jest.fn();
   return new Proxy(target, {
     get(fn, prop) {
-      if (prop === '__isPulsarMock') {
-        return true;
-      }
-      // `received.calls` is how Jest sniffs for a Jasmine spy. A jest.fn() has
-      // no `calls` of its own, so without this guard the catch-all below would
-      // hand back a truthy callable and Jest would mis-detect every leaf as a
-      // spy, breaking matchers like `toHaveBeenCalledTimes`.
+      // Jest sniffs `received.calls.all` to detect a Jasmine spy; without this
+      // the catch-all would return a truthy callable and break matchers like
+      // toHaveBeenCalledTimes.
       if (prop === 'calls') {
         return undefined;
       }
-      // Preserve jest.fn() internals (mock, mockReturnValue, _isMockFunction, …)
-      // and symbol access (e.g. Symbol.iterator) so the leaf behaves like a fn.
       if (typeof prop === 'symbol' || prop in fn) {
         return fn[prop];
       }
@@ -74,8 +45,6 @@ function createDeepMock() {
   });
 }
 
-// `Presets` has 150+ nested entries; the deep mock covers all of them without
-// having to enumerate every preset name.
 const Presets = createDeepMock();
 
 const Settings = {

--- a/react-native/react-native-pulsar/package.json
+++ b/react-native/react-native-pulsar/package.json
@@ -11,11 +11,13 @@
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
+    "./jest-mock": "./jest-mock.js",
     "./package.json": "./package.json"
   },
   "files": [
     "src",
     "lib",
+    "jest-mock.js",
     "android",
     "ios",
     "cpp",

--- a/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
+++ b/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
@@ -1,6 +1,5 @@
-// Exercises the shipped Jest mock (../../jest-mock.js). Consumers wire it up via
-// `jest.mock('react-native-pulsar', () => require('react-native-pulsar/jest-mock'))`;
-// here we require it directly since we are inside the package.
+// Consumers wire this up as require('react-native-pulsar/jest-mock'); inside the
+// package we require it directly.
 jest.mock('react-native-pulsar', () => require('../../jest-mock'), {
   virtual: true,
 });
@@ -22,7 +21,6 @@ describe('react-native-pulsar/jest-mock', () => {
 
     expect(Presets.System.impactLight).toHaveBeenCalledTimes(1);
     expect(Presets.System.Android.effectClick).toHaveBeenCalledTimes(1);
-    // Same reference on repeated access (children are cached).
     expect(Presets.System.impactLight).toBe(Presets.System.impactLight);
   });
 

--- a/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
+++ b/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
@@ -1,0 +1,59 @@
+// Exercises the shipped Jest mock (../../jest-mock.js). Consumers wire it up via
+// `jest.mock('react-native-pulsar', () => require('react-native-pulsar/jest-mock'))`;
+// here we require it directly since we are inside the package.
+jest.mock('react-native-pulsar', () => require('../../jest-mock'), {
+  virtual: true,
+});
+
+const {
+  Presets,
+  Settings,
+  useRealtimeComposer,
+  usePatternComposer,
+  useAdaptiveHaptics,
+  HapticSupport,
+  RealtimeComposerStrategy,
+} = require('react-native-pulsar');
+
+describe('react-native-pulsar/jest-mock', () => {
+  it('exposes Presets as deeply nested, callable, assertable mocks', () => {
+    Presets.System.impactLight();
+    Presets.System.Android.effectClick();
+
+    expect(Presets.System.impactLight).toHaveBeenCalledTimes(1);
+    expect(Presets.System.Android.effectClick).toHaveBeenCalledTimes(1);
+    // Same reference on repeated access (children are cached).
+    expect(Presets.System.impactLight).toBe(Presets.System.impactLight);
+  });
+
+  it('mocks every Settings method and returns a real support level', () => {
+    Settings.enableHaptics(true);
+    expect(Settings.enableHaptics).toHaveBeenCalledWith(true);
+    expect(Settings.getHapticsSupportLevel()).toBe(HapticSupport.ADVANCED_SUPPORT);
+  });
+
+  it('mocks the hooks and the composers they return', () => {
+    const realtime = useRealtimeComposer();
+    realtime.start();
+    realtime.set(1, 200);
+    expect(realtime.start).toHaveBeenCalled();
+    expect(realtime.set).toHaveBeenCalledWith(1, 200);
+    expect(realtime.isActive()).toBe(false);
+
+    const pattern = usePatternComposer();
+    pattern.play();
+    expect(pattern.play).toHaveBeenCalled();
+    expect(pattern.isParsed()).toBe(false);
+
+    const adaptive = useAdaptiveHaptics({ ios: () => {}, android: () => {} });
+    adaptive.play();
+    expect(adaptive.play).toHaveBeenCalled();
+  });
+
+  it('exposes the enums with the correct values', () => {
+    expect(HapticSupport.NO_SUPPORT).toBe(0);
+    expect(HapticSupport.ADVANCED_SUPPORT).toBe(3);
+    expect(RealtimeComposerStrategy.ENVELOPE).toBe(0);
+    expect(RealtimeComposerStrategy.ENVELOPE_WITH_DISCRETE_PRIMITIVES).toBe(3);
+  });
+});


### PR DESCRIPTION
## Why

`react-native-pulsar` is backed by a TurboModule and relies on `react-native-worklets`. In a Jest environment there is no native module to bind to, so importing the library directly throws (`TurboModuleRegistry.getEnforcing('RNPulsar')` cannot find the native module). Today users have to hand-write their own mocks for every Pulsar import. This PR ships a ready-to-use one.

## What

- **New mock — `react-native-pulsar/jest-mock`** (`react-native/react-native-pulsar/jest-mock.js`): a zero-config CommonJS mock of the entire public API.
  - `Presets` — a recursive, cached Proxy where every entry at any depth (e.g. `Presets.System.Android.effectClick`) is a stable `jest.fn()` you can assert on, without enumerating all 150+ presets.
  - `Settings` — all methods mocked; `getHapticsSupportLevel()` defaults to `HapticSupport.ADVANCED_SUPPORT`.
  - `useRealtimeComposer` / `usePatternComposer` / `useAdaptiveHaptics` — return objects of `jest.fn()`s (`isActive`/`isParsed` default to `false`).
  - `HapticSupport` / `RealtimeComposerStrategy` — real enum values.
- **Packaging** (`package.json`): added the `./jest-mock` subpath to `exports` (the package restricts subpaths, so this is required) and to `files` so it's published.
- **Docs** (`docs/.../sdk/react-native.mdx`): new **Testing with Jest** section covering per-file vs. global (`setupFiles`) wiring, asserting a haptic fired, and overriding return values.
- **Tests** (`src/__tests__/jest-mock.test.tsx`): exercises the deep Presets proxy, Settings, the hooks, and the enums.

## Usage

```ts
jest.mock('react-native-pulsar', () => require('react-native-pulsar/jest-mock'));

expect(Presets.System.notificationSuccess).toHaveBeenCalledTimes(1);
```

## Notes

One subtlety: the catch-all Proxy explicitly returns `undefined` for `calls`, because Jest sniffs `received.calls.all` to detect Jasmine spies — without the guard the Proxy hands back a truthy callable and breaks `toHaveBeenCalledTimes`.

## Test plan

- [x] `npx jest` in `react-native/react-native-pulsar` passes (`4 passed, 1 todo`).
- [x] Verified `require('react-native-pulsar/jest-mock')` resolves via the package-name subpath from `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)