### PR TITLE
feat(figma): first-run onboarding tour + Help tab Q&A

### DIFF
--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -42,6 +42,9 @@ const LEGACY_PREVIEW_TOKEN_KEY = 'pulsar:previewToken';
 const PROJECT_CACHE_PREFIX = 'pulsar:project:';
 const FAVOURITES_KEY = 'pulsar:favourites';
 const CUSTOM_PRESETS_KEY = 'pulsar:customPresets';
+// Per-user flag: has the first-run onboarding tour been shown? Stored in
+// clientStorage (not per-file), so the tour auto-opens once per machine.
+const ONBOARDING_SEEN_KEY = 'pulsar:onboardingSeen';
 const WINDOW_SIZE_KEY = 'pulsar:windowSize';
 // Stable per-document id stored in root pluginData; replaces `figma.fileKey`,
 // which needs the private plugin API. Synced to all collaborators.
@@ -247,6 +250,10 @@ async function loadFavourites(): Promise<string[]> {
 async function loadCustomPresets(): Promise<CatalogEntry[]> {
   const raw = await figma.clientStorage.getAsync(CUSTOM_PRESETS_KEY);
   return Array.isArray(raw) ? (raw as CatalogEntry[]) : [];
+}
+
+async function loadOnboardingSeen(): Promise<boolean> {
+  return (await figma.clientStorage.getAsync(ONBOARDING_SEEN_KEY)) === true;
 }
 
 function readBinding(node: BaseNode): BindingMeta | null {
@@ -556,12 +563,14 @@ figma.on('selectionchange', () => {
 figma.ui.onmessage = async (msg: UiToMain) => {
   switch (msg.type) {
     case 'ui-ready': {
-      const [settings, hapticsToken, favourites, customPresets] = await Promise.all([
-        loadSettings(),
-        loadToken(),
-        loadFavourites(),
-        loadCustomPresets()
-      ]);
+      const [settings, hapticsToken, favourites, customPresets, onboardingSeen] =
+        await Promise.all([
+          loadSettings(),
+          loadToken(),
+          loadFavourites(),
+          loadCustomPresets(),
+          loadOnboardingSeen()
+        ]);
       postToUi({
         type: 'init',
         settings,
@@ -570,7 +579,8 @@ figma.ui.onmessage = async (msg: UiToMain) => {
         fileKey: resolveFileKey(),
         figmaFileKey: getFigmaFileKey(),
         favourites,
-        customPresets
+        customPresets,
+        onboardingSeen
       });
       pushSelection();
       break;
@@ -642,6 +652,9 @@ figma.ui.onmessage = async (msg: UiToMain) => {
       break;
     case 'persist-custom-presets':
       await figma.clientStorage.setAsync(CUSTOM_PRESETS_KEY, msg.presets);
+      break;
+    case 'persist-onboarding-seen':
+      await figma.clientStorage.setAsync(ONBOARDING_SEEN_KEY, msg.seen);
       break;
     case 'persist-file-key':
       setFigmaFileKey(msg.figmaFileKey);

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -126,6 +126,9 @@ export type UiToMain =
   | { type: 'persist-haptics-token'; token: string | null }
   | { type: 'persist-favourites'; favourites: string[] }
   | { type: 'persist-custom-presets'; presets: CatalogEntry[] }
+  // Mark the first-run onboarding tour as seen so it doesn't auto-open again.
+  // Stored per-user in clientStorage (not per-file), so the tour shows once.
+  | { type: 'persist-onboarding-seen'; seen: boolean }
   // Per-file project state. The server token and cached config are keyed by
   // fileKey so opening the plugin in another design file gets its own token
   // instead of clobbering the first file's shared preview.
@@ -163,6 +166,9 @@ export type MainToUi =
       figmaFileKey: string;
       favourites: string[];
       customPresets: CatalogEntry[];
+      // Whether the first-run onboarding tour has already been shown. False
+      // (the default) makes the UI auto-open the tour on first launch.
+      onboardingSeen: boolean;
     }
   | { type: 'selection'; node: SelectionInfo | null }
   | { type: 'play-preset'; presetId: string } // emitted when a bound node is clicked in editor

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -10,6 +10,7 @@ import PresetsTab from './components/PresetsTab';
 import LivePreviewTab from './components/LivePreviewTab';
 import LivePreviewPanel from './components/LivePreviewPanel';
 import OnboardingPanel from './components/OnboardingPanel';
+import OnboardingOverlay from './components/OnboardingOverlay';
 import {
   usePhoneConnection,
   phoneStatusOf,
@@ -42,6 +43,9 @@ export default function App() {
 
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [tab, setTab] = useState<Tab>('presets');
+  // First-run onboarding tour. Auto-opens once (gated on the persisted
+  // `onboardingSeen` flag from init); the Help tab can relaunch it any time.
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [openId, setOpenId] = useState<string | null>(null);
   const [tagsGuideOpen, setTagsGuideOpen] = useState(false);
   const [filter, setFilter] = useState<FilterState>(useFilterStateInit());
@@ -112,6 +116,9 @@ export default function App() {
         setCustomPresets(m.customPresets ?? []);
         setFigmaFileKey(m.figmaFileKey ?? '');
         setDocumentName(m.documentName ?? '');
+        // Auto-open the tour on first launch, then never again unless relaunched
+        // from the Help tab.
+        if (!m.onboardingSeen) setShowOnboarding(true);
         // Pull this file's persisted token + cached config, keyed by the stable
         // minted id (the server key). The real Figma file key for the embed is
         // remembered separately per-file (figmaFileKey, see usePreviewSync).
@@ -399,7 +406,20 @@ export default function App() {
         />
       )}
 
-      {tab === 'onboarding' && <OnboardingPanel />}
+      {tab === 'onboarding' && (
+        <OnboardingPanel onStartOnboarding={() => setShowOnboarding(true)} />
+      )}
+
+      {showOnboarding && (
+        <OnboardingOverlay
+          onClose={() => {
+            setShowOnboarding(false);
+            // Remember it was seen so it doesn't auto-open next launch. Harmless
+            // when relaunched from Help (the flag is already set).
+            send({ type: 'persist-onboarding-seen', seen: true });
+          }}
+        />
+      )}
 
       <ResizeHandle />
     </div>

--- a/figma/src/ui/components/OnboardingOverlay.module.css
+++ b/figma/src/ui/components/OnboardingOverlay.module.css
@@ -1,0 +1,184 @@
+/* First-run onboarding tour - a full-window carousel rendered above everything
+   else. Mirrors the App modal chrome (blue-50 border + offset shadow) but owns
+   its own backdrop so it can sit on top of any tab, including other modals. */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 26, 114, 0.45);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 12px;
+  overflow: auto;
+  animation: overlay-in 160ms ease-out both;
+}
+@keyframes overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.card {
+  background: var(--surface);
+  border: 2px solid var(--color-blue-50);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 14px;
+  gap: 14px;
+  animation: card-in 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes card-in {
+  from { opacity: 0; transform: translateY(10px) scale(0.985); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Per-screen slide layer - holds the welcome screen or a feature step's
+   media + copy, and replays a directional slide-in on every navigation
+   (remounted via a React key). Owns the column gap the card used to apply
+   directly to media/body. */
+.screen {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  animation-duration: 280ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  animation-fill-mode: both;
+}
+.slide-next { animation-name: slide-from-right; }
+.slide-prev { animation-name: slide-from-left; }
+@keyframes slide-from-right {
+  from { opacity: 0; transform: translateX(24px); }
+  to { opacity: 1; transform: none; }
+}
+@keyframes slide-from-left {
+  from { opacity: 0; transform: translateX(-24px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Header: step counter on the left, escape hatch on the right. */
+.head { display: flex; align-items: center; }
+.step-count {
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-blue-60);
+}
+.skip {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  box-shadow: none;
+  border-width: 1px;
+}
+.skip:active { box-shadow: none; }
+
+/* Demo media slot - real GIF or the labelled placeholder, kept at a stable
+   aspect ratio so swapping between steps doesn't jump the layout. */
+.media {
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.gif { display: block; width: 100%; height: auto; border-radius: var(--radius); }
+.gif-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  aspect-ratio: 16 / 10;
+  padding: 16px;
+  text-align: center;
+  color: var(--color-blue-60);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  background: var(--color-blue-10);
+  border: 1px dashed var(--color-blue-30);
+  border-radius: var(--radius);
+}
+/* Gently pulse the play glyph so the placeholder reads as a future demo. */
+.gif-placeholder img { opacity: 0.7; animation: play-pulse 2.4s ease-in-out infinite; }
+@keyframes play-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.6; }
+  50% { transform: scale(1.12); opacity: 0.9; }
+}
+.gif-tag {
+  font-size: var(--fs-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--surface);
+  background: var(--color-blue-50);
+  border-radius: 20px;
+  padding: 2px 8px;
+}
+
+/* Welcome screen - brand mark + greeting, centred and given the room the
+   feature steps spend on the demo media so the card height stays stable. */
+.welcome {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+  padding: 24px 8px;
+}
+/* Brand mark pops in slightly after the screen settles for a warmer greeting. */
+.welcome :global(.pulsar-logo) {
+  animation: logo-pop 460ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
+}
+@keyframes logo-pop {
+  from { opacity: 0; transform: scale(0.6); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Step copy. */
+.body { text-align: center; padding: 0 4px; }
+.title { margin: 0 0 6px; font-size: var(--fs-lg); font-weight: 700; color: var(--color-primary); }
+.text { margin: 0; font-size: var(--fs-sm); line-height: 1.5; color: var(--muted); }
+
+/* Progress dots - also clickable to jump to a step. */
+.dots { display: flex; justify-content: center; gap: 8px; }
+.dot {
+  width: 8px;
+  height: 8px;
+  padding: 0;
+  border-radius: 50%;
+  border: none;
+  box-shadow: none;
+  background: var(--color-blue-20);
+  transition: background 120ms ease, transform 120ms ease;
+}
+.dot:active { box-shadow: none; transform: none; }
+.dot-active { background: var(--color-blue-50); transform: scale(1.15); }
+
+/* Footer nav - Back on the left, primary action on the right. */
+.foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.foot button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.foot button:disabled { opacity: 0.4; cursor: default; box-shadow: none; }
+.arrow-left { transform: rotate(90deg); }
+.arrow-right { transform: rotate(-90deg); }
+
+/* Respect users who ask for less motion - drop every entrance/loop animation
+   but keep the final (settled) state. */
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .card,
+  .screen,
+  .welcome :global(.pulsar-logo),
+  .gif-placeholder img {
+    animation: none;
+  }
+}

--- a/figma/src/ui/components/OnboardingOverlay.tsx
+++ b/figma/src/ui/components/OnboardingOverlay.tsx
@@ -1,0 +1,161 @@
+import styles from './OnboardingOverlay.module.css';
+import { useEffect, useState } from 'react';
+import { ONBOARDING_STEPS, WELCOME, OUTRO, type OnboardingStep } from './onboardingContent';
+import PulsarLogo from './PulsarLogo';
+import iconClose from '../assets/icon-close.svg';
+import iconChevron from '../assets/icon-chevron-down.svg';
+import iconPlay from '../assets/icon-play.svg';
+
+// The tour leads with a welcome screen (brand mark + greeting), runs the feature
+// steps, and ends on a send-off. The welcome / finish screens share a brand
+// layout, so screens are a small union rather than a plain step list.
+type Screen =
+  | { kind: 'welcome' }
+  | { kind: 'finish' }
+  | ({ kind: 'feature' } & OnboardingStep);
+
+const SCREENS: Screen[] = [
+  { kind: 'welcome' },
+  ...ONBOARDING_STEPS.map((s) => ({ kind: 'feature' as const, ...s })),
+  { kind: 'finish' }
+];
+
+// First-run onboarding tour. A full-window overlay that walks through the three
+// core flows (bind a preset → live preview → share) one screen at a time. It is
+// always cancellable (Skip / Esc / the X), and the Help tab can relaunch it.
+//
+// Onboarding design notes: one idea per screen, a clear progress indicator
+// (the dots), an always-visible escape hatch, and a single primary action so
+// the path forward is obvious. Content is shared with the Help-tab FAQ via
+// onboardingContent so the two never drift.
+export default function OnboardingOverlay({ onClose }: { onClose: () => void }) {
+  const [index, setIndex] = useState(0);
+  // Paging direction (+1 forward, -1 back) so the screen slides in from the
+  // matching side. Drives the slide-next / slide-prev animation class.
+  const [dir, setDir] = useState(1);
+  const screens = SCREENS;
+  const screen = screens[index];
+  const isFirst = index === 0;
+  const isLast = index === screens.length - 1;
+
+  // Single entry point for every navigation (buttons, dots, arrow keys) so the
+  // slide direction is always set before the index changes.
+  const goTo = (target: number) => {
+    const clamped = Math.max(0, Math.min(target, screens.length - 1));
+    if (clamped === index) return;
+    setDir(clamped > index ? 1 : -1);
+    setIndex(clamped);
+  };
+
+  const next = () => (isLast ? onClose() : goTo(index + 1));
+  const back = () => goTo(index - 1);
+
+  // Esc skips; arrow keys page through the tour.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      else if (e.key === 'ArrowRight') next();
+      else if (e.key === 'ArrowLeft') back();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // `next`/`back` close over `index`; re-bind so the handler always pages
+    // from the current step.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [index]);
+
+  return (
+    <div className={styles['overlay']} role="dialog" aria-modal="true" aria-label="Welcome to Pulsar">
+      <div className={styles['card']}>
+        <header className={styles['head']}>
+          {/* The welcome screen is a greeting, not a numbered step. */}
+          {screen.kind === 'feature' && (
+            <span className={styles['step-count']}>
+              Step {index} of {ONBOARDING_STEPS.length}
+            </span>
+          )}
+          <button
+            className={`ghost ${styles['skip']}`}
+            onClick={onClose}
+            title="Skip the tour (Esc)"
+            aria-label="Skip the tour"
+          >
+            Skip
+            <img src={iconClose} alt="" width={12} height={12} />
+          </button>
+        </header>
+
+        {/* Keyed on `index` so the wrapper remounts each navigation, replaying
+            the slide-in keyframe from the side matching the paging direction. */}
+        <div
+          key={index}
+          className={`${styles['screen']} ${dir >= 0 ? styles['slide-next'] : styles['slide-prev']}`}
+        >
+          {screen.kind === 'welcome' || screen.kind === 'finish' ? (
+            <div className={styles['welcome']}>
+              <PulsarLogo size={72} />
+              <h2 className={styles['title']}>
+                {screen.kind === 'welcome' ? WELCOME.title : OUTRO.title}
+              </h2>
+              <p className={styles['text']}>
+                {screen.kind === 'welcome' ? WELCOME.body : OUTRO.body}
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className={styles['media']}>
+                {screen.gif ? (
+                  <img className={styles['gif']} src={screen.gif} alt={screen.gifPlaceholder} />
+                ) : (
+                  <div className={styles['gif-placeholder']} aria-hidden="true">
+                    <img src={iconPlay} alt="" width={20} height={20} />
+                    <span>{screen.gifPlaceholder}</span>
+                    <span className={styles['gif-tag']}>GIF coming soon</span>
+                  </div>
+                )}
+              </div>
+
+              <div className={styles['body']}>
+                <h2 className={styles['title']}>{screen.title}</h2>
+                <p className={styles['text']}>{screen.body}</p>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className={styles['dots']} role="tablist" aria-label="Tour progress">
+          {screens.map((s, i) => (
+            <button
+              key={s.kind === 'feature' ? s.id : s.kind}
+              type="button"
+              role="tab"
+              aria-selected={i === index}
+              aria-label={
+                s.kind === 'welcome'
+                  ? WELCOME.title
+                  : s.kind === 'finish'
+                    ? OUTRO.title
+                    : s.title
+              }
+              className={`${styles['dot']} ${i === index ? styles['dot-active'] : ''}`}
+              onClick={() => goTo(i)}
+            />
+          ))}
+        </div>
+
+        <footer className={styles['foot']}>
+          <button className="ghost" onClick={back} disabled={isFirst}>
+            <img className={styles['arrow-left']} src={iconChevron} alt="" width={14} height={14} />
+            Back
+          </button>
+          <button className="primary" onClick={next}>
+            {isLast ? 'Get started' : screen.kind === 'welcome' ? 'Start tour' : 'Next'}
+            {!isLast && (
+              <img className={styles['arrow-right']} src={iconChevron} alt="" width={14} height={14} />
+            )}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/figma/src/ui/components/OnboardingPanel.module.css
+++ b/figma/src/ui/components/OnboardingPanel.module.css
@@ -1,25 +1,62 @@
-/* Onboarding / help tab. Placeholder layout for now - real step-by-step usage
-   notes and explanations of the confusing parts will be filled in later. */
-.onboarding-panel { padding: 16px; gap: 14px; flex: 1; min-height: 0; }
-.onboarding-intro { margin: 4px 0 0; font-size: var(--fs-xs); line-height: 1.5; }
-.onboarding-card {
-  position: relative;
-  padding: 12px;
-  background: var(--color-blue-10);
+/* Help tab - "take the tour" button, a Q&A accordion, resource links and a
+   contact line. The accordion rows reuse the shared .acc-row chrome from
+   common.css; only the wrapping card and the link/contact bits are local. */
+.help-panel { padding: 16px; gap: 16px; flex: 1; min-height: 0; }
+.help-intro { margin: 4px 0 0; font-size: var(--fs-xs); line-height: 1.5; }
+
+/* Relaunch-the-tour button - full width, icon + label. */
+.tour-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+/* Extra breathing room above each titled section, on top of the panel's flex
+   gap, so the FAQ / Resources / contact blocks read as distinct groups. */
+.section { margin-top: 12px; }
+
+/* Q&A card - bordered panel, accordion rows separated by hairlines (same recipe
+   as the Presets-tab controls card). */
+.faq-card {
+  margin-top: 6px;
   border: 1px solid var(--color-blue-20);
   border-radius: var(--radius);
-}
-.onboarding-card-title { font-weight: 600; font-size: var(--fs-sm); margin-bottom: 4px; }
-.onboarding-card-body { margin: 0; font-size: var(--fs-xs); line-height: 1.45; }
-.onboarding-badge {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  font-size: var(--fs-2xs);
-  font-weight: 600;
-  color: var(--color-blue-60);
+  overflow: hidden;
   background: var(--surface);
-  border: 1px dashed var(--color-blue-20);
-  border-radius: var(--radius-sm);
-  padding: 1px 6px;
 }
+.faq-card > :global(.acc-row) { border-top: 1px solid var(--color-blue-10); padding-top: 0; }
+.faq-card > :global(.acc-row):first-child { border-top: none; }
+.faq-answer { margin: 0; font-size: var(--fs-xs); line-height: 1.5; color: var(--muted); }
+
+/* Resource links - stacked, label + sub-label on the left, external icon right. */
+.link-list { display: flex; flex-direction: column; gap: 8px; margin-top: 6px; }
+.link-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+}
+.link-text { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 0; }
+.link-title { font-weight: 600; font-size: var(--fs-sm); }
+.link-sub { font-size: var(--fs-2xs); font-weight: 500; color: var(--muted); }
+.link-btn img { flex-shrink: 0; opacity: 0.7; }
+
+/* Contact line - inline email rendered as a link-styled button. */
+.contact-text { margin: 6px 0 0; font-size: var(--fs-xs); line-height: 1.5; }
+.contact-link {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
+  color: var(--color-blue-60);
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.contact-link:active { box-shadow: none; transform: none; }

--- a/figma/src/ui/components/OnboardingPanel.tsx
+++ b/figma/src/ui/components/OnboardingPanel.tsx
@@ -1,32 +1,93 @@
 import styles from './OnboardingPanel.module.css';
+import { send } from '../figmaBridge';
+import {
+  FAQ,
+  FIGMA_DESIGN_URL,
+  EXAMPLE_APP_URL,
+  SUPPORT_EMAIL
+} from './onboardingContent';
+import iconChevron from '../assets/icon-chevron-down.svg';
+import iconExternal from '../assets/icon-external-link.svg';
+import iconPlay from '../assets/icon-play.svg';
 
-// Onboarding / help tab. Placeholder content for now - the real step-by-step
-// instructions and explanations of the confusing parts of the plugin will be
-// written later.
-const SECTIONS = [
-  { title: 'Getting started', body: 'How to bind a haptic preset to a component - coming soon.' },
-  { title: 'Presets', body: 'Browsing, filtering and previewing haptic presets - coming soon.' },
-  { title: 'Components', body: 'Reviewing and managing your bound components - coming soon.' },
-  { title: 'Share', body: 'Sharing a live preview and pairing your phone - coming soon.' }
-];
+// Help tab. A self-serve reference: a "take the tour" button that relaunches the
+// first-run onboarding, a Q&A accordion (which restates the tour plus the
+// follow-up questions), resource links, and a contact address. The FAQ copy is
+// shared with the tour via onboardingContent so they stay in sync.
+export default function OnboardingPanel({ onStartOnboarding }: { onStartOnboarding: () => void }) {
+  const openExternal = (url: string) => send({ type: 'open-external', url });
 
-export default function OnboardingPanel() {
   return (
-    <div className={`col scroll ${styles['onboarding-panel']}`}>
+    <div className={`col scroll ${styles['help-panel']}`}>
       <div>
-        <div className="panel-title">How to use Pulsar</div>
-        <p className={`muted ${styles['onboarding-intro']}`}>
-          A quick guide to the plugin and the parts that need a little explanation.
-          Full instructions are on the way.
+        <div className="panel-title">Help &amp; how-to</div>
+        <p className={`muted ${styles['help-intro']}`}>
+          Everything you need to design haptics in Figma. Replay the guided tour or
+          browse the questions below.
         </p>
       </div>
-      {SECTIONS.map((s) => (
-        <section key={s.title} className={styles['onboarding-card']}>
-          <span className={styles['onboarding-badge']}>Placeholder</span>
-          <div className={styles['onboarding-card-title']}>{s.title}</div>
-          <p className={`muted ${styles['onboarding-card-body']}`}>{s.body}</p>
-        </section>
-      ))}
+
+      <button className={`primary ${styles['tour-btn']}`} onClick={onStartOnboarding}>
+        <img src={iconPlay} alt="" width={15} height={15} />
+        Take the tour
+      </button>
+
+      {/* Q&A - one bordered card, accordion rows separated by hairlines, reusing
+          the shared accordion building blocks from common.css. */}
+      <div className={styles['section']}>
+        <div className="acc-label">Frequently asked</div>
+        <div className={styles['faq-card']}>
+          {FAQ.map((entry) => (
+            <details key={entry.id} className="accordion acc-row">
+              <summary className="acc-head">
+                <span className="acc-title">{entry.question}</span>
+                <span className="acc-chevron" aria-hidden="true">
+                  <img src={iconChevron} alt="" />
+                </span>
+              </summary>
+              <div className="acc-body">
+                <p className={styles['faq-answer']}>{entry.answer}</p>
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+
+      {/* Resources - the example Figma file and the live-preview example app. */}
+      <div className={styles['section']}>
+        <div className="acc-label">Resources</div>
+        <div className={styles['link-list']}>
+          <button className={`ghost ${styles['link-btn']}`} onClick={() => openExternal(FIGMA_DESIGN_URL)}>
+            <span className={styles['link-text']}>
+              <span className={styles['link-title']}>Example Figma file</span>
+              <span className={styles['link-sub']}>A sample design with onboarding instructions</span>
+            </span>
+            <img src={iconExternal} alt="" width={15} height={15} />
+          </button>
+          <button className={`ghost ${styles['link-btn']}`} onClick={() => openExternal(EXAMPLE_APP_URL)}>
+            <span className={styles['link-text']}>
+              <span className={styles['link-title']}>Example app</span>
+              <span className={styles['link-sub']}>Try the live preview in your browser</span>
+            </span>
+            <img src={iconExternal} alt="" width={15} height={15} />
+          </button>
+        </div>
+      </div>
+
+      {/* Contact - email is enough for the cases the FAQ doesn't cover. */}
+      <div className={styles['section']}>
+        <div className="acc-label">Still stuck?</div>
+        <p className={`muted ${styles['contact-text']}`}>
+          Reach the Pulsar team at{' '}
+          <button
+            className={styles['contact-link']}
+            onClick={() => openExternal(`mailto:${SUPPORT_EMAIL}`)}
+          >
+            {SUPPORT_EMAIL}
+          </button>
+          .
+        </p>
+      </div>
     </div>
   );
 }

--- a/figma/src/ui/components/onboardingContent.ts
+++ b/figma/src/ui/components/onboardingContent.ts
@@ -1,0 +1,109 @@
+// Single source of truth for the onboarding tour and the Help tab's Q&A. Both
+// the first-run carousel (OnboardingOverlay) and the FAQ accordion
+// (OnboardingPanel) read from here, so the "how do I…" copy never drifts
+// between the two surfaces.
+
+// One step of the first-run carousel. `gif` is the (eventual) animated demo for
+// the step - left undefined for now so the overlay renders a labelled
+// placeholder box. Drop a built asset import here to light it up:
+//   import gifConnectPreset from '../assets/onboarding-connect-preset.gif';
+//   gif: gifConnectPreset
+export interface OnboardingStep {
+  id: string;
+  title: string;
+  // Short, single-idea explanation shown under the demo. One concept per step
+  // keeps the tour skimmable (progressive disclosure).
+  body: string;
+  // Caption shown inside the placeholder until a real GIF is wired in.
+  gifPlaceholder: string;
+  gif?: string;
+}
+
+// Intro screen shown first in the tour (not part of the FAQ - it's a greeting,
+// not a how-to). Kept here so all onboarding copy lives in one place.
+export const WELCOME = {
+  title: 'Welcome to the Pulsar Figma plugin',
+  body: "Let's start a quick tour of the plugin's features."
+};
+
+// Closing screen shown after the feature steps - a send-off, also not a FAQ.
+export const OUTRO = {
+  title: "You're all set!",
+  body: "Go make something that feels great. Good luck - we can't wait to feel what you build."
+};
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: 'bind-preset',
+    title: 'Connect a preset to a component',
+    body: 'Open the Presets tab, pick a haptic, then select a layer or component on the canvas and hit Bind. Pulsar attaches the preset to that node so it fires whenever the component is tapped in a preview.',
+    gifPlaceholder: 'Binding a preset to a component'
+  },
+  {
+    id: 'live-preview',
+    title: 'Connect a live preview',
+    body: 'On the Live preview tab, paste your Figma file link and scan the QR code with the Pulsar mobile app. Your prototype runs on the phone and plays real haptics as you tap the components you bound.',
+    gifPlaceholder: 'Pairing a phone for live preview'
+  },
+  {
+    id: 'share-design',
+    title: 'Share a design with a developer',
+    body: 'Open the Share tab and publish a share link. Developers open it to feel every bound haptic and copy ready-to-use SDK code for iOS, Android, React Native and more - no Figma access required.',
+    gifPlaceholder: 'Sharing a design with a developer'
+  }
+];
+
+// One Q&A entry for the Help tab accordion.
+export interface FaqEntry {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+// The FAQ leads with the three tour steps (rephrased as questions, same copy as
+// the carousel) so the Help tab fully restates the onboarding, then adds the
+// follow-up questions the tour doesn't cover.
+export const FAQ: FaqEntry[] = [
+  {
+    id: 'what-is-pulsar',
+    question: 'What is Pulsar?',
+    answer:
+      'Pulsar lets you design haptics right in Figma. Attach vibration presets to your components, feel them on a real device through a live preview, and hand developers a shareable link with ready-to-use SDK code.'
+  },
+  ...ONBOARDING_STEPS.map<FaqEntry>((step) => ({
+    id: step.id,
+    question: `How do I ${step.title[0].toLowerCase()}${step.title.slice(1)}?`,
+    answer: step.body
+  })),
+  {
+    id: 'custom-presets',
+    question: 'Can I create my own presets?',
+    answer:
+      'Yes. On the Presets tab use "Add custom preset" to paste a custom haptic pattern as JSON. Your custom presets appear at the top of the list and can be bound just like the built-in ones.'
+  },
+  {
+    id: 'tags',
+    question: 'What do the tags on presets mean?',
+    answer:
+      'Tags describe a preset along four dimensions - Intensity, Sharpness, Shape and Duration. Tap them to filter the list, or open the Tags guide from the Presets tab for a full explanation of each one.'
+  },
+  {
+    id: 'phone-not-connecting',
+    question: 'My phone won’t connect - what should I check?',
+    answer:
+      'Make sure you pasted a valid Figma file link on the Live preview tab, that the Pulsar app is updated, and that the phone has a working internet connection. Re-scan the QR code if the pairing times out.'
+  },
+  {
+    id: 'get-the-app',
+    question: 'Where do I get the mobile app?',
+    answer:
+      'The Pulsar app is on the App Store and Google Play. You can grab it from the QR codes on the Live preview tab, or search for "Pulsar" in your store.'
+  }
+];
+
+// Resource links surfaced on the Help tab. Update these once the public Figma
+// file and example app are live (placeholders point at sensible defaults).
+export const FIGMA_DESIGN_URL =
+  'https://www.figma.com/community/file/pulsar-onboarding-example';
+export const EXAMPLE_APP_URL = 'https://docs.swmansion.com/pulsar/figma-preview/';
+export const SUPPORT_EMAIL = 'projects@swmansion.com';


### PR DESCRIPTION
## What

Adds a guided onboarding experience to the Figma plugin and reworks the **Help** tab into a self-serve reference.

### Onboarding tour (`OnboardingOverlay`)
- Full-window, cancellable carousel that opens **automatically on first launch** (gated on a per-user `pulsar:onboardingSeen` flag in `clientStorage`) and can be **relaunched from the Help tab**.
- Flow: **Welcome** (logo + greeting) → three **feature steps** (connect a preset to a component · connect a live preview · share a design with a developer), each with a title, GIF placeholder and short explanation → a **"good luck" send-off**.
- Progress dots, Back/Next + Skip/Esc, arrow-key paging, and **direction-aware slide/fade animations** with a `prefers-reduced-motion` guard.

### Help tab (`OnboardingPanel`)
- Replaces the placeholder with a **"Take the tour"** button, a **Q&A accordion**, **resource links** (example Figma file + example app) and a **contact email** (`projects@swmansion.com`).
- FAQ copy is shared with the tour via `onboardingContent.ts` so the two surfaces never drift; titled sections get extra spacing.

### Wiring
- New `onboardingSeen` field on the `init` message and a `persist-onboarding-seen` message, loaded/persisted in `code.ts` (`clientStorage`, per-user).

## Why
New users had no in-plugin guidance and the Help tab was a placeholder. This showcases the three core flows up front and gives a lasting reference.

## Notes for reviewers
- ⚠️ **Placeholders**: the resource URLs in `onboardingContent.ts` (`FIGMA_DESIGN_URL`, `EXAMPLE_APP_URL`) and the per-step **GIFs** are placeholders — swap them once the public Figma file / recordings exist. The GIF slots render a labelled "GIF coming soon" box until a `gif` import is added to a step.
- Scope: this PR intentionally excludes an unrelated repo-wide em-dash→hyphen normalization and a `.gitignore` tweak that were present in the working tree.

## Verification
`npm run typecheck` + `npm run build` pass. Verified by rendering `figma/dist/ui.html` in a browser (the plugin has no dev server): first-run auto-open, all 5 screens, dot/keyboard/Back-Next navigation, direction-aware animations, "Take the tour" relaunch, and the Help tab accordion/links/contact — no console errors, layout holds at the 380px plugin width.