### PR TITLE
docs: update Clem ent testimonial avatar URL

### DIFF
--- a/docs/src/data/testimonials.ts
+++ b/docs/src/data/testimonials.ts
@@ -229,7 +229,7 @@ export const rightColumn: Testimonial[] = [
   x(
     'Clem ent',
     'clement___10',
-    'https://pbs.twimg.com/profile_images/2034410428327952384/W7fhYywz_400x400.jpg',
+    'https://pbs.twimg.com/profile_images/2057349147989078016/uiIceaTX_400x400.jpg',
     'https://x.com/clement___10/status/2042570012301390177',
     'banger'
   ),


### PR DESCRIPTION
## What changed

Updated the profile image URL for the **Clem ent** testimonial in `docs/src/data/testimonials.ts`.

- Old: `.../2034410428327952384/W7fhYywz_400x400.jpg`
- New: `.../2057349147989078016/uiIceaTX_400x400.jpg`

## Why

Points the avatar at the current Twitter/X profile image.
