### PR TITLE
feat(docs): vibrate hero phone on haptic button press

### DIFF
--- a/docs/src/components/landing/TopBanner/TopBanner.module.scss
+++ b/docs/src/components/landing/TopBanner/TopBanner.module.scss
@@ -147,8 +147,6 @@
 
     .phoneBackground {
       z-index: 1;
-      background-color: var(--color-blue-50);
-      border-radius: 24px;
       transform: translateX(55px) translateY(130px);
       position: relative;
 
@@ -158,14 +156,6 @@
 
       @media (max-width: 1000px) {
         transform: translateX(0) translateY(0);
-      }
-
-      @media (max-width: 768px) {
-        border-radius: 16px;
-      }
-
-      @media (max-width: 480px) {
-        border-radius: 12px;
       }
 
       .decorativeIcons {
@@ -201,6 +191,9 @@
         border: solid 2px var(--color-blue-50);
         border-radius: 24px;
         background-color: white;
+        // Hard offset shadow replaces the old static background wrapper, so the
+        // blue depth shakes together with the phone during the vibrate animation.
+        box-shadow: -10px 8px 0 var(--color-blue-50);
         transform: translateX(10px) translateY(-8px);
         padding-bottom: 300px;
         box-sizing: border-box;
@@ -924,6 +917,57 @@ $quake-durations: 0.07s, 0.09s, 0.06s, 0.11s, 0.08s;
   }
   100% {
     transform: translate(0, 0) scale(1);
+  }
+}
+
+// --------------------------------------------------
+// phone vibrate animation
+// --------------------------------------------------
+// Keyframes keep the phone's base offset (translateX(10px) translateY(-8px))
+// and add a quick shake on top. Because CSS animations override the static
+// transform set on .phone, this re-uses that same base so the phone doesn't
+// jump when the animation starts or ends.
+.vibrate {
+  animation: phoneVibrate 0.45s linear;
+}
+
+@keyframes phoneVibrate {
+  0%,
+  100% {
+    transform: translateX(10px) translateY(-8px) rotate(0deg);
+  }
+  10% {
+    transform: translateX(8px) translateY(-10px) rotate(-0.7deg);
+  }
+  20% {
+    transform: translateX(12px) translateY(-6px) rotate(0.7deg);
+  }
+  30% {
+    transform: translateX(7px) translateY(-9px) rotate(-0.6deg);
+  }
+  40% {
+    transform: translateX(13px) translateY(-7px) rotate(0.6deg);
+  }
+  50% {
+    transform: translateX(8px) translateY(-10px) rotate(-0.4deg);
+  }
+  60% {
+    transform: translateX(12px) translateY(-6px) rotate(0.4deg);
+  }
+  70% {
+    transform: translateX(9px) translateY(-9px) rotate(-0.25deg);
+  }
+  80% {
+    transform: translateX(11px) translateY(-7px) rotate(0.25deg);
+  }
+  90% {
+    transform: translateX(10px) translateY(-8px) rotate(-0.1deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vibrate {
+    animation: none;
   }
 }
 

--- a/docs/src/components/landing/TopBanner/TopBanner.module.scss
+++ b/docs/src/components/landing/TopBanner/TopBanner.module.scss
@@ -191,8 +191,6 @@
         border: solid 2px var(--color-blue-50);
         border-radius: 24px;
         background-color: white;
-        // Hard offset shadow replaces the old static background wrapper, so the
-        // blue depth shakes together with the phone during the vibrate animation.
         box-shadow: -10px 8px 0 var(--color-blue-50);
         transform: translateX(10px) translateY(-8px);
         padding-bottom: 300px;
@@ -923,10 +921,6 @@ $quake-durations: 0.07s, 0.09s, 0.06s, 0.11s, 0.08s;
 // --------------------------------------------------
 // phone vibrate animation
 // --------------------------------------------------
-// Keyframes keep the phone's base offset (translateX(10px) translateY(-8px))
-// and add a quick shake on top. Because CSS animations override the static
-// transform set on .phone, this re-uses that same base so the phone doesn't
-// jump when the animation starts or ends.
 .vibrate {
   animation: phoneVibrate 0.45s linear;
 }

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -10,7 +10,7 @@ import { Button } from '../Button/Button';
 import { EmojiButton } from '../EmojiButton/EmojiButton';
 import { SoundBar } from '../SoundBar/SoundBar';
 import { Presets } from 'pulsar-haptics';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 declare global {
   interface Window {
@@ -28,6 +28,17 @@ export function TopBanner() {
   const [confettiInstances, setConfettiInstances] = useState<number[]>([]);
   const [backgroundAnimation, setBackgroundAnimation] = useState(styles.wave);
   const [showDecorativeIcons, setShowDecorativeIcons] = useState(true);
+  const phoneRef = useRef<HTMLDivElement>(null);
+
+  // Re-trigger the CSS vibrate animation on every press, even rapid repeats:
+  // remove the class, force a reflow, then re-add so the animation restarts.
+  function triggerVibration() {
+    const el = phoneRef.current;
+    if (!el) return;
+    el.classList.remove(styles.vibrate);
+    void el.offsetWidth;
+    el.classList.add(styles.vibrate);
+  }
 
   function handleAnimationEffect(
     effect: '' | 'stars' | 'angels' | 'confetti',
@@ -112,7 +123,7 @@ export function TopBanner() {
             </div>
           )}
 
-          <div className={styles.phone}>
+          <div ref={phoneRef} className={styles.phone}>
             <div className={styles.notch}></div>
             <div className={styles.buttonHolder}>
               <div className={styles.row}>
@@ -120,6 +131,7 @@ export function TopBanner() {
                   emoji="emoji1"
                   onClick={() => {
                     Presets.sway();
+                    triggerVibration();
                     setColorClass('');
                     setBackgroundAnimation(styles.wave);
                     handleAnimationEffect('');
@@ -133,6 +145,7 @@ export function TopBanner() {
                   emoji="emoji2"
                   onClick={() => {
                     Presets.trill();
+                    triggerVibration();
                     setColorClass(styles.yellow);
                     setBackgroundAnimation(styles.sonar);
                     handleAnimationEffect('stars');
@@ -149,6 +162,7 @@ export function TopBanner() {
                   emoji="emoji3"
                   onClick={() => {
                     Presets.smash();
+                    triggerVibration();
                     setColorClass(styles.red);
                     setBackgroundAnimation(styles.quake);
                     handleAnimationEffect('confetti');
@@ -162,6 +176,7 @@ export function TopBanner() {
                   emoji="emoji4"
                   onClick={() => {
                     Presets.heartbeat();
+                    triggerVibration();
                     setColorClass(styles.green);
                     setBackgroundAnimation(styles.heartbeat);
                     handleAnimationEffect('angels');

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -30,8 +30,6 @@ export function TopBanner() {
   const [showDecorativeIcons, setShowDecorativeIcons] = useState(true);
   const phoneRef = useRef<HTMLDivElement>(null);
 
-  // Re-trigger the CSS vibrate animation on every press, even rapid repeats:
-  // remove the class, force a reflow, then re-add so the animation restarts.
   function triggerVibration() {
     const el = phoneRef.current;
     if (!el) return;


### PR DESCRIPTION
## What

Adds a CSS vibrate animation to the landing-page hero phone so it physically shakes whenever a visitor presses one of the emoji buttons (sway / trill / smash / heartbeat) — reinforcing the haptics/sound the buttons already trigger with a matching visual cue.

## Why

The hero phone's buttons already fire `Presets.*()` (haptics + sound), but there was no on-screen feedback. A short shake makes the "feel it" message of the library tangible right on the landing page.

## Changes

- **New `phoneVibrate` keyframes + `.vibrate` class** (`TopBanner.module.scss`): a quick `0.45s` shake built from small X/Y translations and tiny ±rotations that decays toward the end so it settles smoothly. The keyframes re-use the phone's base `translate(10px, -8px)` offset (CSS animations override the static transform during playback) so the phone doesn't jump on start/end. Wrapped in `@media (prefers-reduced-motion: reduce)` to respect motion preferences.
- **`triggerVibration()` helper** (`TopBanner.tsx`): restarts the animation on every press — including rapid repeated clicks — via remove-class → force reflow → add-class, since a plain state toggle won't restart an already-running animation. Called from all four emoji button handlers.
- **Blue depth now shakes with the phone**: replaced the static `.phoneBackground` blue wrapper (`background-color` + `border-radius`) with a hard `box-shadow: -10px 8px 0 var(--color-blue-50)` on `.phone`. The offset exactly reproduces the previous resting look, but because the shadow is part of the phone's own rendering it inherits the phone's transform and shakes/tilts together with it instead of staying frozen behind.

## Notes for reviewer

- Visually identical at rest; the change is only observable on button press.
- Verified in a local Astro dev preview: the `vibrate` class + `phoneVibrate` animation apply on click, the animation restarts on rapid repeats, and pausing mid-keyframe confirmed the phone is displaced/rotated with the `box-shadow` moving along with it.
- No lockfile/dependency changes are included — only the two source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)