### PR TITLE
feat(figma): live haptics-config updates to an open live preview

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -7,6 +7,7 @@ import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import type { Pattern } from 'react-native-pulsar';
 
 import { FIGMA_PREVIEW_URL } from '@/constants/Connection';
+import { useConnections } from '@/contexts/ConnectionsContext';
 import { usePlayPatternFromHost } from '@/src/haptics/playPattern';
 import { ThemedText } from '@/components/themed-text';
 import BasicLayout from '@/components/BasicLayout';
@@ -30,6 +31,24 @@ const fullscreenEdges = {
   bottom: 'off',
   right: 'off',
 };
+
+// Build a script that delivers a live haptics-config update into the preview.
+// The preview runs either at the top level (local dev) or inside an <iframe
+// srcdoc> (the production docs embed), so we post to the top document AND to
+// every child iframe's contentWindow — same-origin (the srcdoc inherits our
+// origin), so the post is allowed.
+function buildPreviewInjection(envelope: unknown): string {
+  // JSON is a valid JS expression on the ES2019+ engines these WebViews use
+  // (U+2028/U+2029 are legal in string literals), so embed it directly.
+  const json = JSON.stringify(envelope);
+  return (
+    `(function(){try{var u=${json};` +
+    `window.postMessage(u,'*');` +
+    `var f=document.querySelectorAll('iframe');` +
+    `for(var i=0;i<f.length;i++){try{f[i].contentWindow&&f[i].contentWindow.postMessage(u,'*');}catch(e){}}` +
+    `}catch(e){}})();true;`
+  );
+}
 
 // Figma tab. Two modes:
 //   1. Deep-linked from the Figma plugin (`pulsarapp://figma?token=<token>`)
