### PR TITLE
docs: update Meltohamy testimonial avatar URL

### DIFF
--- a/docs/src/data/testimonials.ts
+++ b/docs/src/data/testimonials.ts
@@ -194,7 +194,7 @@ export const rightColumn: Testimonial[] = [
   x(
     'Meltohamy 𓂆',
     'm090009',
-    'https://pbs.twimg.com/profile_images/1926012601093275648/m7_Q7fKj_400x400.jpg',
+    'https://pbs.twimg.com/profile_images/2060083168699670528/arEOmkeU_400x400.jpg',
     'https://x.com/m090009/status/2042255893111374190',
     "There's one for Android too, you guys are awesome"
   ),


### PR DESCRIPTION
## What changed

Updated the profile image URL for the **Meltohamy 𓂆** testimonial in `docs/src/data/testimonials.ts`.

- Old: `.../1926012601093275648/m7_Q7fKj_400x400.jpg`
- New: `.../2060083168699670528/arEOmkeU_400x400.jpg`

## Why

The previous avatar URL pointed at a stale asset; this updates it to the current Twitter/X profile image.
