### PR TITLE
Figma plugin: add tags guide modal to Presets filters

### DIFF
--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -5,6 +5,7 @@ import type { BoundItem, CatalogEntry, SelectionInfo, Settings } from '../shared
 import { onMessage, send } from './figmaBridge';
 import { applyFilter, filterRevealing, useFilterStateInit, type FilterState } from './components/Filters';
 import PresetDetail from './components/PresetDetail';
+import TagsGuide from './components/TagsGuide';
 import PresetsTab from './components/PresetsTab';
 import LivePreviewPanel from './components/LivePreviewPanel';
 import BoundComponentsPanel from './components/BoundComponentsPanel';
@@ -34,6 +35,7 @@ export default function App() {
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [tab, setTab] = useState<Tab>('presets');
   const [openId, setOpenId] = useState<string | null>(null);
+  const [tagsGuideOpen, setTagsGuideOpen] = useState(false);
   const [filter, setFilter] = useState<FilterState>(useFilterStateInit());
   const [favourites, setFavourites] = useState<Set<string>>(new Set());
   const [favouritesOnly, setFavouritesOnly] = useState(false);
@@ -282,7 +284,8 @@ export default function App() {
           onPlay={playEntry}
           onBind={bindEntry}
           onOpen={setOpenId}
-          modalOpen={!!openEntry}
+          onShowTagsGuide={() => setTagsGuideOpen(true)}
+          modalOpen={!!openEntry || tagsGuideOpen}
           scrollToId={scrollToId}
           onScrolledToPreset={() => setScrollToId(null)}
         />
@@ -303,6 +306,14 @@ export default function App() {
               canPlayOnPhone={!!hapticsToken && phoneConnected}
               onBind={() => bindEntry(openEntry)}
             />
+          </div>
+        </div>
+      )}
+
+      {tagsGuideOpen && (
+        <div className={styles['modal-backdrop']} onClick={() => setTagsGuideOpen(false)}>
+          <div className={styles['modal-card']} onClick={(e) => e.stopPropagation()}>
+            <TagsGuide onClose={() => setTagsGuideOpen(false)} />
           </div>
         </div>
       )}

--- a/figma/src/ui/components/Filters.module.css
+++ b/figma/src/ui/components/Filters.module.css
@@ -16,3 +16,26 @@
 .filter-toggle-label { flex: 1; }
 .filter-group { margin-bottom: 12px; }
 .filter-group--flush { margin-bottom: 0; }
+
+/* Info trigger next to the "Filters" title — opens the tags guide. Flat icon
+   chip that only colours up on hover so it stays quiet in the header. */
+.tags-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-left: 6px;
+  padding: 0;
+  vertical-align: middle;
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  box-shadow: none;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 120ms ease, background 120ms ease;
+}
+.tags-info-btn:hover { opacity: 1; background: var(--surface); box-shadow: none; transform: none; }
+.tags-info-btn:active { transform: none; box-shadow: none; }
+.tags-info-btn img { display: block; }

--- a/figma/src/ui/components/Filters.tsx
+++ b/figma/src/ui/components/Filters.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import type { CatalogEntry } from '../../shared/types';
 import iconSliders from '../assets/icon-sliders-horizontal.svg';
 import iconChevron from '../assets/icon-chevron-down.svg';
+import iconInfo from '../assets/icon-info.svg';
 
 // Tag grouping mirrors the docs `TagsInfo`. Within a group selections are OR'd;
 // across groups they are AND'd.
