### PR TITLE
feat(docs): add iOS vs Android haptics article to articles list

### DIFF
--- a/docs/src/data/articles.ts
+++ b/docs/src/data/articles.ts
@@ -10,6 +10,15 @@ export type Article = {
 
 export const articles: Article[] = [
   {
+    title: 'What Is the Difference Between iOS and Android Haptics',
+    shortTitle: 'iOS vs Android Haptics',
+    url: 'https://swmansion.com/blog/what-is-the-difference-between-i-os-and-android-haptics/',
+    source: 'Software Mansion Blog',
+    publishedAt: 'Jun 18, 2026',
+    imageUrl: 'https://strapi-production-5f3f.up.railway.app/uploads/BLOGPOST_i_O_Svs_Android_Haptics_1_bfa763feaf.png',
+    imageAlt: 'Banner for the article What Is the Difference Between iOS and Android Haptics',
+  },
+  {
     title: 'How Haptic Feedback Affects Sales, Trust, and Product Perception',
     shortTitle: 'How Haptic Feedback Affects Sales, Trust, and Product Perception',
     url: 'https://swmansion.com/blog/how-haptic-feedback-affects-sales-trust-and-product-perception/',


### PR DESCRIPTION
## What

Adds the latest Software Mansion blog post — [What Is the Difference Between iOS and Android Haptics](https://swmansion.com/blog/what-is-the-difference-between-i-os-and-android-haptics/) — to the docs articles list.

## Why

Keeps the "Articles" section current with the newest published blog post.

## Details

- Single edit to `docs/src/data/articles.ts`, the shared config that feeds:
  - the landing page articles section (`Articles.tsx`)
  - the docs Articles page (`articles/index.mdx`)
  - the sidebar nav (`astro.config.mjs`, via `shortTitle`)
- New entry placed first as the most recent article. All fields mirror the existing entries; title, publish date (Jun 18, 2026), and cover image URL were taken from the live article page.

## Verification

Ran the docs Astro dev server and confirmed:
- The new card renders first with its banner image loading correctly.
- Publish date displays.
- The sidebar shows the "iOS vs Android Haptics" nav entry (the `shortTitle`).