### PR TITLE
Revert RealtimeComposer.start(), restore auto-starting set()

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeComposer.kt
@@ -18,12 +18,8 @@ class RealtimeComposer(
         RealtimeComposerStrategy.PRIMITIVE_COMPLEX -> RealtimePrimitiveComplexComposer(engine, compatibilityMode)
     }
 
-    override fun start() {
-        delegate.start()
-    }
-
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        delegate.set(amplitude, frequency, startIfNeeded)
+    override fun set(amplitude: Float, frequency: Float) {
+        delegate.set(amplitude, frequency)
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeComposer.kt
@@ -29,19 +29,17 @@ open class RealtimeEnvelopeComposer(
     private var schedulerJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default)
 
-    override fun start() {
-        if (!isPlaying.compareAndSet(false, true)) return
+    private fun start() {
+        isPlaying.set(true)
         scheduleSequentialHaptics()
     }
 
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        if (!isPlaying.get()) {
-            if (!startIfNeeded) return
-            start()
-            if (!isPlaying.get()) return
-        }
+    override fun set(amplitude: Float, frequency: Float) {
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
+        if (!isPlaying.get()) {
+            start()
+        }
     }
 
     open override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -32,20 +32,24 @@ open class RealtimePrimitiveComposer(
     private val handler = Handler(Looper.getMainLooper())
     private val loopRunnable = Runnable { loop() }
 
-    override fun start() {
-        if (!isPlaying.compareAndSet(false, true)) return
+    private fun start(amplitude: Float, frequency: Float) {
+        if (isPlaying.get()) {
+            stop()
+        }
+
+        isPlaying.set(true)
+        set(amplitude, frequency)
         loop()
     }
 
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        if (!isPlaying.get()) {
-            if (!startIfNeeded) return
-            start()
-            if (!isPlaying.get()) return
-        }
+    override fun set(amplitude: Float, frequency: Float) {
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
         currentIntervalMs = (minIntervalMs + (1 - frequency) * (maxIntervalMs - minIntervalMs)).toLong()
+
+        if (!isPlaying.get()) {
+            start(currentAmplitude, currentFrequency)
+        }
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/RealtimeComposer.kt
@@ -30,10 +30,7 @@ enum class RealtimeComposerStrategy {
 }
 
 interface RealtimeComposable {
-    fun start()
-    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean)
-    fun set(amplitude: Float, frequency: Float) = set(amplitude, frequency, false)
-
+    fun set(amplitude: Float, frequency: Float)
     fun playDiscrete(amplitude: Float, frequency: Float)
     fun stop()
     fun isActive(): Boolean

--- a/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/RealtimeComposerScreen.kt
+++ b/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/RealtimeComposerScreen.kt
@@ -141,7 +141,6 @@ fun RealtimeComposerScreen() {
                                 isActive = true
                                 frequency = (offset.x / size.width).coerceIn(0f, 1f)
                                 amplitude = (1f - (offset.y / size.height)).coerceIn(0f, 1f)
-                                realtimeComposer.start()
                                 realtimeComposer.set(amplitude, frequency)
                             },
                             onDrag = { change, _ ->

--- a/PulsarApp/app/(tabs)/demos/balloon-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/balloon-demo.tsx
@@ -155,7 +155,7 @@ function BalloonCell({ index }: { index: number }) {
       if (current > 0 && current < shakeThreshold) {
         const amplitude = interpolate(current, [0, shakeThreshold], [ampMin, ampMid], Extrapolation.CLAMP);
         const frequency = interpolate(current, [0, shakeThreshold], [freqHigh, freqLow], Extrapolation.CLAMP);
-        composer.set(amplitude, frequency, true);
+        composer.set(amplitude, frequency);
       }
 
       // Enter shake zone: stop continuous haptic, let shakeOffset drive impulses

--- a/PulsarApp/app/(tabs)/demos/sensor-haptics-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/sensor-haptics-demo.tsx
@@ -43,7 +43,6 @@ export default function SensorHapticsDemo() {
     }),
     ({ isScreenActive, sensorX, sensorY }) => {
       if (!isScreenActive) {
-        composer.stop();
         return;
       }
 
@@ -106,7 +105,7 @@ export default function SensorHapticsDemo() {
         if (postBounceSpeed > 0.5) {
           const amplitude = interpolate(postBounceSpeed, [0.5, 12], [0.1, 0.5], Extrapolation.CLAMP);
           const frequency = interpolate(postBounceSpeed, [0.5, 12], [0.2, 0.7], Extrapolation.CLAMP);
-          composer.set(amplitude, frequency, true);
+          composer.set(amplitude, frequency);
         } else {
           composer.stop();
         }
@@ -121,7 +120,7 @@ export default function SensorHapticsDemo() {
         if (velocityMagnitude > 0.5) {
           const amplitude = interpolate(velocityMagnitude, [0.5, 12], [0.1, 0.5], Extrapolation.CLAMP);
           const frequency = interpolate(velocityMagnitude, [0.5, 12], [0.2, 0.7], Extrapolation.CLAMP);
-          composer.set(amplitude, frequency, true);
+          composer.set(amplitude, frequency);
         } else {
           composer.stop();
         }

--- a/PulsarApp/hooks/useComposedGesture.ts
+++ b/PulsarApp/hooks/useComposedGesture.ts
@@ -35,7 +35,6 @@ export const useComposedGesture = (
 
   const panGesture = Gesture.Pan()
     .onStart(() => {
-      composer.start();
       recordEvent('pan', 0, 0);
     })
     .onUpdate((e) => {

--- a/PulsarApp/hooks/useHapticsScreenActivity.ts
+++ b/PulsarApp/hooks/useHapticsScreenActivity.ts
@@ -1,6 +1,5 @@
 import { useIsFocused } from 'expo-router';
 import { useEffect } from 'react';
-import { Settings } from 'react-native-pulsar';
 import { useSharedValue } from 'react-native-reanimated';
 import { runOnUIAsync } from 'react-native-worklets';
 
@@ -11,14 +10,21 @@ export function useHapticsScreenActivity(composer: Composer) {
   const isScreenActive = useSharedValue(isFocused);
 
   useEffect(() => {
-    isScreenActive.value = isFocused;
-
     if (!isFocused) {
+      runOnUIAsync((isFocused) => {
+        isScreenActive.value = isFocused;
+        composer.stop();
+      }, isFocused);
+    } else {
+      isScreenActive.value = isFocused;
+    }
+    
+    return () => {
       runOnUIAsync(() => {
+        isScreenActive.value = false;
         composer.stop();
       });
-      Settings.stopHaptics();
-    }
+    };
   }, [composer, isFocused, isScreenActive]);
 
   return isScreenActive;

--- a/PulsarApp/hooks/useOnboardingComposedGesture.ts
+++ b/PulsarApp/hooks/useOnboardingComposedGesture.ts
@@ -30,9 +30,6 @@ export const useOnboardingComposedGesture = (
     });
 
   const onboardingPanGesture = Gesture.Pan()
-    .onStart(() => {
-      composer.start();
-    })
     .onUpdate((e) => {
       const normalized = normalizePosition(e.x, e.y);
       composer.set(normalized.y, normalized.x);

--- a/docs/src/content/docs/sdk/android.mdx
+++ b/docs/src/content/docs/sdk/android.mdx
@@ -666,20 +666,12 @@ val realtime = pulsar.getRealtimeComposer(strategy = RealtimeComposerStrategy.EN
 
 ### Methods
 
-#### `start()`
+#### `set(amplitude, frequency)`
 
-Starts the realtime composer so that subsequent `set(amplitude, frequency)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Available on `RealtimeComposer` and every strategy implementation (envelope, primitive, etc.).
-
-```kotlin
-fun start()
-```
-
-#### `set(amplitude, frequency, startIfNeeded)`
-
-Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded = true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0-1 range.
 
 ```kotlin
-fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean = false)
+fun set(amplitude: Float, frequency: Float)
 ```
 
 #### `playDiscrete(amplitude, frequency)`
@@ -711,22 +703,18 @@ fun isActive(): Boolean
 ```kotlin
 val realtime = pulsar.getRealtimeComposer()
 
-// Begin a continuous haptic — required before set(...) will play
-realtime.start()
-
-// Update parameters over time as the gesture progresses
+// Start a continuous haptic
 realtime.set(amplitude = 0.5f, frequency = 0.8f)
+
+// Update parameters over time
 realtime.set(amplitude = 1.0f, frequency = 0.3f)
 
 // Play a one-off discrete event
 realtime.playDiscrete(amplitude = 0.7f, frequency = 0.5f)
 
-// End the continuous haptic. After this the composer is inactive
-// again — call start() before the next set(...).
+// Stop
 realtime.stop()
 ```
-
-> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture and `stop()` with its end, or pass `startIfNeeded = true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -529,20 +529,12 @@ await pulsar.setRealtimeComposerStrategy(RealtimeComposerStrategy.envelope);
 
 ### Methods
 
-#### `start()`
+#### `set(amplitude, frequency)`
 
-Starts the realtime composer so that subsequent `set(...)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Routes through the active strategy on the same path as the other methods.
-
-```dart
-Future<void> start();
-```
-
-#### `set(amplitude, frequency, {startIfNeeded})`
-
-Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0–1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0–1 range.
 
 ```dart
-Future<void> set(double amplitude, double frequency, {bool startIfNeeded = false});
+Future<void> set(double amplitude, double frequency);
 ```
 
 #### `playDiscrete([amplitude, frequency])`
@@ -574,23 +566,13 @@ Future<bool> isActive();
 ```dart
 final realtime = pulsar.getRealtimeComposer();
 
-// Begin a continuous haptic — required before set(...) will play
-await realtime.start();
-
-// Update parameters over time as the gesture progresses
 await realtime.set(0.5, 0.8);
 await realtime.set(1.0, 0.3);
 
 await realtime.playDiscrete(0.7, 0.5);
 
-// End the continuous haptic. After this the composer is inactive
-// again — call start() before the next set(...).
 await realtime.stop();
 ```
-
-<Aside type="note" title="Lifecycle">
-  `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture (e.g. `onPanStart`) and `stop()` with its end, or pass `startIfNeeded: true` to `set(...)` to opt into auto-start when no clear begin hook is available.
-</Aside>
 
 ---
 

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -558,20 +558,12 @@ let realtime = pulsar.getRealtimeComposer()
 
 ### Methods
 
-#### `start()`
+#### `set(amplitude:frequency:)`
 
-Starts the realtime composer so that subsequent `set(amplitude:frequency:)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`.
-
-```swift
-func start()
-```
-
-#### `set(amplitude:frequency:startIfNeeded:)`
-
-Updates the ongoing haptic with new amplitude and frequency values. Values are clamped to the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values are clamped to the 0-1 range.
 
 ```swift
-func set(amplitude: Float, frequency: Float, startIfNeeded: Bool = false)
+func set(amplitude: Float, frequency: Float)
 ```
 
 #### `playDiscrete(amplitude:frequency:)`
@@ -605,22 +597,18 @@ var isActive: Bool { get }
 ```swift
 let realtime = pulsar.getRealtimeComposer()
 
-// Begin a continuous haptic — required before set(...) will play
-realtime.start()
-
-// Update parameters over time as the gesture progresses
+// Start a continuous haptic
 realtime.set(amplitude: 0.5, frequency: 0.8)
+
+// Update parameters over time
 realtime.set(amplitude: 1.0, frequency: 0.3)
 
 // Play a one-off discrete event
 realtime.playDiscrete(amplitude: 0.7, frequency: 0.5)
 
-// End the continuous haptic. After this the composer is inactive
-// again — call start() before the next set(...).
+// Stop
 realtime.stop()
 ```
-
-> **Note:** `set(amplitude:frequency:)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture (e.g. a drag's begin phase) and `stop()` with its end, or pass `startIfNeeded: true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -498,20 +498,12 @@ pulsar.realtimeComposerStrategy = RealtimeComposerStrategy.ENVELOPE
 
 ### Methods
 
-#### `start()`
+#### `set(amplitude, frequency)`
 
-Starts the realtime composer so that subsequent `set(amplitude, frequency)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Backed by `RealtimeComposerHandle.start()` on each platform target.
-
-```kotlin
-fun start()
-```
-
-#### `set(amplitude, frequency, startIfNeeded)`
-
-Updates the ongoing haptic with new amplitude and frequency values. Values should be in the 0-1 range. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded = true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior.
+Updates the ongoing haptic with new amplitude and frequency values. Automatically starts playback if it is not already active. Values should be in the 0-1 range.
 
 ```kotlin
-fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean = false)
+fun set(amplitude: Float, frequency: Float)
 ```
 
 #### `playDiscrete(amplitude, frequency)`
@@ -543,21 +535,13 @@ fun isActive(): Boolean
 ```kotlin
 val realtime = pulsar.getRealtimeComposer()
 
-// Begin a continuous haptic — required before set(...) will play
-realtime.start()
-
-// Update parameters over time as the gesture progresses
 realtime.set(amplitude = 0.5f, frequency = 0.8f)
 realtime.set(amplitude = 1.0f, frequency = 0.3f)
 
 realtime.playDiscrete(amplitude = 0.7f, frequency = 0.5f)
 
-// End the continuous haptic. After this the composer is inactive
-// again — call start() before the next set(...).
 realtime.stop()
 ```
-
-> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the beginning of a gesture and `stop()` with its end, or pass `startIfNeeded = true` to `set(...)` to opt into auto-start when no clear begin hook is available.
 
 ---
 

--- a/docs/src/content/docs/sdk/react-native.mdx
+++ b/docs/src/content/docs/sdk/react-native.mdx
@@ -424,7 +424,7 @@ function MyComponent() {
 A React hook for real-time haptic control. Provides live amplitude and frequency modulation, useful for gesture-driven or continuously evolving haptic experiences. Haptics stop automatically on unmount.
 
 ```ts
-const { start, set, playDiscrete, stop, isActive } = useRealtimeComposer();
+const { set, playDiscrete, stop, isActive } = useRealtimeComposer();
 ```
 
 ### Parameters
@@ -433,13 +433,9 @@ const { start, set, playDiscrete, stop, isActive } = useRealtimeComposer();
 
 ### Returns
 
-#### `start()`
+#### `set(amplitude: number, frequency: number)`
 
-Starts the realtime composer so that subsequent `set(...)` calls play. `set(...)` requires `start()` first — calls made before `start()` or after `stop()` are silent no-ops. After `stop()`, call `start()` again before the next `set(...)`. Worklet-safe, takes no arguments.
-
-#### `set(amplitude: number, frequency: number, startIfNeeded?: boolean)`
-
-Updates the ongoing haptic with new amplitude and frequency values. Has no effect until `start()` has been called; becomes a no-op again after `stop()`. Pass `startIfNeeded: true` to auto-start the composer when it is not already active — defaults to `false`, preserving the no-op-when-inactive behavior. Worklet-safe.
+Updates the ongoing haptic with new amplitude and frequency values.
 
 #### `playDiscrete(amplitude: number, frequency: number)`
 
@@ -463,25 +459,17 @@ function MyComponent() {
   const realtime = useRealtimeComposer();
 
   const pan = Gesture.Pan()
-    .onStart(() => {
-      // Required before set(...) will play
-      realtime.start();
-    })
     .onUpdate((e) => {
       const amplitude = Math.min(Math.abs(e.velocityY) / 1000, 1);
       realtime.set(amplitude, 0.5);
     })
     .onEnd(() => {
-      // After stop() the composer is inactive again — call start()
-      // before the next set(...).
       realtime.stop();
     });
 
   return <GestureDetector gesture={pan}>...</GestureDetector>;
 }
 ```
-
-> **Note:** `set(amplitude, frequency)` requires `start()` first. Calls before `start()` or after `stop()` are silent no-ops. Pair `start()` with the gesture's `onStart` (or equivalent, like a slider's `onChangeStart`) and `stop()` with its `onEnd`, or pass `startIfNeeded: true` to `set(...)` from an `onChange`-style callback that has no clear begin hook.
 
 ---
 

--- a/flutter/PulsarApp/lib/main.dart
+++ b/flutter/PulsarApp/lib/main.dart
@@ -67,9 +67,7 @@ class _PulsarDemoScreenState extends State<PulsarDemoScreen> {
   Future<void> _onSliderChange(double value) async {
     setState(() => _amplitude = value);
     try {
-      await _pulsar
-          .getRealtimeComposer()
-          .set(_amplitude, _frequency, startIfNeeded: true);
+      await _pulsar.getRealtimeComposer().set(_amplitude, _frequency);
     } catch (_) {}
   }
 

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
@@ -168,24 +168,11 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success(null)
             }
 
-            "RealtimeComposer_start" -> {
-                val strategyIndex = call.argument<Int>("strategy")
-                val strategy = if (strategyIndex != null) {
-                    RealtimeComposerStrategy.entries.getOrNull(strategyIndex)
-                        ?: return result.error("INVALID_ARGS", "invalid strategy", null)
-                } else {
-                    null
-                }
-                p.getRealtimeComposer(strategy).start()
-                result.success(null)
-            }
-
             "RealtimeComposer_set" -> {
                 val amplitude = call.argument<Double>("amplitude")?.toFloat()
                     ?: return result.error("INVALID_ARGS", "amplitude required", null)
                 val frequency = call.argument<Double>("frequency")?.toFloat()
                     ?: return result.error("INVALID_ARGS", "frequency required", null)
-                val startIfNeeded = call.argument<Boolean>("startIfNeeded") ?: false
                 val strategyIndex = call.argument<Int>("strategy")
                 val strategy = if (strategyIndex != null) {
                     RealtimeComposerStrategy.entries.getOrNull(strategyIndex)
@@ -193,7 +180,7 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 } else {
                     null
                 }
-                p.getRealtimeComposer(strategy).set(amplitude, frequency, startIfNeeded)
+                p.getRealtimeComposer(strategy).set(amplitude, frequency)
                 result.success(null)
             }
 

--- a/flutter/pulsar/example/lib/main.dart
+++ b/flutter/pulsar/example/lib/main.dart
@@ -159,9 +159,7 @@ class _RealtimeSliderState extends State<_RealtimeSlider> {
   Future<void> _onChanged(double value) async {
     setState(() => _amplitude = value);
     try {
-      await widget.pulsar
-          .getRealtimeComposer()
-          .set(_amplitude, 0.5, startIfNeeded: true);
+      await widget.pulsar.getRealtimeComposer().set(_amplitude, 0.5);
       if (!mounted) return;
       setState(() => _active = true);
     } on PlatformException {

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -117,14 +117,6 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
       result(nil)
 
     // MARK: — RealtimeComposer
-    case "RealtimeComposer_start":
-      if let strategyError = applyRealtimeStrategy(args) {
-        result(strategyError)
-        return
-      }
-      realtimeComposer.start()
-      result(nil)
-
     case "RealtimeComposer_set":
       guard let amplitude = args?["amplitude"] as? Double,
             let frequency = args?["frequency"] as? Double else {
@@ -135,8 +127,7 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
         result(strategyError)
         return
       }
-      let startIfNeeded = (args?["startIfNeeded"] as? Bool) ?? false
-      realtimeComposer.set(amplitude: Float(amplitude), frequency: Float(frequency), startIfNeeded: startIfNeeded)
+      realtimeComposer.set(amplitude: Float(amplitude), frequency: Float(frequency))
       result(nil)
 
     case "RealtimeComposer_stop":

--- a/flutter/pulsar/lib/pulsar_method_channel.dart
+++ b/flutter/pulsar/lib/pulsar_method_channel.dart
@@ -114,21 +114,13 @@ class MethodChannelPulsar extends PulsarPlatform {
   // ── RealtimeComposer ────────────────────────────────────────────────────────
 
   @override
-  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) =>
-      methodChannel.invokeMethod('RealtimeComposer_start', {
-        if (strategy != null) 'strategy': strategy.index,
-      });
-
-  @override
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
-    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) => methodChannel.invokeMethod('RealtimeComposer_set', {
     'amplitude': amplitude,
     'frequency': frequency,
-    'startIfNeeded': startIfNeeded,
     if (strategy != null) 'strategy': strategy.index,
   });
 

--- a/flutter/pulsar/lib/pulsar_platform_interface.dart
+++ b/flutter/pulsar/lib/pulsar_platform_interface.dart
@@ -79,13 +79,9 @@ abstract class PulsarPlatform extends PlatformInterface {
 
   // ── RealtimeComposer ────────────────────────────────────────────────────────
 
-  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) =>
-      throw UnimplementedError('realtimeStart() not implemented');
-
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
-    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) => throw UnimplementedError('realtimeSet() not implemented');
 

--- a/flutter/pulsar/lib/src/pulsar_realtime_composer.dart
+++ b/flutter/pulsar/lib/src/pulsar_realtime_composer.dart
@@ -4,9 +4,7 @@ part of 'package:pulsar_haptics/pulsar.dart';
 ///
 /// Ideal for gesture-driven feedback (e.g. sliders, drag gestures).
 /// ```dart
-/// // Start the composer before sending updates
-/// await pulsar.getRealtimeComposer().start();
-/// // Update haptic as the user drags
+/// // Start/update haptic as the user drags
 /// await pulsar.getRealtimeComposer().set(0.8, 0.5);
 /// // Stop when the gesture ends
 /// await pulsar.getRealtimeComposer().stop();
@@ -16,26 +14,11 @@ class PulsarRealtimeComposer {
 
   final RealtimeComposerStrategy? strategy;
 
-  /// Start the realtime composer. Must be called before [set] has any effect.
-  /// Calling [set] on a composer that is not started (or already stopped) is a no-op.
-  Future<void> start() =>
-      PulsarPlatform.instance.realtimeStart(strategy: strategy);
-
-  /// Update continuous haptic parameters. The composer must be started via
-  /// [start] first; otherwise this call has no effect — unless
-  /// [startIfNeeded] is `true`, in which case the composer is started
-  /// automatically before applying the new parameters.
+  /// Set continuous haptic parameters. Starts automatically if not already active.
   /// [amplitude] and [frequency] are in the range 0.0–1.0.
-  Future<void> set(
-    double amplitude,
-    double frequency, {
-    bool startIfNeeded = false,
-  }) => PulsarPlatform.instance.realtimeSet(
-    amplitude,
-    frequency,
-    startIfNeeded: startIfNeeded,
-    strategy: strategy,
-  );
+  Future<void> set(double amplitude, double frequency) => PulsarPlatform
+      .instance
+      .realtimeSet(amplitude, frequency, strategy: strategy);
 
   /// Stop the continuous haptic.
   Future<void> stop() =>

--- a/flutter/pulsar/test/pulsar_test.dart
+++ b/flutter/pulsar/test/pulsar_test.dart
@@ -81,9 +81,6 @@ class MockPulsarPlatform
   Future<bool> presetExists(String presetName) async => true;
 
   @override
-  Future<void> realtimeStart({RealtimeComposerStrategy? strategy}) async {}
-
-  @override
   Future<bool> realtimeIsActive({RealtimeComposerStrategy? strategy}) async =>
       false;
 
@@ -98,7 +95,6 @@ class MockPulsarPlatform
   Future<void> realtimeSet(
     double amplitude,
     double frequency, {
-    bool startIfNeeded = false,
     RealtimeComposerStrategy? strategy,
   }) async {}
 

--- a/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
@@ -13,28 +13,22 @@ public class RealtimeComposer: NSObject {
     stop()
   }
 
-  @objc public func start() {
-    guard engine.isHapticsEnabled else { return }
+  private func start(amplitude: Float = 0.0, frequency: Float = 0.0) {
     guard !isPlaying else { return }
     guard let player = engine?.getRealtimePlayer() else { return }
     isPlaying = true
+    set(amplitude: amplitude, frequency: frequency)
     do {
       try player.start(atTime: 0)
     } catch {
-      isPlaying = false
       print("Error starting realtime player: \(error.localizedDescription)")
     }
   }
 
   @objc public func set(amplitude: Float, frequency: Float) {
-    set(amplitude: amplitude, frequency: frequency, startIfNeeded: false)
-  }
-
-  @objc public func set(amplitude: Float, frequency: Float, startIfNeeded: Bool) {
     guard engine.isHapticsEnabled else { return }
-    if !isPlaying {
-      guard startIfNeeded else { return }
-      start()
+    if (!isPlaying) {
+      start(amplitude: amplitude, frequency: frequency)
     }
     guard isPlaying, let player = engine?.getRealtimePlayer() else { return }
 

--- a/iOS/PulsarApp/PulsarApp/RealtimeComposerView.swift
+++ b/iOS/PulsarApp/PulsarApp/RealtimeComposerView.swift
@@ -176,10 +176,9 @@ struct RealtimeComposerView: View {
     
     func handleDrag(at location: CGPoint) {
         pointerLocation = location
-
+        
         if !isDragging {
             isDragging = true
-            composer?.start()
         }
         composer?.set(amplitude: getIntensity(), frequency: getSharpness())
     }

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
@@ -351,12 +351,8 @@ private class AndroidPatternComposerHandle(
 private class AndroidRealtimeComposerHandle(
     private val composer: AndroidRealtimeComposer,
 ) : RealtimeComposerHandle {
-    override fun start() {
-        composer.start()
-    }
-
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        composer.set(amplitude, frequency, startIfNeeded)
+    override fun set(amplitude: Float, frequency: Float) {
+        composer.set(amplitude, frequency)
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarControllers.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarControllers.kt
@@ -853,16 +853,8 @@ class PatternComposer internal constructor(
 class RealtimeComposer internal constructor(
     private val handle: RealtimeComposerHandle,
 ) {
-    fun start() {
-        handle.start()
-    }
-
-    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        handle.set(amplitude, frequency, startIfNeeded)
-    }
-
     fun set(amplitude: Float, frequency: Float) {
-        handle.set(amplitude, frequency, false)
+        handle.set(amplitude, frequency)
     }
 
     fun playDiscrete(amplitude: Float, frequency: Float) {

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
@@ -269,9 +269,7 @@ interface PatternComposerHandle {
 }
 
 interface RealtimeComposerHandle {
-    fun start()
-    fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean)
-    fun set(amplitude: Float, frequency: Float) = set(amplitude, frequency, false)
+    fun set(amplitude: Float, frequency: Float)
     fun playDiscrete(amplitude: Float, frequency: Float)
     fun stop()
     fun isActive(): Boolean

--- a/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
+++ b/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
@@ -47,9 +47,7 @@ class PulsarFacadeTest {
         composer.playPattern(PatternData())
         composer.playAudioOnly()
         composer.stop()
-        realtime.start()
         realtime.set(0.6f, 0.4f)
-        configuredRealtime.start()
         configuredRealtime.set(0.3f, 0.9f)
         realtime.playDiscrete(1f, 0.5f)
         realtime.stop()
@@ -432,15 +430,9 @@ private class FakePatternHandle : PatternComposerHandle {
 private class FakeRealtimeHandle : RealtimeComposerHandle {
     var lastSet: Pair<Float, Float>? = null
     var lastDiscrete: Pair<Float, Float>? = null
-    var started = false
     var stopped = false
 
-    override fun start() {
-        started = true
-    }
-
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
-        if (startIfNeeded && !started) start()
+    override fun set(amplitude: Float, frequency: Float) {
         lastSet = amplitude to frequency
     }
 
@@ -452,5 +444,5 @@ private class FakeRealtimeHandle : RealtimeComposerHandle {
         stopped = true
     }
 
-    override fun isActive(): Boolean = started && !stopped
+    override fun isActive(): Boolean = false
 }

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/RealtimeComposer.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/RealtimeComposer.kt
@@ -20,24 +20,10 @@ internal class IOSRealtimeComposerHandle(
 ) : RealtimeComposerHandle {
     private var isPlaying = false
 
-    override fun start() {
-        if (!engine.isHapticsEnabled) return
-        if (isPlaying) return
-        val player = engine.getRealtimePlayer() ?: return
-        isPlaying = true
-        runCatching { player.startAtTime(0.0, error = null) }
-            .onFailure {
-                isPlaying = false
-                log("Error starting realtime player: ${it.message}")
-            }
-    }
-
-    override fun set(amplitude: Float, frequency: Float, startIfNeeded: Boolean) {
+    override fun set(amplitude: Float, frequency: Float) {
         if (!engine.isHapticsEnabled) return
         if (!isPlaying) {
-            if (!startIfNeeded) return
-            start()
-            if (!isPlaying) return
+            start(amplitude, frequency)
         }
         val player = engine.getRealtimePlayer() ?: return
         val parameters = listOf(
@@ -78,4 +64,16 @@ internal class IOSRealtimeComposerHandle(
     }
 
     override fun isActive(): Boolean = isPlaying
+
+    private fun start(amplitude: Float = 0f, frequency: Float = 0f) {
+        if (isPlaying) return
+        val player = engine.getRealtimePlayer() ?: return
+        isPlaying = true
+        set(amplitude, frequency)
+        runCatching { player.startAtTime(0.0, error = null) }
+            .onFailure {
+                isPlaying = false
+                log("Error starting realtime player: ${it.message}")
+            }
+    }
 }

--- a/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
+++ b/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
@@ -118,11 +118,7 @@ fun App() {
                         value = amplitude,
                         onValueChange = {
                             amplitude = it
-                            pulsar?.getRealtimeComposer()?.set(
-                                amplitude = amplitude,
-                                frequency = frequency,
-                                startIfNeeded = true,
-                            )
+                            pulsar?.getRealtimeComposer()?.set(amplitude = amplitude, frequency = frequency)
                             status = "Updated realtime haptics."
                         },
                         enabled = pulsar != null,
@@ -132,11 +128,7 @@ fun App() {
                         value = frequency,
                         onValueChange = {
                             frequency = it
-                            pulsar?.getRealtimeComposer()?.set(
-                                amplitude = amplitude,
-                                frequency = frequency,
-                                startIfNeeded = true,
-                            )
+                            pulsar?.getRealtimeComposer()?.set(amplitude = amplitude, frequency = frequency)
                             status = "Updated realtime haptics."
                         },
                         enabled = pulsar != null,

--- a/react-native/PulsarApp/src/screens/RealtimeComposerScreen.tsx
+++ b/react-native/PulsarApp/src/screens/RealtimeComposerScreen.tsx
@@ -76,7 +76,6 @@ export default function RealtimeComposerScreen() {
       const normalizedX = (x / containerSize.value.width);
       const normalizedY = ((containerSize.value.height - y) / containerSize.value.height);
 
-      composer.start();
       composer.set(normalizedY, normalizedX);
     })
     .onUpdate((event: any) => {

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarModule.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarModule.kt
@@ -194,12 +194,8 @@ class PulsarModule(reactContext: ReactApplicationContext) :
 
   // RealtimeComposer -----------------------------------------------------------------
 
-  override fun RealtimeComposer_start() {
-    realtimeComposer.start()
-  }
-
-  override fun RealtimeComposer_set(amplitude: Double, frequency: Double, startIfNeeded: Boolean) {
-    realtimeComposer.set(amplitude.toFloat(), frequency.toFloat(), startIfNeeded)
+  override fun RealtimeComposer_set(amplitude: Double, frequency: Double) {
+    realtimeComposer.set(amplitude.toFloat(), frequency.toFloat())
   }
 
   override fun RealtimeComposer_playDiscrete(amplitude: Double, frequency: Double) {

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -187,23 +187,13 @@ static PatternData *PatternDataFromJSPattern(JS::NativeRNPulsar::Pattern &data) 
 
 // RealtimeComposer -----------------------------------------------------------------
 
-- (void)RealtimeComposer_start {
-  if (!RNPulsarIsAppActive()) {
-    return;
-  }
-
-  RNPulsarPerformSafely(@"RealtimeComposer_start", ^{
-    [realtimeComposer_ start];
-  });
-}
-
-- (void)RealtimeComposer_set:(double)amplitude frequency:(double)frequency startIfNeeded:(BOOL)startIfNeeded {
+- (void)RealtimeComposer_set:(double)amplitude frequency:(double)frequency {
   if (!RNPulsarIsAppActive()) {
     return;
   }
 
   RNPulsarPerformSafely(@"RealtimeComposer_set", ^{
-    [realtimeComposer_ setWithAmplitude:amplitude frequency:frequency startIfNeeded:startIfNeeded];
+    [realtimeComposer_ setWithAmplitude:amplitude frequency:frequency];
   });
 }
 

--- a/react-native/react-native-pulsar/jest-mock.js
+++ b/react-native/react-native-pulsar/jest-mock.js
@@ -62,7 +62,6 @@ const Settings = {
 };
 
 const useRealtimeComposer = jest.fn(() => ({
-  start: jest.fn(),
   set: jest.fn(),
   playDiscrete: jest.fn(),
   stop: jest.fn(),

--- a/react-native/react-native-pulsar/src/NativeRNPulsar.ts
+++ b/react-native/react-native-pulsar/src/NativeRNPulsar.ts
@@ -36,8 +36,7 @@ export interface Spec extends TurboModule {
   Pulsar_enableImpulseCompositionMode(state: boolean): void;
   Pulsar_setRealtimeComposerStrategy(strategy: RealtimeComposerStrategy): void;
 
-  RealtimeComposer_start(): void;
-  RealtimeComposer_set(amplitude: number, frequency: number, startIfNeeded: boolean): void;
+  RealtimeComposer_set(amplitude: number, frequency: number): void;
   RealtimeComposer_stop(): void;
   RealtimeComposer_isActive(): boolean;
   RealtimeComposer_playDiscrete(amplitude: number, frequency: number): void;

--- a/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
+++ b/react-native/react-native-pulsar/src/__tests__/jest-mock.test.tsx
@@ -32,9 +32,7 @@ describe('react-native-pulsar/jest-mock', () => {
 
   it('mocks the hooks and the composers they return', () => {
     const realtime = useRealtimeComposer();
-    realtime.start();
     realtime.set(1, 200);
-    expect(realtime.start).toHaveBeenCalled();
     expect(realtime.set).toHaveBeenCalledWith(1, 200);
     expect(realtime.isActive()).toBe(false);
 

--- a/react-native/react-native-pulsar/src/useRealtimeComposer.ts
+++ b/react-native/react-native-pulsar/src/useRealtimeComposer.ts
@@ -2,29 +2,22 @@ import { useCallback, useEffect } from 'react';
 import Pulsar from './NativeRNPulsar';
 
 // workaround for RN prototype caching issue
-Pulsar.RealtimeComposer_start;
 Pulsar.RealtimeComposer_set;
 Pulsar.RealtimeComposer_playDiscrete;
 Pulsar.RealtimeComposer_stop;
 Pulsar.RealtimeComposer_isActive;
 
 export type RealtimeComposer = {
-  start: () => void;
-  set: (amplitude: number, frequency: number, startIfNeeded?: boolean) => void;
+  set: (amplitude: number, frequency: number) => void;
   playDiscrete: (amplitude: number, frequency: number) => void;
   stop: () => void;
   isActive: () => boolean;
 };
 
 export default function useRealtimeComposer(): RealtimeComposer {
-  const start = useCallback(() => {
+  const set = useCallback((amplitude: number, frequency: number) => {
     'worklet';
-    Pulsar.RealtimeComposer_start();
-  }, []);
-
-  const set = useCallback((amplitude: number, frequency: number, startIfNeeded: boolean = false) => {
-    'worklet';
-    Pulsar.RealtimeComposer_set(amplitude, frequency, startIfNeeded);
+    Pulsar.RealtimeComposer_set(amplitude, frequency);
   }, []);
 
   const playDiscrete = useCallback((amplitude: number, frequency: number) => {
@@ -44,5 +37,5 @@ export default function useRealtimeComposer(): RealtimeComposer {
 
   useEffect(() => stop, [stop]);
 
-  return { start, set, playDiscrete, stop, isActive };
+  return { set, playDiscrete, stop, isActive };
 }


### PR DESCRIPTION
## What

Reverts the `start()` method added to the RealtimeComposer in #46 and restores the original behavior where `set(amplitude, frequency)` starts the realtime player automatically when it is not already active. The public realtime API is back to a single `set(amplitude, frequency)` entry point (plus `playDiscrete` / `stop` / `isActive`).

## Why

The #46 design split start from set: `set(...)` became a silent no-op until `start()` (or `set(..., startIfNeeded: true)`) was called. For gesture- and sensor-driven continuous haptics this is an easy footgun — e.g. the accelerometer demo went silent because nothing ever started the player. Going back to auto-start removes that sharp edge.

## Scope (all SDKs)

- **React Native** — drop `start` from `useRealtimeComposer`, the TurboModule spec (`NativeRNPulsar.ts`), the ObjC++ bridge (`Haptics.mm`), and the Android module; back out the `start` entry from the shipped jest mock + its test.
- **iOS** (Swift core) / **Android** (Kotlin core + envelope/primitive strategies) / **KMP** / **Flutter** — remove `start()` / `startIfNeeded` and reinstate auto-start inside `set`.
- **Docs** (`android`, `ios`, `kmp`, `flutter`, `react-native`) and all demo / example call sites updated back to the two-arg `set`.

## Notes for reviewers

- The in-progress screen-activity refactor in `useHapticsScreenActivity.ts` / `sensor-haptics-demo.tsx` is intentionally preserved.
- **Breaking change** for the SDKs that already published `start()`: React Native ≥ 1.6.0, iOS native ≥ 1.1.3, Android native 1.1.2. Their next release should bump accordingly and re-publish the core libs so apps stop hitting the no-auto-start behavior. Flutter / KMP never shipped `start()`, so no migration there.
- RN `jest-mock` test suite passes locally (4/4). Native targets were not compiled in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)