### PR TITLE
docs: add KMP, Flutter, and Web cards to Start building section

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -71,6 +71,21 @@ These docs double as an interactive playground. Pair your phone with the browser
     href={`${BASE_PATH}/sdk/android/`}
     description="Kotlin library with VibrationEffect support and graceful fallbacks for older devices."
   />
+  <LinkCard
+    title="Kotlin Multiplatform SDK"
+    href={`${BASE_PATH}/sdk/kmp/`}
+    description="Shared Kotlin API targeting Android and iOS from a single codebase."
+  />
+  <LinkCard
+    title="Flutter SDK"
+    href={`${BASE_PATH}/sdk/flutter/`}
+    description="Dart plugin for cross-platform haptics on iOS and Android."
+  />
+  <LinkCard
+    title="Web SDK"
+    href={`${BASE_PATH}/sdk/web/`}
+    description="Plays through the Web Vibration API with an audio fallback for unsupported browsers."
+  />
 </CardGrid>
 
 New to haptics? Read the <a href={`${BASE_PATH}/sdk/overview/`}>SDK overview</a> first. It covers discrete vs. continuous haptics, preloading, and caching.


### PR DESCRIPTION
## What changed

Added three `LinkCard`s to the **Start building** card grid in `getting-started.mdx`:

- Kotlin Multiplatform SDK
- Flutter SDK
- Web SDK

## Why

The grid previously only linked React Native, iOS, and Android, even though docs pages exist for all six SDKs. Now every supported platform is discoverable from the getting-started page.