@@ -36,12 +37,14 @@ export default function Filters({
   state,
   setState,
   favouritesOnly,
-  onFavouritesOnlyChange
+  onFavouritesOnlyChange,
+  onShowTagsGuide
 }: {
   state: FilterState;
   setState: (s: FilterState) => void;
   favouritesOnly: boolean;
   onFavouritesOnlyChange: (v: boolean) => void;
+  onShowTagsGuide: () => void;
 }) {
   const update = (patch: Partial<FilterState>) => setState({ ...state, ...patch });
 
@@ -65,7 +68,24 @@ export default function Filters({
         <span className="acc-icon">
           <img src={iconSliders} alt="" />
         </span>
-        <span className="acc-title">Filters</span>
+        <span className="acc-title">
+          Filters
+          {/* Opens the tags guide. Lives inside <summary>, so swallow the click
+              to stop it toggling the accordion. */}
+          <button
+            type="button"
+            className={styles['tags-info-btn']}
+            title="Learn more about tags"
+            aria-label="Learn more about tags"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onShowTagsGuide();
+            }}
+          >
+            <img src={iconInfo} alt="" width={14} height={14} />
+          </button>
+        </span>
         {activeCount > 0 && (
           <span className="tag active tag-flush">{activeCount}</span>
         )}

--- a/figma/src/ui/components/PresetsTab.tsx
+++ b/figma/src/ui/components/PresetsTab.tsx
@@ -30,6 +30,7 @@ export default function PresetsTab({
   onPlay,
   onBind,
   onOpen,
+  onShowTagsGuide,
   modalOpen,
   scrollToId,
   onScrolledToPreset
@@ -54,6 +55,8 @@ export default function PresetsTab({
   onPlay: (entry: CatalogEntry) => void;
   onBind: (entry: CatalogEntry) => void;
   onOpen: (id: string) => void;
+  // Opens the "Tags guide" modal (info icon in the Filters header).
+  onShowTagsGuide: () => void;
   // Whether the preset-detail modal is open (hides the scroll-to-top FAB).
   modalOpen: boolean;
   // When set, scroll that preset into view + flash it (e.g. jumped to from the
@@ -110,6 +113,7 @@ export default function PresetsTab({
               setState={setFilter}
               favouritesOnly={favouritesOnly}
               onFavouritesOnlyChange={setFavouritesOnly}
+              onShowTagsGuide={onShowTagsGuide}
             />
             <AddCustomPreset
               customPresets={customPresets}

--- a/figma/src/ui/components/TagsGuide.module.css
+++ b/figma/src/ui/components/TagsGuide.module.css
@@ -1,0 +1,142 @@
+/* Tags guide modal — rendered inside App's .modal-card chrome. Head bar and
+   close button mirror PresetDetail.module.css; the underlined tab strip mirrors
+   its .docs-tabs; the per-tag cards mirror the docs TagDescription recipe
+   (blue-10 fill, white tag pill with offset shadow). */
+
+.modal-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--color-blue-20);
+  background: var(--color-blue-10);
+}
+.modal-head-text { flex: 1; min-width: 0; }
+.modal-title {
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  color: var(--color-primary);
+  line-height: 1.25;
+}
+.modal-close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: var(--surface);
+  border: 1px solid var(--color-blue-20);
+  border-radius: var(--radius);
+  color: var(--color-primary);
+  box-shadow: none;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+.modal-close:hover {
+  background: var(--color-blue-10);
+  border-color: var(--color-blue-50);
+  box-shadow: -2px 2px 0 var(--color-blue-50);
+  transform: translate(1px, -1px);
+}
+.modal-close:active { transform: translate(-1px, 1px); box-shadow: none; }
+
+.modal-body {
+  padding: 14px 16px 16px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Underlined tab strip — identical recipe to PresetDetail's SDK tabs. Sticks to
+   the top of the scrollable body so switching dimension is always reachable. */
+.docs-tabs {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  border-bottom: 2px solid var(--color-blue-10);
+  background: var(--surface);
+}
+.docs-tab {
+  padding: 5px 10px;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: var(--fs-2xs);
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  box-shadow: none;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+.docs-tab:hover { color: var(--color-primary); transform: none; box-shadow: none; }
+.docs-tab.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-blue-50);
+  background: var(--color-blue-10);
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+}
+.docs-tab:active { transform: none; box-shadow: none; }
+
+/* Per-tag cards — one blue-10 card per tag, matching docs TagDescription. */
+.tag-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.tag-card {
+  background: var(--color-blue-10);
+  padding: 16px;
+  border-radius: var(--radius);
+}
+.tag-pill {
+  display: inline-block;
+  padding: 4px 10px;
+  background: var(--surface);
+  border: 2px solid var(--color-blue-50);
+  border-radius: 2px;
+  box-shadow: -2px 2px 0 var(--color-blue-50);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-bottom: 14px;
+}
+.tag-desc {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--color-primary);
+  margin-bottom: 8px;
+}
+.tag-usage {
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+  color: var(--color-primary);
+}
+.tag-usage-label { font-weight: 700; }
+
+/* Docs-aligned scrollbar — thin transparent track, blue-tinted thumb. */
+.modal-body { scrollbar-width: thin; scrollbar-color: var(--color-blue-20) transparent; }
+.modal-body::-webkit-scrollbar { width: 8px; }
+.modal-body::-webkit-scrollbar-track { background: transparent; }
+.modal-body::-webkit-scrollbar-thumb {
+  background: var(--color-blue-20);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.modal-body::-webkit-scrollbar-thumb:hover {
+  background: var(--color-blue-30);
+  background-clip: padding-box;
+}

--- a/figma/src/ui/components/TagsGuide.tsx
+++ b/figma/src/ui/components/TagsGuide.tsx
@@ -1,0 +1,71 @@
+import styles from './TagsGuide.module.css';
+import { useEffect, useState } from 'react';
+import { TagsInfo } from './tagsInfo';
+import iconClose from '../assets/icon-close.svg';
+
+// "Tags guide" modal — the plugin counterpart to the docs TagsModal
+// (docs/.../components/TagsModal). Explains every haptic tag grouped by
+// dimension (Intensity / Sharpness / Shape / Duration) behind underlined
+// tabs, with one blue-10 card per tag describing it and listing typical
+// usage. Rendered inside App's shared .modal-card chrome, so it reuses the
+// same head bar / close button recipe as PresetDetail.
+export default function TagsGuide({ onClose }: { onClose: () => void }) {
+  const [activeTab, setActiveTab] = useState(0);
+  const group = TagsInfo[activeTab];
+
+  // Esc closes — matches PresetDetail's affordance.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <header className={styles['modal-head']}>
+        <div className={styles['modal-head-text']}>
+          <div className={styles['modal-title']}>Tags guide</div>
+        </div>
+        <button
+          className={styles['modal-close']}
+          onClick={onClose}
+          title="Close (Esc)"
+          aria-label="Close"
+        >
+          <img src={iconClose} alt="" width={14} height={14} />
+        </button>
+      </header>
+
+      <div className={styles['modal-body']}>
+        <div className={styles['docs-tabs']} role="tablist">
+          {TagsInfo.map((g, i) => (
+            <button
+              key={g.groupName}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === i}
+              className={`${styles['docs-tab']}${activeTab === i ? ` ${styles['active']}` : ''}`}
+              onClick={() => setActiveTab(i)}
+            >
+              {g.groupName}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles['tag-cards']}>
+          {group.tags.map((tag) => (
+            <div key={tag.name} className={styles['tag-card']}>
+              <div className={styles['tag-pill']}>{tag.name}</div>
+              <div className={styles['tag-desc']}>{tag.description}</div>
+              <div className={styles['tag-usage']}>
+                <span className={styles['tag-usage-label']}>Usage:</span> {tag.usage}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/figma/src/ui/components/tagsInfo.ts
+++ b/figma/src/ui/components/tagsInfo.ts
@@ -1,0 +1,148 @@
+// Tag taxonomy reference used by the Filters "Tags guide" modal. Mirrors the
+// docs `TagsInfo` (docs/src/content/docs/components/PresetsList/Tags.ts) so the
+// plugin and the web documentation describe haptic tags identically. Keep the
+// two in sync when tag copy changes.
+export type TagInfo = { name: string; description: string; usage: string };
+export type TagGroupInfo = { groupName: string; tags: TagInfo[] };
+
+export const TagsInfo: TagGroupInfo[] = [
+  {
+    groupName: 'Intensity',
+    tags: [
+      {
+        name: 'Gentle',
+        description:
+          'Haptics with low amplitude — barely perceptible vibration that stays in the background.',
+        usage:
+          'Good for subtle confirmations, hover effects, or any interaction where the feedback should not interrupt the user. Common situations: cursor hover, background sync, silent notification, passive scroll boundary nudge, accessibility hints.'
+      },
+      {
+        name: 'Substantial',
+        description:
+          'Haptics with medium amplitude — a clear, balanced vibration that is easy to notice without being disruptive.',
+        usage:
+          'Ideal for most standard UI interactions such as button presses, toggles, or form confirmations. Common situations: button tap, toggle switch, form validation, menu item selection, pull-to-refresh trigger.'
+      },
+      {
+        name: 'Bold',
+        description:
+          'Haptics with high amplitude — a strong, attention-commanding vibration that is immediately felt.',
+        usage:
+          "Best for critical alerts, error states, or high-impact moments that require the user's immediate attention. Common situations: payment failure, security alert, authentication error, destructive action confirmation, game hit or collision."
+      }
+    ]
+  },
+  {
+    groupName: 'Sharpness',
+    tags: [
+      {
+        name: 'Soft',
+        description:
+          'Haptics with low frequency — a smooth, rounded vibration with a gentle, cushioned feel.',
+        usage:
+          'Perfect for calm, ambient feedback, wellness interactions, or any context where a soft touch is preferred. Common situations: sleep reminder, gentle onboarding hint, ambient soundscape interaction.'
+      },
+      {
+        name: 'Flexible',
+        description:
+          'Haptics with medium frequency — a balanced vibration that sits between soft and rigid.',
+        usage:
+          'Suitable for general-purpose UI feedback, notifications, and interactions that need a neutral tactile character. Common situations: incoming message, push notification, content scroll snap, date picker tick, standard in-app alert.'
+      },
+      {
+        name: 'Rigid',
+        description:
+          'Haptics with high frequency — a crisp, precise vibration with a sharp, mechanical feel.',
+        usage:
+          'Great for snappy UI elements, keyboard-like taps, or any interaction that should feel precise and definitive. Common situations: virtual keyboard key press, numeric keypad tap, rotary dial click, picker wheel snap, PIN entry digit confirmation.'
+      }
+    ]
+  },
+  {
+    groupName: 'Shape',
+    tags: [
+      {
+        name: 'Peak',
+        description:
+          'Haptics with a single amplitude peak — a quick rise and fall in intensity.',
+        usage:
+          'Ideal for single-event feedback, such as button presses or selection confirmations. Common situations: like or heart button tap, photo shutter release, item selection confirmation, swipe action completion, quick reply send.'
+      },
+      {
+        name: 'Impulses',
+        description:
+          'Haptics with a discrete pattern — short, distinct pulses separated by silence.',
+        usage:
+          'Useful for click-like feedback, Morse-style cues, or sequences of distinct tactile events. Common situations: step counter tick, quantity increment, metronome cue, item added to cart, typing indicator in chat.'
+      },
+      {
+        name: 'Solid',
+        description:
+          'Haptics with a long continuous pattern at a constant amplitude — a steady, uniform vibration.',
+        usage:
+          'Good for indicating ongoing processes, loading states, or sustained alerts that need consistent presence. Common situations: file upload or download in progress, active voice recording, hold-to-confirm gesture, persistent alarm, live activity tracking.'
+      },
+      {
+        name: 'Bumps',
+        description:
+          'Haptics with multiple amplitude peaks — a series of rhythmic rises and falls.',
+        usage:
+          'Perfect for multi-step feedback, rhythmic notifications, or interactions that need a repeating pulse feel. Common situations: in-app achievement or badge unlock, multi-item batch selection, dice roll, streak milestone reached, coin or reward collection.'
+      },
+      {
+        name: 'Saw',
+        description:
+          'Haptics with a sawtooth-shaped amplitude pattern — a sharp rise followed by an abrupt drop, or vice versa.',
+        usage:
+          'Effective for mechanical-feeling interactions, ratchet effects, or any feedback with a sharp, asymmetric edge. Common situations: ratchet scroll, slot machine reel spin, rotary dial simulation, drag-and-drop snap into position, file shredding animation.'
+      },
+      {
+        name: 'Pattern',
+        description:
+          'Haptics with a custom, often repeating amplitude pattern — a structured sequence that defines a unique rhythm.',
+        usage:
+          'Best for branded feedback signatures, complex notifications, or effects that carry a recognizable tactile identity. Common situations: branded notification signature, custom incoming call alert, game character footstep cycle, sound-to-haptic mapping, recurring rhythm in a music app.'
+      },
+      {
+        name: 'Ramp',
+        description:
+          'Haptics with a ramp-shaped amplitude pattern — amplitude increases or decreases linearly over the duration.',
+        usage:
+          'Suited for fade-in or fade-out effects, swipe feedback, or any interaction that should feel like a gradual build or release. Common situations: volume or brightness slider, swipe-to-dismiss gesture, pinch zoom, countdown timer nearing zero, pull-down refresh building tension.'
+      }
+    ]
+  },
+  {
+    groupName: 'Duration',
+    tags: [
+      {
+        name: 'Impulse',
+        description:
+          'Extremely short haptic lasting less than 100 ms — an instantaneous tactile click.',
+        usage:
+          'Best for keyboard taps, quick confirmations, or any interaction that requires an instant, minimal response. Common situations: virtual keyboard key press, quick tap micro-interaction, toggle switch flip, checkbox tick, cursor click simulation.'
+      },
+      {
+        name: 'Short',
+        description:
+          'Brief haptic lasting between 100 ms and 250 ms — long enough to be clearly felt without lingering.',
+        usage:
+          'Ideal for button presses, toggle switches, and standard UI element interactions. Common situations: primary action button press, navigation tab switch, swipe gesture acknowledgement, photo filter selection, card flip or reveal.'
+      },
+      {
+        name: 'Extended',
+        description:
+          'Medium-length haptic lasting between 250 ms and 600 ms — provides richer, more expressive feedback.',
+        usage:
+          'Good for notifications, multi-step confirmations, or interactions that benefit from a more deliberate tactile moment. Common situations: incoming push notification, payment or purchase success, pull-to-refresh completion, form submission success, app rating prompt.'
+      },
+      {
+        name: 'Long',
+        description:
+          'Prolonged haptic lasting 600 ms or more — creates an immersive, sustained tactile experience.',
+        usage:
+          'Best for complex animations, gaming effects, elaborate alerts, or experiences where the haptic plays a central role. Common situations: in-app achievement or level completion, onboarding celebration, game victory screen, subscription or reward unlock, end-of-session summary celebration.'
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## What

Adds an **info icon** next to the **Filters** title in the Figma plugin's Presets tab. Clicking it opens a **Tags guide** modal that explains every haptic tag — mirroring the approach and design already used on the [web documentation](https://github.com/software-mansion/pulsar/tree/main/docs/src/content/docs/components/TagsModal).

## Why

The web docs have a tags-explanation modal behind an info icon, but the Figma plugin's filter chips had no equivalent — users filtering by tags had no in-context way to learn what each tag means. This brings the two surfaces to parity.

## Changes

- **New `TagsGuide` modal** (`TagsGuide.tsx` / `TagsGuide.module.css`) — underlined tabs per dimension (Intensity / Sharpness / Shape / Duration), one blue-10 card per tag with its description and typical usage. Mirrors the docs' `TagsModal` + `TagDescription` recipe, while reusing the plugin's existing `.modal-card` chrome and `PresetDetail` head/close styling so it feels native to the plugin. Esc and backdrop-click close it.
- **`tagsInfo.ts`** — tag copy ported verbatim from the docs `PresetsList/Tags.ts`, with a note to keep the two in sync.
- **Info trigger** in `Filters.tsx` — a quiet info-icon button (the same Lucide info glyph the docs use) inside the `<summary>`; its click is swallowed (`preventDefault` + `stopPropagation`) so it opens the guide without toggling the Filters accordion.
- **Wiring** — `onShowTagsGuide` threads `App → PresetsTab → Filters`; the modal renders at `App` level alongside the existing preset-detail modal, and `modalOpen` now accounts for it so the scroll-to-top FAB stays hidden while it's open.

## Notes for reviewers

- The tag descriptions in `tagsInfo.ts` duplicate the docs' `Tags.ts` (the two packages don't share a module). Keep them in sync when tag copy changes.
- `tsc --noEmit` passes for both the UI and main tsconfigs.
- This is a Figma-plugin UI change (runs inside Figma's iframe), so there's no browser preview to attach; build with `npm run build` in `figma/` and reload the plugin in Figma to see it live.