### PR TITLE
feat: connection management in the app + producer identity on the relay

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -1,21 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, View, ActivityIndicator, ScrollView } from 'react-native';
-import { useLocalSearchParams, useNavigation } from 'expo-router';
+import { StyleSheet, View, ActivityIndicator, ScrollView, TouchableOpacity } from 'react-native';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
 import type { Pattern } from 'react-native-pulsar';
 
 import { FIGMA_PREVIEW_URL } from '@/constants/Connection';
-import { useConnections } from '@/contexts/ConnectionsContext';
+import { connectionType, useConnections } from '@/contexts/ConnectionsContext';
 import { usePlayPatternFromHost } from '@/src/haptics/playPattern';
 import { ThemedText } from '@/components/themed-text';
+import { Icon } from '@/components/Icon';
 import BasicLayout from '@/components/BasicLayout';
 import Card from '@/components/Card';
 import Point from '@/components/Point';
-import Input from '@/components/Input';
-import Button from '@/components/Button';
 import SvgIcon from '@/components/SvgIcon';
+import ConnectionList from '@/components/home/ConnectionList';
 import { Margins } from '@/constants/theme';
 
 const defaultEdges = {
@@ -58,14 +58,12 @@ function buildPreviewInjection(envelope: unknown): string {
 //      describing what Figma Live Preview is and how to connect a design file.
 export default function FigmaScreen() {
   const params = useLocalSearchParams<{ token?: string }>();
-  const paramToken = typeof params.token === 'string' ? params.token : '';
-  const [enteredToken, setEnteredToken] = useState('');
-  const token = paramToken || enteredToken;
+  const token = typeof params.token === 'string' ? params.token : '';
 
   if (token) {
     return <FigmaPreviewWebView token={token} />;
   }
-  return <FigmaExplainer onConnect={(t) => setEnteredToken(t.trim())} />;
+  return <FigmaExplainer />;
 }
 
 function FigmaPreviewWebView({ token }: { token: string }) {
@@ -79,7 +77,15 @@ function FigmaPreviewWebView({ token }: { token: string }) {
   const webRef = useRef<WebView>(null);
   const playFromHost = usePlayPatternFromHost();
   const navigation = useNavigation();
+  const router = useRouter();
   const { lastPreviewUpdate } = useConnections();
+
+  // Leave the active preview and return to the Figma list/explainer by clearing
+  // the route's token (FigmaScreen renders the explainer when it's empty).
+  const closePreview = useCallback(() => {
+    setTabBarHidden(false);
+    router.setParams({ token: '' });
+  }, [router]);
 
   // Deliver live haptics-config updates relayed by the plugin into the preview.
   // Seed the handled nonce at mount so an update that arrived before this
@@ -133,6 +139,16 @@ function FigmaPreviewWebView({ token }: { token: string }) {
 
   return (
     <SafeAreaView edges={(tabBarHidden ? fullscreenEdges : defaultEdges) as any} style={styles.safeArea}>
+      {!tabBarHidden && (
+        <View style={styles.previewBar}>
+          <TouchableOpacity onPress={closePreview} style={styles.closeBtn} hitSlop={8}>
+            <Icon name="x" size={20} color="#001A72" />
+            <ThemedText type="defaultSemiBold" style={styles.closeLabel}>
+              Close preview
+            </ThemedText>
+          </TouchableOpacity>
+        </View>
+      )}
       <WebView
         ref={webRef}
         source={{ uri: previewUrl }}
@@ -152,9 +168,19 @@ function FigmaPreviewWebView({ token }: { token: string }) {
   );
 }
 
-function FigmaExplainer({ onConnect }: { onConnect: (token: string) => void }) {
-  const [manualToken, setManualToken] = useState('');
-  const canConnect = manualToken.trim().length > 0;
+function FigmaExplainer() {
+  const router = useRouter();
+  const { connections, remove, reconnect } = useConnections();
+
+  // Only Figma producers belong on this screen — browser connections stay on
+  // the home list. A preview can only be reopened once its token has arrived.
+  const figmaConnections = connections.filter((c) => connectionType(c) === 'figma');
+
+  // We're already on the Figma tab, so update the route param in place rather
+  // than pushing a new screen; FigmaScreen renders the WebView when it's set.
+  const openPreview = (token: string) => router.setParams({ token });
+  const editConnection = (connectionId: string) =>
+    router.push({ pathname: '/editConnectionModal', params: { connectionId } });
 
   return (
     <SafeAreaView edges={defaultEdges as any} style={styles.safeArea}>
@@ -169,6 +195,19 @@ function FigmaExplainer({ onConnect }: { onConnect: (token: string) => void }) {
             Connect a Figma design to your phone and feel haptics when
             you tap on a component in the prototype preview.
           </ThemedText>
+
+          {figmaConnections.length > 0 && (
+            <View style={Margins.marginTop4X}>
+              <ThemedText type="subtitle">Your Figma previews</ThemedText>
+              <ConnectionList
+                connections={figmaConnections}
+                onRemove={remove}
+                onReconnect={reconnect}
+                onOpenPreview={openPreview}
+                onEdit={editConnection}
+              />
+            </View>
+          )}
 
           <Card style={Margins.marginTop4X}>
             <ThemedText type="subtitle">How to connect Figma</ThemedText>
@@ -192,37 +231,10 @@ function FigmaExplainer({ onConnect }: { onConnect: (token: string) => void }) {
             </Point>
             <Point index={4}>
               <ThemedText>
-                Scan the QR code (or paste the token above) - PulsarApp opens
-                straight on this screen with the preview loaded.
+                Scan the QR code - PulsarApp opens straight on this screen
+                with the preview loaded.
               </ThemedText>
             </Point>
-          </Card>
-
-          <Card style={Margins.marginTop4X}>
-            <ThemedText type="subtitle">Connect with a token</ThemedText>
-            <ThemedText style={Margins.marginTop2X}>
-              Already have a share token from the Figma plugin? Paste it here
-              to open the preview without scanning the QR code.
-            </ThemedText>
-            <Input
-              placeholder="Paste preview token"
-              style={Margins.marginTop3X}
-              value={manualToken}
-              onChangeText={setManualToken}
-              keyboardType="default"
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <Button
-              label="Connect"
-              style={Margins.marginTop3X}
-              enabled={canConnect}
-              onClick={() => {
-                if (canConnect) onConnect(manualToken);
-              }}
-            />
           </Card>
 
         </BasicLayout>
@@ -237,6 +249,25 @@ const styles = StyleSheet.create({
   },
   webContainer: { flex: 1, backgroundColor: '#fff' },
   webview: { flex: 1 },
+  previewBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E1F3FA',
+    backgroundColor: '#fff',
+  },
+  closeBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 4,
+  },
+  closeLabel: {
+    color: '#001A72',
+  },
   loader: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   scrollContent: { paddingBottom: 40 },
   titleContainer: {

--- a/PulsarApp/app/(tabs)/index.tsx
+++ b/PulsarApp/app/(tabs)/index.tsx
@@ -58,6 +58,9 @@ export default function HomeScreen() {
 
   const openPreview = (token: string) => router.push({ pathname: '/figma', params: { token } });
 
+  const editConnection = (connectionId: string) =>
+    router.push({ pathname: '/editConnectionModal', params: { connectionId } });
+
   // A scanned QR is a pairing deep link (pulsarapp:///?code=… or the unified
   // pulsarapp://figma?token=…&code=…). Parse it the same way the deep-link
   // handler does: add the connection from `code`, and open the preview from
@@ -79,7 +82,11 @@ export default function HomeScreen() {
     if (!code && !token && /^\d{3,}$/.test(data.trim())) {
       code = data.trim();
     }
-    if (code) addByCode(code, { name });
+    // A figma QR carries the preview token; seed it (and the Figma type) onto
+    // the connection so the row is tagged Figma and can reopen the preview.
+    if (code) {
+      addByCode(code, { name, ...(token ? { previewToken: token, producerType: 'figma' as const } : {}) });
+    }
     if (token) openPreview(token);
     if (!code && !token) {
       Alert.alert('Unrecognized QR code', 'That doesn’t look like a Pulsar pairing code.');
@@ -106,6 +113,7 @@ export default function HomeScreen() {
             onRemove={remove}
             onReconnect={reconnect}
             onOpenPreview={openPreview}
+            onEdit={editConnection}
           />
 
           <AddConnectionCard

--- a/PulsarApp/app/_layout.tsx
+++ b/PulsarApp/app/_layout.tsx
@@ -92,6 +92,7 @@ function RootLayout() {
                       <Stack.Screen name="tagsModal" options={{ presentation: 'modal', title: 'Tags', headerShown: false }} />
                       <Stack.Screen name="playgroundModal" options={{ presentation: 'modal', title: 'Playground', headerShown: false }} />
                       <Stack.Screen name="playgroundSettingsModal" options={{ presentation: 'modal', title: 'Playground settings', headerShown: false }} />
+                      <Stack.Screen name="editConnectionModal" options={{ presentation: 'modal', title: 'Connection', headerShown: false }} />
                     </Stack>
                     <StatusBar style="auto" />
                   </ThemeProvider>

--- a/PulsarApp/app/editConnectionModal.tsx
+++ b/PulsarApp/app/editConnectionModal.tsx
@@ -1,0 +1,152 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import Button from '@/components/Button';
+import Card from '@/components/Card';
+import { Icon } from '@/components/Icon';
+import Input from '@/components/Input';
+import { ThemedText } from '@/components/themed-text';
+import { Margins } from '@/constants/theme';
+import {
+  connectionDisplayName,
+  connectionType,
+  useConnections,
+} from '@/contexts/ConnectionsContext';
+import { statusLabel } from '@/components/home/ConnectionRow';
+
+function formatCreatedAt(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return '—';
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.detailRow}>
+      <ThemedText style={styles.detailLabel}>{label}</ThemedText>
+      <ThemedText type="defaultSemiBold" style={styles.detailValue} numberOfLines={1}>
+        {value}
+      </ThemedText>
+    </View>
+  );
+}
+
+export default function EditConnectionModal() {
+  const params = useLocalSearchParams<{ connectionId?: string }>();
+  const connectionId = typeof params.connectionId === 'string' ? params.connectionId : '';
+  const { connections, rename } = useConnections();
+  const connection = connections.find((c) => c.id === connectionId);
+
+  // Seed the field with whatever is currently shown for this connection.
+  const [name, setName] = useState(connection ? connectionDisplayName(connection) : '');
+
+  const handleSave = () => {
+    if (connection) rename(connection.id, name);
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.header}>
+        <ThemedText type="subtitle">Connection</ThemedText>
+        <TouchableOpacity onPress={() => router.back()} style={styles.closeButton}>
+          <Icon name="x" size={28} color="#001A72" />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        {!connection ? (
+          <Card style={Margins.marginTop2X}>
+            <ThemedText>This connection is no longer available.</ThemedText>
+          </Card>
+        ) : (
+          <>
+            <Card>
+              <ThemedText type="defaultSemiBold">Name</ThemedText>
+              <ThemedText style={[styles.help, Margins.marginTop2X]}>
+                Choose a label for this connection. Leave blank to use the default name.
+              </ThemedText>
+              <Input
+                placeholder="Connection name"
+                style={Margins.marginTop3X}
+                value={name}
+                onChangeText={setName}
+                keyboardType="default"
+                autoCapitalize="sentences"
+                autoCorrect
+                returnKeyType="done"
+                onSubmitEditing={handleSave}
+              />
+              <Button label="Save" style={Margins.marginTop3X} onClick={handleSave} />
+            </Card>
+
+            <Card style={Margins.marginTop4X}>
+              <ThemedText type="defaultSemiBold">Details</ThemedText>
+              <View style={Margins.marginTop2X}>
+                <DetailRow
+                  label="Type"
+                  value={connectionType(connection) === 'figma' ? 'Figma' : 'Browser'}
+                />
+                <DetailRow label="Status" value={statusLabel(connection.status)} />
+                <DetailRow label="Created" value={formatCreatedAt(connection.createdAt)} />
+                <DetailRow
+                  label="Live preview"
+                  value={connection.previewToken ? 'Available' : 'Not available'}
+                />
+              </View>
+            </Card>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 8,
+    borderBottomWidth: 2,
+    borderBottomColor: '#B5E1F1',
+  },
+  closeButton: {
+    paddingVertical: 8,
+    paddingLeft: 12,
+  },
+  scrollContent: {
+    padding: 15,
+    paddingBottom: 40,
+  },
+  help: {
+    fontSize: 14,
+    color: '#496695',
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#EAEEF5',
+  },
+  detailLabel: {
+    fontSize: 14,
+    color: '#496695',
+    marginRight: 12,
+  },
+  detailValue: {
+    flexShrink: 1,
+    textAlign: 'right',
+  },
+});

--- a/PulsarApp/components/home/ConnectionList.tsx
+++ b/PulsarApp/components/home/ConnectionList.tsx
@@ -10,17 +10,22 @@ export default function ConnectionList({
   onRemove,
   onReconnect,
   onOpenPreview,
+  onEdit,
+  emptyLabel = 'No connections yet.',
 }: {
   connections: Connection[];
   onRemove: (id: string) => void;
   onReconnect: (id: string) => void;
   // Open the live preview for a connection that advertised a preview token.
   onOpenPreview: (token: string) => void;
+  // Long-press a row to edit its name / view details.
+  onEdit?: (id: string) => void;
+  emptyLabel?: string;
 }) {
   if (connections.length === 0) {
     return (
       <Card style={Margins.marginTop2X}>
-        <ThemedText>No connections yet.</ThemedText>
+        <ThemedText>{emptyLabel}</ThemedText>
       </Card>
     );
   }
@@ -34,6 +39,7 @@ export default function ConnectionList({
           onRemove={() => onRemove(c.id)}
           onReconnect={() => onReconnect(c.id)}
           onOpenPreview={c.previewToken ? () => onOpenPreview(c.previewToken as string) : undefined}
+          onEdit={onEdit ? () => onEdit(c.id) : undefined}
         />
       ))}
     </>

--- a/PulsarApp/components/home/ConnectionRow.tsx
+++ b/PulsarApp/components/home/ConnectionRow.tsx
@@ -3,7 +3,12 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import Card from '@/components/Card';
 import { Icon } from '@/components/Icon';
 import { ThemedText } from '@/components/themed-text';
-import type { Connection, ConnectionStatus } from '@/contexts/ConnectionsContext';
+import {
+  connectionDisplayName,
+  connectionType,
+  type Connection,
+  type ConnectionStatus,
+} from '@/contexts/ConnectionsContext';
 
 function statusColor(status: ConnectionStatus): string {
   if (status === 'connected') return '#57B495';
@@ -11,7 +16,7 @@ function statusColor(status: ConnectionStatus): string {
   return '#FF6259';
 }
 
-function statusLabel(status: ConnectionStatus): string {
+export function statusLabel(status: ConnectionStatus): string {
   switch (status) {
     case 'connected':
       return 'Connected';
@@ -26,42 +31,81 @@ function statusLabel(status: ConnectionStatus): string {
   }
 }
 
+// A small text badge distinguishing a Figma producer from a plain browser one.
+// Text-only (no icon): the row already carries a Figma glyph in its open-preview
+// button, so an icon here would be a redundant second indicator.
+function TypeChip({ type }: { type: 'figma' | 'browser' }) {
+  const isFigma = type === 'figma';
+  return (
+    <View style={[styles.chip, isFigma ? styles.chipFigma : styles.chipBrowser]}>
+      <ThemedText style={[styles.chipText, isFigma ? styles.chipTextFigma : styles.chipTextBrowser]}>
+        {isFigma ? 'Figma' : 'Browser'}
+      </ThemedText>
+    </View>
+  );
+}
+
 export default function ConnectionRow({
   connection,
   onRemove,
   onReconnect,
   onOpenPreview,
+  onEdit,
 }: {
   connection: Connection;
   onRemove: () => void;
   onReconnect: () => void;
   onOpenPreview?: () => void;
+  // Long-press handler: opens the edit/details modal for this connection.
+  onEdit?: () => void;
 }) {
-  const { name, status, token } = connection;
+  const { status, token } = connection;
+  const type = connectionType(connection);
+  const name = connectionDisplayName(connection);
   // Retry reinitialises the link (tears the socket down and re-opens from the
   // token). Only meaningful once a token exists — i.e. the pairing succeeded
   // at least once; a brand-new connection still negotiating has nothing to reuse.
   const canRetry = !!token;
+  const isFigma = type === 'figma';
+
+  // Tapping the row body opens the Figma preview (when one is available). A
+  // long-press anywhere on the body opens the edit modal. A Figma row that can
+  // be opened advertises that in its subtitle in stable states (connected or
+  // offline); transient/problem states show the status instead.
+  const canOpenFigma = isFigma && !!onOpenPreview;
+  const sublabel =
+    canOpenFigma && (status === 'connected' || status === 'offline')
+      ? 'Click to open figma preview'
+      : status !== 'connected'
+        ? statusLabel(status)
+        : null;
 
   return (
     <Card style={styles.connCard}>
       <View style={styles.connRow}>
-        <View style={[styles.statusDot, { backgroundColor: statusColor(status) }]} />
-        <View style={styles.connInfo}>
-          <ThemedText type="defaultSemiBold" numberOfLines={1}>
-            {name}
-          </ThemedText>
-          {status !== 'connected' && (
-            <ThemedText style={styles.statusTextSmall} numberOfLines={1}>
-              {statusLabel(status)}
-            </ThemedText>
-          )}
-        </View>
-        {onOpenPreview && (
-          <TouchableOpacity onPress={onOpenPreview} hitSlop={8} style={styles.iconBtn}>
-            <Icon name="figma" size={20} color="#001A72" />
-          </TouchableOpacity>
-        )}
+        <TouchableOpacity
+          style={styles.pressArea}
+          onPress={isFigma ? onOpenPreview : undefined}
+          onLongPress={onEdit}
+          delayLongPress={350}
+          disabled={!onEdit && !(isFigma && onOpenPreview)}
+          activeOpacity={0.6}
+        >
+          <View style={[styles.statusDot, { backgroundColor: statusColor(status) }]} />
+          <View style={styles.connInfo}>
+            <View style={styles.nameRow}>
+              <ThemedText type="defaultSemiBold" numberOfLines={1} style={styles.name}>
+                {name}
+              </ThemedText>
+              <TypeChip type={type} />
+            </View>
+            {sublabel && (
+              <ThemedText style={styles.statusTextSmall} numberOfLines={1}>
+                {sublabel}
+              </ThemedText>
+            )}
+          </View>
+        </TouchableOpacity>
         {canRetry && (
           <TouchableOpacity
             onPress={onReconnect}
@@ -90,6 +134,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  pressArea: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 8,
+  },
   statusDot: {
     width: 12,
     height: 12,
@@ -98,7 +148,38 @@ const styles = StyleSheet.create({
   },
   connInfo: {
     flex: 1,
-    marginRight: 8,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  name: {
+    flexShrink: 1,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    marginLeft: 8,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  chipFigma: {
+    backgroundColor: '#E6ECFF',
+  },
+  chipBrowser: {
+    backgroundColor: '#EAEEF5',
+  },
+  chipText: {
+    fontSize: 11,
+    lineHeight: 14,
+  },
+  chipTextFigma: {
+    color: '#001A72',
+  },
+  chipTextBrowser: {
+    color: '#496695',
   },
   statusTextSmall: {
     fontSize: 13,

--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -31,6 +31,8 @@ export type ConnectionStatus =
   | 'offline' // socket closed cleanly (e.g. backgrounded) — will reconnect
   | 'error'; // connection attempt failed
 
+export type ProducerType = 'figma' | 'browser';
+
 export interface Connection {
   // Stable local id for the row + persistence; survives socket churn and app
   // restarts (persisted alongside the token).
@@ -45,6 +47,18 @@ export interface Connection {
   // Figma preview share token relayed by the producer, if any — lets the row
   // offer "Open preview".
   previewToken?: string;
+  // What kind of producer paired with us, relayed at (re)establish. Absent on
+  // older producers — fall back to inferring from `previewToken` (see
+  // `connectionType`).
+  producerType?: ProducerType;
+  // Human-readable Figma file/project name (`figma.root.name`), relayed by the
+  // Figma plugin. Absent for browsers and older plugins.
+  figmaProjectName?: string;
+  // User-edited label. Takes precedence over the relayed name so a rename isn't
+  // overwritten by `connection_restored` on the next reconnect.
+  customName?: string;
+  // When this connection was first added (epoch ms). Shown in the edit modal.
+  createdAt: number;
 }
 
 interface PersistedConnection {
@@ -52,6 +66,22 @@ interface PersistedConnection {
   token: string;
   name: string;
   previewToken?: string;
+  producerType?: ProducerType;
+  figmaProjectName?: string;
+  customName?: string;
+  createdAt?: number;
+}
+
+// What kind of producer a connection is. Prefer the relayed `producerType`;
+// fall back to the presence of a preview token (only the Figma plugin sends one).
+export function connectionType(c: Connection): ProducerType {
+  return c.producerType ?? (c.previewToken ? 'figma' : 'browser');
+}
+
+// The label to show in the list: a user rename wins, then the Figma project
+// name, then the producer-advertised name.
+export function connectionDisplayName(c: Connection): string {
+  return c.customName?.trim() || c.figmaProjectName || c.name;
 }
 
 export interface ReceivedPattern {
@@ -75,12 +105,19 @@ export interface PreviewUpdate {
 
 interface ConnectionsContextValue {
   connections: Connection[];
-  // Pair a new producer from a 4-digit code (manual entry or a scanned QR).
-  addByCode: (code: string, opts?: { name?: string }) => void;
+  // Pair a new producer from a 4-digit code (manual entry or a scanned QR). A
+  // Figma QR also carries the preview token + type up front, so the row is
+  // tagged Figma and can reopen the preview without waiting on the server relay.
+  addByCode: (
+    code: string,
+    opts?: { name?: string; previewToken?: string; producerType?: ProducerType },
+  ) => void;
   // Drop a connection: close its socket and forget its token.
   remove: (id: string) => void;
   // Re-open a closed/errored connection from its stored token.
   reconnect: (id: string) => void;
+  // Set a user-chosen label for a connection (blank clears it).
+  rename: (id: string, name: string) => void;
   // Transient "preset received" banner, auto-cleared shortly after the last hit.
   lastReceived: ReceivedPattern | null;
   // Most recent live haptics-config update relayed by a producer, for an open
@@ -194,7 +231,15 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
 
       socket.onmessage = (event) => {
         const payload = typeof event.data === 'string' ? event.data : '';
-        let json: { type?: string; token?: string; message?: unknown; name?: string; previewToken?: string };
+        let json: {
+          type?: string;
+          token?: string;
+          message?: unknown;
+          name?: string;
+          previewToken?: string;
+          producerType?: ProducerType;
+          figmaProjectName?: string;
+        };
         try {
           json = JSON.parse(payload);
         } catch {
@@ -208,6 +253,8 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
                 status: 'connected',
                 ...(json.name ? { name: json.name } : {}),
                 ...(json.previewToken ? { previewToken: json.previewToken } : {}),
+                ...(json.producerType ? { producerType: json.producerType } : {}),
+                ...(json.figmaProjectName ? { figmaProjectName: json.figmaProjectName } : {}),
               });
               // A short buzz confirms the new pairing to the user.
               Presets.breakingWave();
@@ -220,6 +267,8 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
               status: 'connected',
               ...(json.name ? { name: json.name } : {}),
               ...(json.previewToken ? { previewToken: json.previewToken } : {}),
+              ...(json.producerType ? { producerType: json.producerType } : {}),
+              ...(json.figmaProjectName ? { figmaProjectName: json.figmaProjectName } : {}),
             });
             posthog?.capture('device_connected', { connection_type: 'restored' });
             break;
@@ -280,7 +329,7 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   );
 
   const addByCode = useCallback(
-    (code: string, opts?: { name?: string }) => {
+    (code: string, opts?: { name?: string; previewToken?: string; producerType?: ProducerType }) => {
       const trimmed = code.trim();
       if (!trimmed) return;
       const conn: Connection = {
@@ -288,6 +337,11 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
         token: null,
         name: opts?.name?.trim() || 'Unnamed connection',
         status: 'connecting',
+        createdAt: Date.now(),
+        // Seed Figma identity from the QR so the row is tagged + openable right
+        // away; the server relay confirms (and adds the project name) later.
+        ...(opts?.previewToken ? { previewToken: opts.previewToken } : {}),
+        ...(opts?.producerType ? { producerType: opts.producerType } : {}),
       };
       setConnections((prev) => [...prev, conn]);
       openSocket(conn, 'new', trimmed);
@@ -315,6 +369,18 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
     [teardownLive, posthog],
   );
 
+  // Set (or clear, when blank) a user-chosen label for a connection. Stored as
+  // `customName` so it survives reconnects without being clobbered by the
+  // producer-relayed name.
+  const rename = useCallback(
+    (id: string, name: string) => {
+      const trimmed = name.trim();
+      patchConnection(id, { customName: trimmed || undefined });
+      posthog?.capture('connection_renamed');
+    },
+    [patchConnection, posthog],
+  );
+
   // Initial load: restore the persisted list (or migrate the legacy single
   // token) and reconnect each established connection.
   useEffect(() => {
@@ -333,7 +399,7 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
         try {
           const legacy = await AsyncStorage.getItem(LEGACY_TOKEN_KEY);
           if (legacy && legacy.length > 0) {
-            persisted = [{ id: newId(), token: legacy, name: 'Saved device' }];
+            persisted = [{ id: newId(), token: legacy, name: 'Saved device', createdAt: Date.now() }];
           }
         } catch {
           // ignore — nothing to migrate
@@ -346,6 +412,10 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
           token: p.token,
           name: p.name,
           previewToken: p.previewToken,
+          producerType: p.producerType,
+          figmaProjectName: p.figmaProjectName,
+          customName: p.customName,
+          createdAt: p.createdAt ?? Date.now(),
           status: 'connecting',
         }));
         setConnections(restored);
@@ -370,7 +440,11 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
         id: c.id,
         token: c.token as string,
         name: c.name,
+        createdAt: c.createdAt,
         ...(c.previewToken ? { previewToken: c.previewToken } : {}),
+        ...(c.producerType ? { producerType: c.producerType } : {}),
+        ...(c.figmaProjectName ? { figmaProjectName: c.figmaProjectName } : {}),
+        ...(c.customName ? { customName: c.customName } : {}),
       }));
     AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist)).catch(() => {});
   }, [connections, didLoad]);
@@ -405,7 +479,14 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
       const code = parsed.queryParams?.code;
       if (code) {
         const name = parsed.queryParams?.name;
-        addByCode(code.toString(), { name: name ? name.toString() : undefined });
+        // A `token` means this is the unified Figma link — capture it as the
+        // connection's preview token + Figma type so the row reopens the preview.
+        const token = parsed.queryParams?.token;
+        const previewToken = token ? token.toString() : undefined;
+        addByCode(code.toString(), {
+          name: name ? name.toString() : undefined,
+          ...(previewToken ? { previewToken, producerType: 'figma' as const } : {}),
+        });
         posthog?.capture('deep_link_connection_initiated', { has_code: true });
       }
     };
@@ -437,7 +518,7 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
 
   return (
     <ConnectionsContext.Provider
-      value={{ connections, addByCode, remove, reconnect, lastReceived, lastPreviewUpdate }}
+      value={{ connections, addByCode, remove, reconnect, rename, lastReceived, lastPreviewUpdate }}
     >
       {children}
     </ConnectionsContext.Provider>

--- a/docs/server/src/connection-manager.ts
+++ b/docs/server/src/connection-manager.ts
@@ -253,9 +253,19 @@ export class ConnectionManager {
   // Additive producer identity relayed to the receiver (and harmlessly to the
   // sender) on (re)establish. `undefined` fields are dropped by JSON.stringify,
   // so a producer that advertised nothing yields the exact legacy payload.
-  private senderIdentity(connection: Connection): { name?: string; previewToken?: string } {
+  private senderIdentity(connection: Connection): {
+    name?: string;
+    previewToken?: string;
+    producerType?: string;
+    figmaProjectName?: string;
+  } {
     const meta = connection.sender?.metadata;
-    return { name: meta?.name, previewToken: meta?.previewToken };
+    return {
+      name: meta?.name,
+      previewToken: meta?.previewToken,
+      producerType: meta?.producerType,
+      figmaProjectName: meta?.figmaProjectName,
+    };
   }
 
   private sendTokenNotification(token: string, connection: Connection): void {

--- a/docs/server/src/websocket-handler.ts
+++ b/docs/server/src/websocket-handler.ts
@@ -104,16 +104,21 @@ export class WebSocketHandler {
     ws.id = `${++this.nextId}`;
     ws.type = type as 'sender' | 'receiver';
     // Optional, additive producer identity. A producer may advertise a human
-    // name (e.g. "Figma Plugin macOS") and a Figma preview token to hand to the
-    // phone; the server relays these to the receiver on (re)establish. Older
-    // producers omit them and older receivers ignore them — kept off the socket
-    // entirely when absent so the relayed messages stay byte-for-byte unchanged.
+    // name (e.g. "Figma Plugin macOS"), its type ('figma' | 'browser'), the
+    // Figma project name, and a Figma preview token to hand to the phone; the
+    // server relays these to the receiver on (re)establish. Older producers omit
+    // them and older receivers ignore them — kept off the socket entirely when
+    // absent so the relayed messages stay byte-for-byte unchanged.
     const name = url.searchParams.get('name');
     const previewToken = url.searchParams.get('previewToken');
-    if (name || previewToken) {
+    const producerType = url.searchParams.get('producerType');
+    const figmaProjectName = url.searchParams.get('figmaProjectName');
+    if (name || previewToken || producerType || figmaProjectName) {
       ws.metadata = {
         ...(name ? { name } : {}),
         ...(previewToken ? { previewToken } : {}),
+        ...(producerType ? { producerType } : {}),
+        ...(figmaProjectName ? { figmaProjectName } : {}),
       };
     }
     const ip = getClientIp(req);

--- a/docs/server/tests/connection-manager.test.ts
+++ b/docs/server/tests/connection-manager.test.ts
@@ -163,8 +163,9 @@ describe('ConnectionManager', () => {
     });
   });
 
-  // Additive producer identity: a sender may advertise a `name` and a Figma
-  // `previewToken`; the server relays them to the receiver on (re)establish.
+  // Additive producer identity: a sender may advertise a `name`, its
+  // `producerType` ('figma' | 'browser'), a Figma `previewToken`, and the Figma
+  // `figmaProjectName`; the server relays them to the receiver on (re)establish.
   describe('producer identity relay', () => {
     it('relays the sender name + previewToken to the receiver on establish', () => {
       const code = cm.getParingCode();
@@ -180,17 +181,38 @@ describe('ConnectionManager', () => {
       expect(typeof est.token).toBe('string');
     });
 
+    it('relays the Figma producerType + figmaProjectName to the receiver on establish', () => {
+      const code = cm.getParingCode();
+      const sender = new FakeWs('s');
+      sender.metadata = {
+        name: 'Figma Plugin macOS',
+        previewToken: 'pub-123',
+        producerType: 'figma',
+        figmaProjectName: 'Checkout Redesign',
+      };
+      const receiver = new FakeWs('r');
+      cm.createNewSenderConnection(asWs(sender), code);
+      cm.createNewReceiverConnection(asWs(receiver), code);
+
+      const est = firstOfType(receiver, 'connection_established');
+      expect(est.producerType).toBe('figma');
+      expect(est.figmaProjectName).toBe('Checkout Redesign');
+    });
+
     it('relays the sender identity again on connection_restored', () => {
       const { token } = pair();
       const newSender = new FakeWs('s2');
-      newSender.metadata = { name: 'Google Chrome Windows' };
+      newSender.metadata = { name: 'Google Chrome Windows', producerType: 'browser' };
       const newReceiver = new FakeWs('r2');
       cm.reuseSenderConnection(asWs(newSender), token);
       cm.reuseReceiverConnection(asWs(newReceiver), token);
 
       const restored = firstOfType(newReceiver, 'connection_restored');
       expect(restored.name).toBe('Google Chrome Windows');
+      expect(restored.producerType).toBe('browser');
+      // A browser advertises neither a preview token nor a Figma project name.
       expect(restored).not.toHaveProperty('previewToken');
+      expect(restored).not.toHaveProperty('figmaProjectName');
     });
 
     it('omits identity fields entirely for a producer that advertised none (old client)', () => {

--- a/docs/server/tests/websocket.test.ts
+++ b/docs/server/tests/websocket.test.ts
@@ -231,6 +231,21 @@ describe('WebSocket pairing protocol', () => {
       expect(est.previewToken).toBe('pub-xyz');
     });
 
+    it('relays producerType + figmaProjectName from the handshake query to the receiver', async () => {
+      running = await startServer();
+      const code = (await request(running.app).get('/create-channel')).body.code as string;
+      connect(
+        `type=sender&action=new_connection&code=${code}` +
+          `&name=${encodeURIComponent('Figma Plugin macOS')}&previewToken=pub-xyz` +
+          `&producerType=figma&figmaProjectName=${encodeURIComponent('Checkout Redesign')}`,
+      );
+      const receiver = connect(`type=receiver&action=new_connection&code=${code}`);
+      const rf = new Frames(receiver);
+      const est = await rf.await(type('connection_established'));
+      expect(est.producerType).toBe('figma');
+      expect(est.figmaProjectName).toBe('Checkout Redesign');
+    });
+
     it('omits identity fields when the producer advertises none (old client)', async () => {
       running = await startServer();
       const code = (await request(running.app).get('/create-channel')).body.code as string;

--- a/docs/src/content/docs/components/Connection/Connection.tsx
+++ b/docs/src/content/docs/components/Connection/Connection.tsx
@@ -84,9 +84,10 @@ export default function Connection() {
     if (localStorage.getItem('hapticsToken')) {
       token = localStorage.getItem('hapticsToken');
     }
-    // Advertise the producer name on the handshake; the server relays it to the
-    // phone on (re)establish. Additive — older servers ignore it.
-    const nameParam = `&name=${encodeURIComponent(getConnectionName())}`;
+    // Advertise the producer name + type on the handshake; the server relays
+    // them to the phone on (re)establish. Additive — older servers ignore them.
+    const nameParam =
+      `&name=${encodeURIComponent(getConnectionName())}` + `&producerType=browser`;
     let params = '';
     if (token) {
       params = `&action=reuse_connection&token=${token}${nameParam}`;


### PR DESCRIPTION
## What

The phone-side and server-side counterpart to the Figma plugin pairing work (split out from the figma UI PR for a focused review).

### App (`PulsarApp/`)
- **Editable connections** — a new `editConnectionModal` to rename/manage a paired producer, a richer `ConnectionRow`, and connection persistence/edit logic in `ConnectionsContext`, wired through the tabs `_layout` and home screen.
- **Figma screen** — removed the manual-token connect UI; pairing now happens purely through the scanned deep link / QR.

### Relay server (`docs/server/`)
- The **producer handshake now carries identity**: `name`, `producerType` (`'figma' | 'browser'`), and `figmaProjectName`, relayed to the phone so a connection can show a meaningful label and type. `connection-manager` + `websocket-handler` updated, with tests covering the new fields.

### Docs
- Small `Connection` component tweak to match the handshake.

## Why
Gives paired connections a real identity (which producer, which Figma file) and lets users rename/manage them in the app — and lets the Figma plugin advertise itself (`producerType=figma`, `figmaProjectName`) so the app can label it.

## Notes for reviewers
- Pairs with #116 (the Figma plugin / web-preview UI): the plugin's pairing handshake sends the `producerType` / `figmaProjectName` that this server change consumes.
- This is pre-existing working-tree work that was committed as-is during PR cleanup; I did **not** author it and have **not** run the server test suite locally — worth a sanity check before merge.