@@ -60,6 +79,28 @@ function FigmaPreviewWebView({ token }: { token: string }) {
   const webRef = useRef<WebView>(null);
   const playFromHost = usePlayPatternFromHost();
   const navigation = useNavigation();
+  const { lastPreviewUpdate } = useConnections();
+
+  // Deliver live haptics-config updates relayed by the plugin into the preview.
+  // Seed the handled nonce at mount so an update that arrived before this
+  // preview opened doesn't fire on first render; only newer ones inject.
+  const handledNonceRef = useRef<number | null>(lastPreviewUpdate?.nonce ?? null);
+  useEffect(() => {
+    const update = lastPreviewUpdate;
+    if (!update || handledNonceRef.current === update.nonce) return;
+    handledNonceRef.current = update.nonce;
+    // Ignore updates targeting a different preview than the one we're showing.
+    if (update.previewToken && update.previewToken !== token) return;
+    webRef.current?.injectJavaScript(
+      buildPreviewInjection({
+        type: 'pulsar-haptics-update',
+        kind: update.kind,
+        fromRevision: update.fromRevision,
+        toRevision: update.toRevision,
+        diff: update.diff,
+      })
+    );
+  }, [lastPreviewUpdate, token]);
 
   const [tabBarHidden, setTabBarHidden] = useState(false);
   useEffect(() => {

--- a/PulsarApp/constants/Connection.ts
+++ b/PulsarApp/constants/Connection.ts
@@ -5,4 +5,10 @@ export const SOCKET_SERVER_URL = 'wss://pulsar-server.swmansion.com';
 // export const SOCKET_SERVER_URL = 'ws://localhost:8080';
 
 export const FIGMA_PREVIEW_URL = 'https://docs.swmansion.com/pulsar/figma-preview/';
+// Local override for testing live haptics-config updates against a
+// listener-equipped preview before docs is redeployed: run
+// `cd figma/preview && npm run dev` (serves :5173) and swap the line above for
+// the one below. iOS simulator reaches the host via localhost; a physical
+// device needs the machine's LAN IP instead.
+// export const FIGMA_PREVIEW_URL = 'http://localhost:5173/';
 

--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -59,6 +59,20 @@ export interface ReceivedPattern {
   name: string;
 }
 
+// A live haptics-config update relayed by the Figma plugin over the paired
+// channel, destined for an open live preview. The payload is forwarded verbatim
+// to the WebView (figma.tsx); we only read `previewToken` (to match the right
+// open preview) here. `nonce` is monotonic so an identical repeat still
+// re-triggers the consumer effect.
+export interface PreviewUpdate {
+  kind: 'preview-haptics-diff' | 'preview-haptics-refetch';
+  previewToken?: string;
+  fromRevision?: number;
+  toRevision?: number;
+  diff?: unknown;
+  nonce: number;
+}
+
 interface ConnectionsContextValue {
   connections: Connection[];
   // Pair a new producer from a 4-digit code (manual entry or a scanned QR).
@@ -69,6 +83,9 @@ interface ConnectionsContextValue {
   reconnect: (id: string) => void;
   // Transient "preset received" banner, auto-cleared shortly after the last hit.
   lastReceived: ReceivedPattern | null;
+  // Most recent live haptics-config update relayed by a producer, for an open
+  // live preview to apply. Null until the first update arrives.
+  lastPreviewUpdate: PreviewUpdate | null;
 }
 
 const ConnectionsContext = createContext<ConnectionsContextValue | undefined>(undefined);
@@ -85,6 +102,7 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   const posthog = usePostHog();
   const [connections, setConnections] = useState<Connection[]>([]);
   const [lastReceived, setLastReceived] = useState<ReceivedPattern | null>(null);
+  const [lastPreviewUpdate, setLastPreviewUpdate] = useState<PreviewUpdate | null>(null);
   // Gate persistence until the initial load runs, so the first (empty) render
   // doesn't clobber the stored list before it's restored.
   const [didLoad, setDidLoad] = useState(false);
@@ -95,6 +113,9 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   const appStateRef = useRef(AppState.currentState);
   const notifyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastUrlRef = useRef<string | null>(null);
+  // Monotonic counter so two identical preview updates still re-trigger the
+  // preview consumer (e.g. a binding toggled back and forth).
+  const previewNonceRef = useRef(0);
 
   useEffect(() => {
     connectionsRef.current = connections;
@@ -207,14 +228,35 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
             break;
           case 'pong':
             break;
-          case 'broadcast':
-            // Producers send a preset *name* (a string). Ignore anything else so
-            // a malformed/structured payload can never throw here.
-            if (typeof json.message === 'string') {
-              const found = playPattern(json.message);
-              notify(found, json.message);
+          case 'broadcast': {
+            // A producer sends either a preset *name* (a string, to play now) or
+            // a structured live-preview update (an object). Branch on the shape
+            // so neither path can throw on the other's payload.
+            const msg = json.message;
+            if (typeof msg === 'string') {
+              const found = playPattern(msg);
+              notify(found, msg);
+            } else if (
+              msg &&
+              typeof msg === 'object' &&
+              typeof (msg as { kind?: unknown }).kind === 'string' &&
+              (msg as { kind: string }).kind.startsWith('preview-haptics-')
+            ) {
+              // Forwarded verbatim to the open live preview (figma.tsx). Match on
+              // the producer-supplied previewToken, falling back to the one this
+              // connection advertised at pairing time.
+              const update = msg as Omit<PreviewUpdate, 'nonce'>;
+              const fallbackToken =
+                connectionsRef.current.find((c) => c.id === conn.id)?.previewToken ??
+                conn.previewToken;
+              setLastPreviewUpdate({
+                ...update,
+                previewToken: update.previewToken ?? fallbackToken,
+                nonce: ++previewNonceRef.current,
+              });
             }
             break;
+          }
         }
       };
 
@@ -394,7 +436,9 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <ConnectionsContext.Provider value={{ connections, addByCode, remove, reconnect, lastReceived }}>
+    <ConnectionsContext.Provider
+      value={{ connections, addByCode, remove, reconnect, lastReceived, lastPreviewUpdate }}
+    >
       {children}
     </ConnectionsContext.Provider>
   );

--- a/docs/server/tests/connection-manager.test.ts
+++ b/docs/server/tests/connection-manager.test.ts
@@ -100,6 +100,21 @@ describe('ConnectionManager', () => {
       expect(frames(receiver)).toContainEqual({ type: 'broadcast', message: 'hello' });
     });
 
+    it('relays a structured live-preview update object intact', () => {
+      const { receiver, token } = pair();
+      const before = receiver.sent.length;
+      const update = {
+        kind: 'preview-haptics-diff',
+        previewToken: 'pub-123',
+        fromRevision: 4,
+        toRevision: 5,
+        diff: { bindings: { set: { 'a:1': { name: 'breakingWave' } }, del: ['b:2'] } },
+      };
+      expect(cm.broadcastChannel(JSON.stringify(update), token)).toBe('ok');
+      const delivered = frames(receiver).slice(before);
+      expect(delivered).toContainEqual({ type: 'broadcast', message: update });
+    });
+
     it('returns an error string for an unknown token', () => {
       expect(cm.broadcastChannel('hi', 'unknown-token')).toBe(
         'Invalid token or no active connection found',

--- a/docs/server/tests/websocket.test.ts
+++ b/docs/server/tests/websocket.test.ts
@@ -76,6 +76,14 @@ describe('WebSocket pairing protocol', () => {
 
   function connect(query: string): WebSocket {
     const ws = new WebSocket(`${running.wsUrl}/?${query}`);
+    // Fire-and-forget sender sockets are never awaited. Closing one in afterEach
+    // while its handshake is still in flight makes ws emit an 'error'
+    // ("WebSocket was closed before the connection was established"); with no
+    // listener Node rethrows it as an unhandled error and fails whichever test
+    // just ran (nondeterministically, by handshake timing). A no-op handler
+    // keeps these expected teardown aborts benign. Tests that need to observe
+    // connection errors attach their own 'error' listener on top of this.
+    ws.on('error', () => {});
     sockets.push(ws);
     return ws;
   }

--- a/figma/preview/src/App.tsx
+++ b/figma/preview/src/App.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FrameInfo, NodeBox, PresetData, PreviewPayload } from './types';
 import { getTokenFromUrl, readPayload } from './lib/payload';
 import { normalizeId } from './lib/ids';
+import { applyDiff, type HapticsDiff } from './lib/applyDiff';
+import { useHostUpdates } from './lib/useHostUpdates';
 import { useFigmaMessages } from './lib/useFigmaMessages';
 import { useFullscreen } from './lib/useFullscreen';
 import { useIsMobile } from './lib/useIsMobile';
@@ -37,10 +39,20 @@ export default function App() {
   // Set when the server reports the share link was made private (403). Drives a
   // dedicated empty state distinct from "no design loaded".
   const [isPrivate, setIsPrivate] = useState(false);
+  // The server revision our current `payload` reflects, and a mirror of the
+  // payload itself — both in refs so the (stable) host-update handlers below can
+  // read the latest values without re-binding the window message listener.
+  const revisionRef = useRef(0);
+  const payloadRef = useRef<PreviewPayload | null>(null);
+  useEffect(() => {
+    payloadRef.current = payload;
+  }, [payload]);
+
   useEffect(() => {
     let cancelled = false;
     readPayload().then((res) => {
       if (cancelled) return;
+      if (res.status === 'ok') revisionRef.current = res.revision;
       setPayload(res.status === 'ok' ? res.payload : null);
       setIsPrivate(res.status === 'private');
       setPayloadLoaded(true);
@@ -49,6 +61,54 @@ export default function App() {
       cancelled = true;
     };
   }, []);
+
+  // Re-pull the whole config from the server in place (no iframe reload). When a
+  // minimum revision is known, retry briefly to ride out read-after-write lag so
+  // we never settle on a snapshot older than the change that triggered us.
+  const refetch = useCallback(async (minRevision?: number) => {
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const res = await readPayload();
+      if (res.status === 'ok') {
+        if (minRevision != null && res.revision < minRevision && attempt < 3) {
+          await new Promise((r) => setTimeout(r, 250));
+          continue;
+        }
+        revisionRef.current = res.revision;
+        payloadRef.current = res.payload;
+        setPayload(res.payload);
+        setIsPrivate(false);
+        setPayloadLoaded(true);
+        return;
+      }
+      if (res.status === 'private') {
+        payloadRef.current = null;
+        setPayload(null);
+        setIsPrivate(true);
+        setPayloadLoaded(true);
+      }
+      // 'missing' / 'no-token': leave the current state as-is and stop retrying.
+      return;
+    }
+  }, []);
+
+  // Apply a relayed delta in place when our revision is exactly the one the diff
+  // was computed against; otherwise we've missed an update (a gap) — refetch.
+  const onDiff = useCallback(
+    (fromRevision: number, toRevision: number, diff: HapticsDiff) => {
+      if (!payloadRef.current || revisionRef.current !== fromRevision) {
+        void refetch(toRevision);
+        return;
+      }
+      const next = applyDiff(payloadRef.current, diff);
+      payloadRef.current = next;
+      revisionRef.current = toRevision;
+      setPayload(next);
+    },
+    [refetch]
+  );
+  const onRefetch = useCallback((toRevision: number) => void refetch(toRevision), [refetch]);
+  const hostHandlers = useMemo(() => ({ onDiff, onRefetch }), [onDiff, onRefetch]);
+  useHostUpdates(hostHandlers);
 
   // Derived lookup maps (stable across renders).
   const { bindings, ownerMap, presentedId, frames } = useMemo(() => {

--- a/figma/preview/src/lib/applyDiff.ts
+++ b/figma/preview/src/lib/applyDiff.ts
@@ -1,0 +1,53 @@
+import type { ElementInfo, FrameInfo, NodeBox, PresetData, PreviewPayload } from '../types';
+
+// Delta over the render-relevant parts of a PreviewPayload. Mirrors the
+// plugin's figma/src/ui/lib/diffPayload.ts `HapticsDiff` — the two are
+// hand-kept in sync (same convention as the rest of the preview/plugin type
+// mirror). `set` upserts entries; `del` lists removed keys/ids.
+export interface HapticsDiff {
+  bindings?: { set: Record<string, PresetData>; del: string[] };
+  owner?: { set: Record<string, string>; del: string[] };
+  elements?: { set: ElementInfo[]; del: string[] };
+  frames?: { set: Record<string, FrameInfo | NodeBox>; del: string[] };
+}
+
+function patchRecord<T>(
+  base: Record<string, T> | undefined,
+  delta: { set: Record<string, T>; del: string[] } | undefined,
+): Record<string, T> {
+  const out: Record<string, T> = { ...(base ?? {}) };
+  if (!delta) return out;
+  for (const id of delta.del) delete out[id];
+  for (const [id, v] of Object.entries(delta.set)) out[id] = v;
+  return out;
+}
+
+// Apply a diff to a payload immutably, returning a new payload. `fileKey`,
+// `nodeId`, and `frame` are preserved untouched — a diff never moves the
+// presented node (the app's Figma iframe owns that) or changes the prototype.
+export function applyDiff(payload: PreviewPayload, diff: HapticsDiff): PreviewPayload {
+  const next: PreviewPayload = {
+    ...payload,
+    bindings: patchRecord(payload.bindings, diff.bindings),
+    owner: patchRecord(payload.owner, diff.owner),
+  };
+
+  if (diff.frames) {
+    next.frames = patchRecord(payload.frames, diff.frames);
+  }
+
+  if (diff.elements) {
+    const del = new Set(diff.elements.del);
+    const setById = new Map(diff.elements.set.map((e) => [e.id, e]));
+    // Keep existing order, replacing changed entries and dropping removed ones,
+    // then append any genuinely new elements.
+    const kept = (payload.elements ?? [])
+      .filter((e) => !del.has(e.id))
+      .map((e) => setById.get(e.id) ?? e);
+    const existingIds = new Set(kept.map((e) => e.id));
+    const added = diff.elements.set.filter((e) => !existingIds.has(e.id));
+    next.elements = [...kept, ...added];
+  }
+
+  return next;
+}

--- a/figma/preview/src/lib/payload.ts
+++ b/figma/preview/src/lib/payload.ts
@@ -30,7 +30,7 @@ export function getTokenFromUrl(): string | null {
 //   - 'no-token' → no ?token= in the URL (the bare preview app).
 //   - 'missing'  → token present but the project is gone / unreadable (404 etc.).
 export type PayloadResult =
-  | { status: 'ok'; payload: PreviewPayload }
+  | { status: 'ok'; payload: PreviewPayload; revision: number }
   | { status: 'private' }
   | { status: 'no-token' }
   | { status: 'missing' };
@@ -53,18 +53,23 @@ export async function readPayload(): Promise<PayloadResult> {
     // can explain the link was revoked rather than showing "no design loaded".
     if (res.status === 403) return { status: 'private' };
     if (!res.ok) return { status: 'missing' };
-    const data = (await res.json()) as { success: boolean; config?: PreviewPayload | string };
+    const data = (await res.json()) as {
+      success: boolean;
+      config?: PreviewPayload | string;
+      revision?: number;
+    };
     if (!data.success || !data.config) return { status: 'missing' };
+    const revision = typeof data.revision === 'number' ? data.revision : 0;
     // Server returns the parsed object when storage was JSON; fall back to
     // parsing if it handed back a raw string for any reason.
     if (typeof data.config === 'string') {
       try {
-        return { status: 'ok', payload: JSON.parse(data.config) as PreviewPayload };
+        return { status: 'ok', payload: JSON.parse(data.config) as PreviewPayload, revision };
       } catch {
         return { status: 'missing' };
       }
     }
-    return { status: 'ok', payload: data.config };
+    return { status: 'ok', payload: data.config, revision };
   } catch {
     return { status: 'missing' };
   }

--- a/figma/preview/src/lib/useHostUpdates.ts
+++ b/figma/preview/src/lib/useHostUpdates.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import type { HapticsDiff } from './applyDiff';
+
+// Envelope posted into the preview by the PulsarApp WebView host
+// (PulsarApp/app/(tabs)/figma.tsx → buildPreviewInjection) when the Figma
+// plugin relays a live haptics-config change over the paired socket.
+interface HapticsUpdateEnvelope {
+  type: 'pulsar-haptics-update';
+  kind: 'preview-haptics-diff' | 'preview-haptics-refetch';
+  fromRevision?: number;
+  toRevision?: number;
+  diff?: HapticsDiff;
+}
+
+// Listen for host-relayed config updates. Pass stable handlers (useMemo/
+// useCallback) so the listener doesn't re-bind every render. `onDiff` applies an
+// incremental delta; `onRefetch` re-pulls the whole config from the server.
+export function useHostUpdates(handlers: {
+  onDiff: (fromRevision: number, toRevision: number, diff: HapticsDiff) => void;
+  onRefetch: (toRevision: number) => void;
+}) {
+  useEffect(() => {
+    const listener = (event: MessageEvent) => {
+      const data = event.data as HapticsUpdateEnvelope | null;
+      if (!data || data.type !== 'pulsar-haptics-update') return;
+      if (
+        data.kind === 'preview-haptics-diff' &&
+        data.diff &&
+        typeof data.fromRevision === 'number' &&
+        typeof data.toRevision === 'number'
+      ) {
+        handlers.onDiff(data.fromRevision, data.toRevision, data.diff);
+      } else if (data.kind === 'preview-haptics-refetch' && typeof data.toRevision === 'number') {
+        handlers.onRefetch(data.toRevision);
+      }
+    };
+    window.addEventListener('message', listener);
+    return () => window.removeEventListener('message', listener);
+  }, [handlers]);
+}

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -10,7 +10,7 @@ import PresetsTab from './components/PresetsTab';
 import LivePreviewPanel from './components/LivePreviewPanel';
 import BoundComponentsPanel from './components/BoundComponentsPanel';
 import OnboardingPanel from './components/OnboardingPanel';
-import { broadcastToPhone } from './components/PhonePanel';
+import { broadcastToPhone, broadcastPreviewUpdate } from './components/PhonePanel';
 import SelectionBar from './components/SelectionBar';
 import PulsarLogo from './components/PulsarLogo';
 import ResizeHandle from './components/ResizeHandle';
@@ -58,7 +58,18 @@ export default function App() {
 
   // Live-preview / sharing sync — owns the server token bookkeeping and the
   // share affordances; listens for project / doc-changed / preview-data itself.
-  const previewSync = usePreviewSync({ settings, figmaFileKey, presetById, notify });
+  // On every persisted publish it hands us a diff/refetch message to relay to an
+  // open live preview; we only broadcast it when a phone is actually connected
+  // (same gating as "play on phone").
+  const previewSync = usePreviewSync({
+    settings,
+    figmaFileKey,
+    presetById,
+    notify,
+    onPublished: (message) => {
+      if (hapticsToken && phoneConnected) broadcastPreviewUpdate(hapticsToken, message);
+    }
+  });
 
   // Wire up the bridge once for the messages App owns (init, selection, bound
   // list, toasts). Sync-related messages are handled inside usePreviewSync.

--- a/figma/src/ui/components/PhonePanel.tsx
+++ b/figma/src/ui/components/PhonePanel.tsx
@@ -355,3 +355,19 @@ export async function broadcastToPhone(token: string, presetName: string) {
     console.warn('broadcast failed', e);
   }
 }
+
+// Relay a structured object to the paired phone over the same channel. The
+// server JSON.parses the `message`, so an object survives the relay structured
+// (bare preset names stay strings — see connection-manager.broadcastChannel).
+// Used to push live haptics-config updates to an open live preview.
+export async function broadcastPreviewUpdate(token: string, payload: unknown) {
+  try {
+    await fetch(`${API_SERVER_URL}/broadcast`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: JSON.stringify(payload), token })
+    });
+  } catch (e) {
+    console.warn('preview-update broadcast failed', e);
+  }
+}

--- a/figma/src/ui/hooks/usePreviewSync.ts
+++ b/figma/src/ui/hooks/usePreviewSync.ts
@@ -5,6 +5,12 @@ import { copyToClipboard } from '../lib/clipboard';
 import { extractFileKey } from '../lib/fileKey';
 import { stableStringify } from '../lib/stableStringify';
 import {
+  diffPayloads,
+  isEmptyDiff,
+  type PreviewPayload,
+  type PreviewUpdateMessage
+} from '../lib/diffPayload';
+import {
   createProject,
   fetchProject,
   resolvePreviewBaseUrl,
@@ -12,6 +18,12 @@ import {
   updateProject
 } from '../lib/previewServer';
 import type { ToastOptions } from '../components/Toast';
+
+// Above this serialized size a binding-config diff is considered "complicated"
+// and we tell the preview to refetch the whole config from the server instead
+// of relaying the delta — keeps a single socket message well under any payload
+// limit on the relay.
+const PREVIEW_DIFF_MAX_BYTES = 24_000;
 
 // Live-preview sync state, surfaced as a pill in the Live preview tab.
 //   idle     — nothing shared for this file yet (no server row).
@@ -34,6 +46,10 @@ interface Params {
   // Resolves a preset id to its pattern data when building the payload.
   presetById: Map<string, CatalogEntry>;
   notify: Notify;
+  // Called after a publish is persisted by the server (a new revision is
+  // confirmed) with a diff/refetch message to relay to an open live preview.
+  // The caller decides whether a phone is connected before broadcasting.
+  onPublished?: (message: PreviewUpdateMessage) => void;
 }
 
 // Owns everything about publishing the current document's bindings to the Pulsar
@@ -41,7 +57,7 @@ interface Params {
 // copy token / QR / visibility toggle). Keeps the per-file token + revision
 // bookkeeping in refs so the (rebinding) message handlers always read fresh
 // values, and exposes the sync status + share affordances for the UI.
-export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: Params) {
+export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onPublished }: Params) {
   // --- Per-file server-sync state ---------------------------------------
   // The file we're editing. Tokens + cached config are keyed by this so a
   // different design file gets its own server row instead of overwriting the
@@ -57,6 +73,15 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
   // stableStringify of the payload we last successfully pushed — lets us skip a
   // network round-trip when nothing actually changed.
   const lastSyncedJsonRef = useRef<string | null>(null);
+  // The payload object behind lastSyncedJsonRef — the basis we diff the next
+  // publish against when relaying a live update to the preview. Kept in lockstep
+  // with lastSyncedJsonRef (set/cleared together).
+  const lastSyncedPayloadRef = useRef<PreviewPayload | null>(null);
+  // Always-fresh handle to the publish callback so the (rebinding) preview-data
+  // effect never goes stale on it and we don't rebind just because the parent
+  // passes a new closure each render.
+  const onPublishedRef = useRef(onPublished);
+  onPublishedRef.current = onPublished;
   // Promise chain that serializes all publishes, so concurrent triggers (cold
   // start + a doc-change) can't both create a token and orphan a server row.
   const syncLockRef = useRef<Promise<void>>(Promise.resolve());
@@ -106,6 +131,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
     setIsPublic(m.isPublic);
     if (m.config != null) {
       lastSyncedJsonRef.current = stableStringify(m.config);
+      lastSyncedPayloadRef.current = m.config as PreviewPayload;
       setSyncStatus(m.token ? 'synced' : 'idle');
     } else if (m.token) {
       setSyncStatus('syncing');
@@ -114,6 +140,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
         if (got.kind === 'ok') {
           baseRevisionRef.current = got.revision;
           lastSyncedJsonRef.current = stableStringify(got.config);
+          lastSyncedPayloadRef.current = got.config as PreviewPayload;
           setIsPublic(got.isPublic);
           // Recover/refresh the read-only share token from the server.
           if (got.publicToken && got.publicToken !== publicTokenRef.current) {
@@ -146,6 +173,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
           tokenRef.current = null;
           rememberPublicToken(null);
           lastSyncedJsonRef.current = null;
+          lastSyncedPayloadRef.current = null;
           baseRevisionRef.current = null;
           setSyncStatus('idle');
         }
@@ -154,6 +182,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
       }
     } else {
       lastSyncedJsonRef.current = null;
+      lastSyncedPayloadRef.current = null;
       setSyncStatus('idle');
     }
     send({ type: 'request-preview-data', purpose: 'autosync' });
@@ -294,11 +323,52 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
       // allowed — i.e. a background auto-sync of a never-shared file).
       const ensurePublished = async (allowCreate: boolean): Promise<string | null> => {
         const json = stableStringify(payload);
+        // Capture the basis to diff the live-preview update against before any
+        // branch below overwrites our last-synced snapshot.
+        const prevPayload = lastSyncedPayloadRef.current;
+        const prevRevision = baseRevisionRef.current;
+        const nextPayload = payload as unknown as PreviewPayload;
+
+        // Relay the just-persisted change to an open live preview. `forced` (we
+        // resolved a conflict by re-publishing on the server's revision) always
+        // refetches — our local basis may not match what the preview last read.
+        // Otherwise diff the render-relevant config and relay only the delta,
+        // falling back to a full refetch when there's no basis, the file key
+        // changed (a different prototype), or the diff is too large for one
+        // socket message. Only ever called once the server has confirmed the
+        // write (a new revision), so a refetch can't read stale data.
+        const emitUpdate = (toRevision: number, forced: boolean) => {
+          const cb = onPublishedRef.current;
+          if (!cb) return;
+          const previewToken = publicTokenRef.current ?? undefined;
+          if (
+            !forced &&
+            prevPayload != null &&
+            prevRevision != null &&
+            prevPayload.fileKey === nextPayload.fileKey
+          ) {
+            const diff = diffPayloads(prevPayload, nextPayload);
+            if (isEmptyDiff(diff)) return; // nothing the preview renders changed
+            if (stableStringify(diff).length <= PREVIEW_DIFF_MAX_BYTES) {
+              cb({
+                kind: 'preview-haptics-diff',
+                previewToken,
+                fromRevision: prevRevision,
+                toRevision,
+                diff
+              });
+              return;
+            }
+          }
+          cb({ kind: 'preview-haptics-refetch', previewToken, toRevision });
+        };
+
         const adopt = (t: string, publicToken: string, revision: number) => {
           tokenRef.current = t;
           rememberPublicToken(publicToken);
           baseRevisionRef.current = revision;
           lastSyncedJsonRef.current = json;
+          lastSyncedPayloadRef.current = nextPayload;
           send({ type: 'persist-project-token', fileKey, token: t, publicToken });
           send({ type: 'persist-project-cache', fileKey, config: payload, baseRevision: revision });
         };
@@ -308,6 +378,8 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
         if (token && json === lastSyncedJsonRef.current) return token;
 
         if (!token) {
+          // Creating the project: no preview can be open against a token that
+          // didn't exist yet, so there's nothing to relay.
           if (!allowCreate) return null;
           const created = await createProject(payload);
           adopt(created.token, created.publicToken, created.revision);
@@ -318,7 +390,9 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
         if (res.kind === 'ok') {
           baseRevisionRef.current = res.revision;
           lastSyncedJsonRef.current = json;
+          lastSyncedPayloadRef.current = nextPayload;
           send({ type: 'persist-project-cache', fileKey, config: payload, baseRevision: res.revision });
+          emitUpdate(res.revision, false);
           return token;
         }
         if (res.kind === 'gone') {
@@ -327,6 +401,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
             tokenRef.current = null;
             baseRevisionRef.current = null;
             lastSyncedJsonRef.current = null;
+            lastSyncedPayloadRef.current = null;
             return null;
           }
           const created = await createProject(payload);
@@ -341,7 +416,9 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
         if (forced.kind === 'ok') {
           baseRevisionRef.current = forced.revision;
           lastSyncedJsonRef.current = json;
+          lastSyncedPayloadRef.current = nextPayload;
           send({ type: 'persist-project-cache', fileKey, config: payload, baseRevision: forced.revision });
+          emitUpdate(forced.revision, true);
           return token;
         }
         if (forced.kind === 'gone') {
@@ -349,6 +426,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify }: P
             tokenRef.current = null;
             baseRevisionRef.current = null;
             lastSyncedJsonRef.current = null;
+            lastSyncedPayloadRef.current = null;
             return null;
           }
           const created = await createProject(payload);

--- a/figma/src/ui/lib/diffPayload.ts
+++ b/figma/src/ui/lib/diffPayload.ts
@@ -1,0 +1,109 @@
+import type { FrameInfo, NodeBox, PresetData } from '../../shared/types';
+import { stableStringify } from './stableStringify';
+
+// The full preview payload the plugin publishes to the server and the live
+// preview renders. Mirrors figma/preview/src/types.ts `PreviewPayload`; kept
+// here so the diff helper is typed against exactly what `usePreviewSync` builds.
+export interface PreviewElement {
+  id: string;
+  name: string;
+  presetName: string;
+  box: NodeBox | null;
+  frameId?: string | null;
+  isCustom?: boolean;
+}
+
+export interface PreviewPayload {
+  fileKey: string;
+  nodeId: string | null;
+  frame: NodeBox | null;
+  elements: PreviewElement[];
+  owner: Record<string, string>;
+  bindings: Record<string, PresetData>;
+  frames?: Record<string, FrameInfo | NodeBox>;
+}
+
+// A minimal delta over the parts of the payload that affect what the preview
+// renders: the haptic bindings, the tap→owner map, the per-element list, and
+// the per-frame highlight boxes. Top-level `nodeId`/`frame` are deliberately
+// excluded — the app's Figma iframe drives its own presented-node state, so a
+// diff must never move it. A `fileKey` change can't be expressed as a delta
+// (it's a different prototype) and forces a refetch instead (see emitUpdate).
+export interface HapticsDiff {
+  bindings?: { set: Record<string, PresetData>; del: string[] };
+  owner?: { set: Record<string, string>; del: string[] };
+  // `set` carries the full (added or changed) element objects, keyed off their
+  // id when applied; `del` lists removed element ids.
+  elements?: { set: PreviewElement[]; del: string[] };
+  frames?: { set: Record<string, FrameInfo | NodeBox>; del: string[] };
+}
+
+// The structured message relayed over the paired socket to an open preview.
+// `previewToken` lets the app match the diff to the right open WebView.
+export type PreviewUpdateMessage =
+  | {
+      kind: 'preview-haptics-diff';
+      previewToken?: string;
+      fromRevision: number;
+      toRevision: number;
+      diff: HapticsDiff;
+    }
+  | {
+      kind: 'preview-haptics-refetch';
+      previewToken?: string;
+      toRevision: number;
+    };
+
+// Diff two record maps by stable value-equality. Returns `{ set, del }` or
+// undefined when nothing changed, so the caller can omit empty sections.
+function diffRecord<T>(
+  prev: Record<string, T>,
+  next: Record<string, T>,
+): { set: Record<string, T>; del: string[] } | undefined {
+  const set: Record<string, T> = {};
+  const del: string[] = [];
+  for (const [k, v] of Object.entries(next)) {
+    const before = prev[k];
+    if (before === undefined || stableStringify(before) !== stableStringify(v)) set[k] = v;
+  }
+  for (const k of Object.keys(prev)) {
+    if (!(k in next)) del.push(k);
+  }
+  if (Object.keys(set).length === 0 && del.length === 0) return undefined;
+  return { set, del };
+}
+
+// Compute the delta between the previously-published payload and the new one.
+// Only the render-relevant sections are diffed (see HapticsDiff).
+export function diffPayloads(prev: PreviewPayload, next: PreviewPayload): HapticsDiff {
+  const diff: HapticsDiff = {};
+
+  const bindings = diffRecord(prev.bindings ?? {}, next.bindings ?? {});
+  if (bindings) diff.bindings = bindings;
+
+  const owner = diffRecord(prev.owner ?? {}, next.owner ?? {});
+  if (owner) diff.owner = owner;
+
+  const frames = diffRecord(prev.frames ?? {}, next.frames ?? {});
+  if (frames) diff.frames = frames;
+
+  // Elements are an array; diff them by id with stable value-equality.
+  const prevById = new Map((prev.elements ?? []).map((e) => [e.id, e]));
+  const nextById = new Map((next.elements ?? []).map((e) => [e.id, e]));
+  const set: PreviewElement[] = [];
+  const del: string[] = [];
+  for (const [id, e] of nextById) {
+    const before = prevById.get(id);
+    if (!before || stableStringify(before) !== stableStringify(e)) set.push(e);
+  }
+  for (const id of prevById.keys()) {
+    if (!nextById.has(id)) del.push(id);
+  }
+  if (set.length > 0 || del.length > 0) diff.elements = { set, del };
+
+  return diff;
+}
+
+export function isEmptyDiff(diff: HapticsDiff): boolean {
+  return !diff.bindings && !diff.owner && !diff.frames && !diff.elements;
+}


### PR DESCRIPTION
## What

The in-app Figma **live preview** used to fetch its haptics config from the server **once on mount** and never refresh. So when you added/changed a preset binding in the plugin, an already-open preview stayed stale — tapping an element played the old (or no) haptic.

This pushes config changes to the open preview over the **existing paired socket** and applies them **in place**, without reloading the Figma prototype iframe.

## How

```
plugin usePreviewSync (after a PERSISTED change)
  → diff bindings/owner/elements/frames vs last synced snapshot
  → broadcast preview-haptics-diff {fromRevision,toRevision,diff}  OR  preview-haptics-refetch {toRevision}
server /broadcast            → already JSON.parses → relays the object structured (no change)
app ConnectionsContext       → structured broadcast → lastPreviewUpdate (monotonic nonce)
app figma.tsx                → match previewToken → injectJavaScript → postMessage into WebView (+ child srcdoc iframe)
preview useHostUpdates       → diff: apply in place iff revision==fromRevision, else refetch (gap)
                             → refetch: re-pull with revision-aware retry; PrototypeView keyed on fileKey ⇒ no iframe reload
```

**Diff vs refetch:** send the delta normally; fall back to a full refetch when it would be unsafe or wasteful — a sync **conflict**, no prior basis, a `fileKey` change (different prototype), or a diff over **24 KB** (keeps a single socket message small).

**Safety properties**
- Signals are emitted **only from the post-persist success path** → a refetch can never be told to read data the server doesn't have yet.
- `fromRevision`/`toRevision` keep diffs strictly ordered; a missed update is detected and **self-heals via refetch**.
- The Figma iframe is never remounted (state updates in place), so prototype navigation survives.
- **Backward compatible:** server untouched; old apps ignore the structured message (they only act on string broadcasts).

## Files
- **Plugin:** `diffPayload.ts` (new), `usePreviewSync.ts` (emit after persist), `PhonePanel.tsx` (`broadcastPreviewUpdate`), `App.tsx` (wire `onPublished`, gated on connected phone)
- **App:** `ConnectionsContext.tsx` (handle structured broadcast → `lastPreviewUpdate`), `figma.tsx` (inject into WebView, match `previewToken`), `Connection.ts` (commented localhost override for local testing)
- **Preview:** `useHostUpdates.ts` + `applyDiff.ts` (new), `App.tsx` (track revision, apply/refetch), `payload.ts` (return revision)
- **Server:** `connection-manager.test.ts` (assert structured relay round-trips intact)

## Testing
- Typechecks clean (plugin, preview, changed app files); diff→apply round-trip reproduces a compound change exactly.
- Verified **end-to-end in Chrome against a real share token**: a `preview-haptics-diff` flipped one element's preset live and a `preview-haptics-refetch` re-pulled server truth — both with the Figma iframe **not** remounted. Confirmed on iOS sim that the app loads the listener-equipped preview.

## Reviewer notes
- This only takes effect in **production after the docs site is rebuilt + redeployed** (the preview listener ships inside the docs embed, regenerated from `figma/preview` by the docs `prebuild`) **and the plugin is republished to Figma**. Until then the inject is a harmless no-op against the old embed.
- Includes an **unrelated test-only fix** in `docs/server/tests/websocket.test.ts` (no-op `error` handler so sockets closed mid-handshake during teardown don't throw unhandled errors and flake the suite). It was already in the working tree; flagging since it's outside the feature scope.
- The generated `figma/preview/dist-embed/index.html` (gitignored, regenerated by the docs build) is intentionally **not** included.