### PR TITLE
feat(figma): separate designer's private preview token from share token

### DIFF
--- a/figma/AGENT_CONTEXT.md
+++ b/figma/AGENT_CONTEXT.md
@@ -262,13 +262,20 @@ a sub-frame.
 
 ## Per-file tokens & live-preview sync
 
-Each design file has **two** tokens, not global. **Edit token** = the owner's
+Each design file has **three** tokens, not global. **Edit token** = the owner's
 secret; grants write access (PUT config, PATCH visibility) and the owner read.
-Kept only in the plugin, **never** put in a URL. **Public token** = read-only;
-the only thing handed out in share links / QR / deep links. The preview & app
-read through `GET /figma-project/public/:publicToken`, which can view but never
-modify. This is what stops a shared link from letting a viewer edit/delete the
-project. Storage in `clientStorage` (all main-thread, in `src/main/code.ts`):
+Kept only in the plugin, **never** put in a URL. **Public token** = read-only
+share token; handed out in **share links** (copy link / copy token / open).
+Honours the public/private toggle and is **rotated** server-side on every
+private → public re-publish, so a revoked link stays dead. **Preview token** =
+read-only private token; the only thing in the **pairing QR / deep link** the
+designer scans to mirror on their phone. Always-on (ignores the toggle) and
+never rotated, so a paired phone's live preview survives the share link going
+private or being re-shared. Both read tokens go through
+`GET /figma-project/public/:readToken` (view-only, never modify) - the server
+resolves either and applies the right visibility rule. This split is the fix for
+"making the share link private kills the designer's own paired preview." Storage
+in `clientStorage` (all main-thread, in `src/main/code.ts`):
 
 - `pulsar:previewTokens` → `{ [fileKey]: editToken }`. Small and **never
   evicted** - losing it orphans a server row. Replaces the old single
@@ -278,6 +285,10 @@ project. Storage in `clientStorage` (all main-thread, in `src/main/code.ts`):
   share token, paired by `fileKey`. Also never evicted. Recovered from the
   server (the owner GET returns it) if missing - e.g. a reinstall, or a legacy
   share created before the split.
+- `pulsar:previewPrivateTokens` → `{ [fileKey]: previewToken }`. The read-only
+  private preview token (pairing QR), paired by `fileKey`. Never evicted.
+  Recovered from the server (owner GET returns it) if missing; falls back to the
+  share token against a pre-split server.
 - `pulsar:project:<fileKey>` → `{ config, baseRevision, lastAccess }`. The
   cached payload + the server revision it synced at. These are the **only**
   thing evicted (oldest `lastAccess` first) when `clientStorage` hits its quota

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -33,6 +33,11 @@ const PROJECT_TOKENS_KEY = 'pulsar:previewTokens';
 // Per-file read-only share tokens: { [fileKey]: publicToken }. Kept separate
 // from the edit tokens so the share URL never carries the secret. Never evicted.
 const PROJECT_PUBLIC_TOKENS_KEY = 'pulsar:previewPublicTokens';
+// Per-file read-only private preview tokens: { [fileKey]: previewToken }. This
+// is the always-on token the pairing QR encodes; it is never revoked or rotated
+// by the share-link visibility toggle, so a paired phone keeps its live preview.
+// Kept separate from the share tokens (which rotate). Never evicted.
+const PROJECT_PREVIEW_TOKENS_KEY = 'pulsar:previewPrivateTokens';
 // Legacy single global preview token (pre per-file). Migrated lazily into the
 // per-file map for the first file that asks, then deleted.
 const LEGACY_PREVIEW_TOKEN_KEY = 'pulsar:previewToken';
@@ -179,6 +184,24 @@ async function setProjectPublicToken(fileKey: string, publicToken: string): Prom
   const tokens = await loadProjectPublicTokens();
   tokens[fileKey] = publicToken;
   await figma.clientStorage.setAsync(PROJECT_PUBLIC_TOKENS_KEY, tokens);
+}
+
+async function loadProjectPreviewTokens(): Promise<Record<string, string>> {
+  const raw = await figma.clientStorage.getAsync(PROJECT_PREVIEW_TOKENS_KEY);
+  return raw && typeof raw === 'object' ? (raw as Record<string, string>) : {};
+}
+
+// Resolve the private preview token for a file. Null for legacy shares (pre
+// preview-token); the plugin recovers it from the server on the next reconcile.
+async function getProjectPreviewToken(fileKey: string): Promise<string | null> {
+  const tokens = await loadProjectPreviewTokens();
+  return tokens[fileKey] ?? null;
+}
+
+async function setProjectPreviewToken(fileKey: string, previewToken: string): Promise<void> {
+  const tokens = await loadProjectPreviewTokens();
+  tokens[fileKey] = previewToken;
+  await figma.clientStorage.setAsync(PROJECT_PREVIEW_TOKENS_KEY, tokens);
 }
 
 async function getProjectCache(fileKey: string): Promise<ProjectCache | null> {
@@ -474,7 +497,7 @@ function bindToSelection(binding: BindingMeta) {
   node.setPluginData(BINDING_NEGATED_KEY, '');
   node.setPluginData(BINDING_KEY, JSON.stringify(binding));
   node.setRelaunchData({ play: `Pulsar: ${binding.presetName}` });
-  notifyUi(`Bound "${binding.presetName}" to ${node.name}`, 'success');
+  notifyUi(`Preset "${binding.presetName}" connected to ${node.name}`, 'success');
   pushSelection();
 }
 
@@ -521,7 +544,7 @@ function unbindSelection() {
     node.setPluginData(BINDING_KEY, '');
     node.setRelaunchData({});
   }
-  notifyUi('Preset unbound.', 'success');
+  notifyUi('Preset removed from component.', 'success');
   pushSelection();
 }
 
@@ -586,9 +609,10 @@ figma.ui.onmessage = async (msg: UiToMain) => {
       break;
     }
     case 'get-project': {
-      const [token, publicToken, cache] = await Promise.all([
+      const [token, publicToken, previewToken, cache] = await Promise.all([
         getProjectToken(msg.fileKey),
         getProjectPublicToken(msg.fileKey),
+        getProjectPreviewToken(msg.fileKey),
         getProjectCache(msg.fileKey)
       ]);
       postToUi({
@@ -596,6 +620,7 @@ figma.ui.onmessage = async (msg: UiToMain) => {
         fileKey: msg.fileKey,
         token,
         publicToken,
+        previewToken,
         config: cache ? cache.config : null,
         baseRevision: cache ? cache.baseRevision : null,
         // Default to public for legacy caches with no stored visibility.
@@ -606,7 +631,10 @@ figma.ui.onmessage = async (msg: UiToMain) => {
     case 'persist-project-token':
       await Promise.all([
         setProjectToken(msg.fileKey, msg.token),
-        setProjectPublicToken(msg.fileKey, msg.publicToken)
+        // Skip empty values so a partial update (only one token known) never
+        // clobbers a good token with a blank.
+        ...(msg.publicToken ? [setProjectPublicToken(msg.fileKey, msg.publicToken)] : []),
+        ...(msg.previewToken ? [setProjectPreviewToken(msg.fileKey, msg.previewToken)] : [])
       ]);
       break;
     case 'persist-project-cache':

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -133,8 +133,17 @@ export type UiToMain =
   // fileKey so opening the plugin in another design file gets its own token
   // instead of clobbering the first file's shared preview.
   | { type: 'get-project'; fileKey: string }
-  // Persist this file's tokens: secret edit `token` + read-only `publicToken`.
-  | { type: 'persist-project-token'; fileKey: string; token: string; publicToken: string }
+  // Persist this file's tokens: secret edit `token`, read-only share
+  // `publicToken`, and the read-only private `previewToken` (the pairing QR).
+  // previewToken is optional/nullable so a partial recovery (e.g. only the share
+  // token changed) doesn't clobber a known preview token with an empty value.
+  | {
+      type: 'persist-project-token';
+      fileKey: string;
+      token: string;
+      publicToken: string;
+      previewToken?: string | null;
+    }
   | { type: 'persist-project-cache'; fileKey: string; config: unknown; baseRevision: number | null }
   // Persist just the share-link visibility for a file (the public/private
   // toggle), without rewriting the cached config. Keyed by fileKey like the
@@ -183,6 +192,9 @@ export type MainToUi =
       // Read-only share token, or null when unknown (never shared, or a legacy
       // share the cold-start reconcile hasn't recovered yet).
       publicToken: string | null;
+      // Read-only private preview token (the pairing QR), or null when unknown.
+      // Recovered from the server on cold start for legacy/pre-split shares.
+      previewToken: string | null;
       config: unknown | null;
       baseRevision: number | null;
       // Last-known share-link visibility for this file. Defaults to true (public)

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
     onTokenChange: setHapticsToken,
     onConnectedChange: setPhoneConnected,
     ensureSharedPreview: previewSync.ensureShared,
-    previewToken: previewSync.publicToken,
+    previewToken: previewSync.previewToken,
     documentName,
     autoStart: tab === 'live' && isFileKeyValid(figmaFileKey)
   });

--- a/figma/src/ui/hooks/usePreviewSync.ts
+++ b/figma/src/ui/hooks/usePreviewSync.ts
@@ -66,8 +66,14 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
   // Current file's secret edit token (write access). Kept in a ref so the
   // (rebound) preview-data and doc-changed handlers always read the latest value.
   const tokenRef = useRef<string | null>(null);
-  // Current file's read-only share token - what goes into share links/QRs.
+  // Current file's read-only share token - what goes into share links. Rotated
+  // server-side whenever a revoked link is re-published.
   const publicTokenRef = useRef<string | null>(null);
+  // Current file's read-only private preview token - what goes into the pairing
+  // QR + the live-update relay. Unlike the share token it always resolves
+  // (ignores the public/private toggle) and is never rotated, so a paired
+  // phone's live preview survives the share link being made private.
+  const previewTokenRef = useRef<string | null>(null);
   // Server revision our local state is based on (for conflict detection).
   const baseRevisionRef = useRef<number | null>(null);
   // stableStringify of the payload we last successfully pushed - lets us skip a
@@ -101,6 +107,13 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
     publicTokenRef.current = t;
     setPublicToken(t);
   }, []);
+  // Mirror of previewTokenRef as state so the phone-pairing panel can fold the
+  // private preview token into the unified QR / relay it to a paired phone.
+  const [previewToken, setPreviewToken] = useState<string | null>(null);
+  const rememberPreviewToken = useCallback((t: string | null) => {
+    previewTokenRef.current = t;
+    setPreviewToken(t);
+  }, []);
   // Resolver for an in-flight ensureShared() request (the 'pair' purpose), so
   // the async preview-data round-trip can hand its result back to the caller.
   const pairResolveRef = useRef<((t: string | null) => void) | null>(null);
@@ -118,6 +131,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
     fileKey: string;
     token: string | null;
     publicToken: string | null;
+    previewToken: string | null;
     config: unknown | null;
     baseRevision: number | null;
     isPublic: boolean;
@@ -125,6 +139,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
     fileKeyRef.current = m.fileKey;
     tokenRef.current = m.token;
     rememberPublicToken(m.publicToken);
+    rememberPreviewToken(m.previewToken);
     baseRevisionRef.current = m.baseRevision;
     // Seed the toggle from the cached value; the server-fetch branch below
     // reconciles it with the source of truth when there's a token to check.
@@ -142,14 +157,21 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
           lastSyncedJsonRef.current = stableStringify(got.config);
           lastSyncedPayloadRef.current = got.config as PreviewPayload;
           setIsPublic(got.isPublic);
-          // Recover/refresh the read-only share token from the server.
-          if (got.publicToken && got.publicToken !== publicTokenRef.current) {
-            rememberPublicToken(got.publicToken);
+          // Recover/refresh the read-only share + preview tokens from the server.
+          const recoveredPublic = got.publicToken ?? publicTokenRef.current;
+          const recoveredPreview = got.previewToken ?? previewTokenRef.current;
+          if (
+            (got.publicToken && got.publicToken !== publicTokenRef.current) ||
+            (got.previewToken && got.previewToken !== previewTokenRef.current)
+          ) {
+            if (got.publicToken) rememberPublicToken(got.publicToken);
+            if (got.previewToken) rememberPreviewToken(got.previewToken);
             send({
               type: 'persist-project-token',
               fileKey: m.fileKey,
               token: m.token,
-              publicToken: got.publicToken
+              publicToken: recoveredPublic ?? '',
+              previewToken: recoveredPreview
             });
           }
           send({ type: 'persist-project-visibility', fileKey: m.fileKey, isPublic: got.isPublic });
@@ -172,6 +194,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
           // Token no longer exists server-side - forget it; nothing is shared.
           tokenRef.current = null;
           rememberPublicToken(null);
+          rememberPreviewToken(null);
           lastSyncedJsonRef.current = null;
           lastSyncedPayloadRef.current = null;
           baseRevisionRef.current = null;
@@ -340,7 +363,9 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
         const emitUpdate = (toRevision: number, forced: boolean) => {
           const cb = onPublishedRef.current;
           if (!cb) return;
-          const previewToken = publicTokenRef.current ?? undefined;
+          // Relay against the private preview token so a paired phone refetches
+          // through the always-on read path, even if the share link is private.
+          const previewToken = previewTokenRef.current ?? undefined;
           if (
             !forced &&
             prevPayload != null &&
@@ -363,13 +388,19 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
           cb({ kind: 'preview-haptics-refetch', previewToken, toRevision });
         };
 
-        const adopt = (t: string, publicToken: string, revision: number) => {
+        const adopt = (
+          t: string,
+          publicToken: string,
+          previewToken: string,
+          revision: number
+        ) => {
           tokenRef.current = t;
           rememberPublicToken(publicToken);
+          rememberPreviewToken(previewToken);
           baseRevisionRef.current = revision;
           lastSyncedJsonRef.current = json;
           lastSyncedPayloadRef.current = nextPayload;
-          send({ type: 'persist-project-token', fileKey, token: t, publicToken });
+          send({ type: 'persist-project-token', fileKey, token: t, publicToken, previewToken });
           send({ type: 'persist-project-cache', fileKey, config: payload, baseRevision: revision });
         };
 
@@ -382,7 +413,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
           // didn't exist yet, so there's nothing to relay.
           if (!allowCreate) return null;
           const created = await createProject(payload);
-          adopt(created.token, created.publicToken, created.revision);
+          adopt(created.token, created.publicToken, created.previewToken, created.revision);
           return created.token;
         }
 
@@ -405,7 +436,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
             return null;
           }
           const created = await createProject(payload);
-          adopt(created.token, created.publicToken, created.revision);
+          adopt(created.token, created.publicToken, created.previewToken, created.revision);
           return created.token;
         }
         // Conflict: someone changed the row since our base. The server is the
@@ -430,7 +461,7 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
             return null;
           }
           const created = await createProject(payload);
-          adopt(created.token, created.publicToken, created.revision);
+          adopt(created.token, created.publicToken, created.previewToken, created.revision);
           return created.token;
         }
         // Lost a second race - bail; the next change will retry from the new base.
@@ -462,16 +493,53 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
         }
         setSyncStatus('synced');
 
+        // Pairing a phone hands the designer their PRIVATE preview token, which
+        // the QR encodes and the phone reads through the always-on path. It must
+        // NOT touch the share link's visibility (pairing a phone is unrelated to
+        // who can open a shared link). Recover the token from the server if it
+        // isn't cached (e.g. a legacy share or a phone re-paired after restart).
+        if (isPair) {
+          let pairToken = previewTokenRef.current;
+          if (!pairToken) {
+            const got = await fetchProject(token);
+            if (got.kind === 'ok' && got.previewToken) {
+              pairToken = got.previewToken;
+              rememberPreviewToken(pairToken);
+              if (got.publicToken) rememberPublicToken(got.publicToken);
+              send({
+                type: 'persist-project-token',
+                fileKey,
+                token,
+                publicToken: got.publicToken ?? publicTokenRef.current ?? '',
+                previewToken: pairToken
+              });
+            }
+          }
+          settlePair(pairToken ?? null);
+          return;
+        }
+
         // Beyond the sync itself, share actions also need a URL / QR / clipboard.
         if (purpose === 'autosync' || purpose === 'sync') return;
 
         // Any explicit share re-opens the link to the public: if the user had
         // made it private, handing the link out again necessarily makes it
-        // viewable, so flip the toggle back on. Optimistic + best-effort - the
-        // server is the source of truth, reconciled on the next cold start.
+        // viewable, so flip the toggle back on. Re-publishing a previously-private
+        // link rotates the share token server-side (the old link stays dead), so
+        // adopt whatever token the PATCH returns before building the URL.
         setIsPublic(true);
         send({ type: 'persist-project-visibility', fileKey, isPublic: true });
-        void setProjectVisibility(token, true).catch(() => {});
+        const vis = await setProjectVisibility(token, true).catch(() => null);
+        if (vis?.ok && vis.publicToken && vis.publicToken !== publicTokenRef.current) {
+          rememberPublicToken(vis.publicToken);
+          send({
+            type: 'persist-project-token',
+            fileKey,
+            token,
+            publicToken: vis.publicToken,
+            previewToken: previewTokenRef.current
+          });
+        }
 
         // Everything we hand out carries the read-only public token, never the
         // edit token. Recover it from the server if not cached (e.g. legacy share).
@@ -482,22 +550,17 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
           if (got.kind === 'ok' && got.publicToken) {
             shareToken = got.publicToken;
             rememberPublicToken(shareToken);
-            send({ type: 'persist-project-token', fileKey, token, publicToken: shareToken });
+            send({
+              type: 'persist-project-token',
+              fileKey,
+              token,
+              publicToken: shareToken,
+              previewToken: got.previewToken ?? previewTokenRef.current
+            });
           }
         }
         if (!shareToken) {
-          if (isPair) {
-            settlePair(null);
-            return;
-          }
           notify('Could not resolve the share link. Try “Sync now” and retry.', { level: 'error' });
-          return;
-        }
-
-        // Pairing only needs the public token (the visibility was just re-opened
-        // above) - hand it back and stop before building share URLs.
-        if (isPair) {
-          settlePair(shareToken);
           return;
         }
 
@@ -536,10 +599,12 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
   const showInLivePreview = () => send({ type: 'request-preview-data', purpose: 'open' });
   const copyShareLink = () => send({ type: 'request-preview-data', purpose: 'copy' });
   const copyShareToken = () => send({ type: 'request-preview-data', purpose: 'copy-token' });
-  // Resolve the file's read-only share token for the unified phone-pairing QR,
-  // publishing the project first if needed. Resolves null when the file isn't
-  // preview-ready (no Figma file key / no bindings) so the caller pairs the
-  // phone with the code alone.
+  // Resolve the file's private preview token for the unified phone-pairing QR,
+  // publishing the project first if needed. This is the always-on token (never
+  // revoked or rotated by the share-link toggle), so a paired phone keeps its
+  // live preview regardless of the link's visibility. Resolves null when the
+  // file isn't preview-ready (no Figma file key / no bindings) so the caller
+  // pairs the phone with the code alone.
   const ensureShared = useCallback((): Promise<string | null> => {
     // Supersede any in-flight pairing request.
     settlePair(null);
@@ -574,17 +639,30 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
     setIsPublic(next);
     send({ type: 'persist-project-visibility', fileKey, isPublic: next });
     void (async () => {
-      let ok = false;
+      let res: Awaited<ReturnType<typeof setProjectVisibility>> | null = null;
       try {
-        ok = await setProjectVisibility(token, next);
+        res = await setProjectVisibility(token, next);
       } catch {
-        ok = false;
+        res = null;
       }
-      if (!ok) {
+      if (!res?.ok) {
         setIsPublic(!next);
         send({ type: 'persist-project-visibility', fileKey, isPublic: !next });
         notify('Could not update the preview’s visibility. Please try again.', { level: 'error' });
         return;
+      }
+      // Re-publishing (private → public) rotates the share token: adopt the fresh
+      // one so the next "copy link" hands out a working URL. (The private preview
+      // token the paired phone uses is untouched, so its live preview survives.)
+      if (next && res.publicToken && res.publicToken !== publicTokenRef.current) {
+        rememberPublicToken(res.publicToken);
+        send({
+          type: 'persist-project-token',
+          fileKey,
+          token,
+          publicToken: res.publicToken,
+          previewToken: previewTokenRef.current
+        });
       }
       notify(
         next
@@ -598,9 +676,13 @@ export function usePreviewSync({ settings, figmaFileKey, presetById, notify, onP
   return {
     syncStatus,
     isPublic,
-    // The current file's read-only share token (null until shared), surfaced so
-    // the phone-pairing panel can fold it into the unified QR / relay it.
+    // The current file's read-only share token (null until shared), surfaced for
+    // the share-link UI (copy link / copy token).
     publicToken,
+    // The current file's private preview token (null until shared), surfaced so
+    // the phone-pairing panel can fold it into the unified QR / relay it. Unlike
+    // publicToken it's never revoked or rotated by the visibility toggle.
+    previewToken,
     ensureShared,
     initProject,
     showInLivePreview,

--- a/figma/src/ui/lib/previewServer.ts
+++ b/figma/src/ui/lib/previewServer.ts
@@ -24,10 +24,11 @@ export function resolvePreviewBaseUrl(override: string): string {
 }
 
 // POST the preview payload. Returns the secret edit token, a read-only
-// publicToken for share links, and the revision.
+// publicToken for share links, a read-only previewToken for the pairing QR
+// (always serves, independent of share-link visibility), and the revision.
 export async function createProject(
   payload: unknown
-): Promise<{ token: string; publicToken: string; revision: number }> {
+): Promise<{ token: string; publicToken: string; previewToken: string; revision: number }> {
   const res = await fetch(`${API_SERVER_URL}/figma-project`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -38,6 +39,7 @@ export async function createProject(
         success: boolean;
         token?: string;
         publicToken?: string;
+        previewToken?: string;
         revision?: number;
         error?: string;
         detail?: string;
@@ -50,7 +52,14 @@ export async function createProject(
   if (!data?.success || !data.token || !data.publicToken) {
     throw new Error(data?.error || 'No token returned');
   }
-  return { token: data.token, publicToken: data.publicToken, revision: data.revision ?? 0 };
+  return {
+    token: data.token,
+    publicToken: data.publicToken,
+    // Fall back to the share token against an older server that predates the
+    // split (mirrors the server's preview_token = public_token backfill).
+    previewToken: data.previewToken ?? data.publicToken,
+    revision: data.revision ?? 0
+  };
 }
 
 // Result of a conditional update: applied (new revision), gone (404, caller
@@ -92,12 +101,21 @@ export async function updateProject(
 // missing row. Only 'missing' means forget the token. ('private' is only
 // reachable against an older server that still 403s the owner read.)
 export type FetchResult =
-  | { kind: 'ok'; config: unknown; revision: number; isPublic: boolean; publicToken: string | null }
+  | {
+      kind: 'ok';
+      config: unknown;
+      revision: number;
+      isPublic: boolean;
+      publicToken: string | null;
+      // Read-only private preview token (the pairing QR). Null against an older
+      // server that predates the split.
+      previewToken: string | null;
+    }
   | { kind: 'private' }
   | { kind: 'missing' };
 
 // GET the owner's project by its secret edit token. Also returns the read-only
-// publicToken so the plugin can (re)learn the share token for a legacy share.
+// share + preview tokens so the plugin can (re)learn them for a legacy share.
 export async function fetchProject(token: string): Promise<FetchResult> {
   const res = await fetch(`${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}`);
   if (res.status === 404) return { kind: 'missing' };
@@ -110,6 +128,7 @@ export async function fetchProject(token: string): Promise<FetchResult> {
         revision?: number;
         isPublic?: boolean;
         publicToken?: string;
+        previewToken?: string;
         error?: string;
         detail?: string;
       }
@@ -124,20 +143,34 @@ export async function fetchProject(token: string): Promise<FetchResult> {
     config: data.config ?? null,
     revision: data.revision ?? 0,
     isPublic: data.isPublic ?? true,
-    publicToken: data.publicToken ?? null
+    publicToken: data.publicToken ?? null,
+    // Fall back to the share token against an older (pre-split) server.
+    previewToken: data.previewToken ?? data.publicToken ?? null
   };
 }
 
-// PATCH a token's share-link visibility (public ⇄ private). Returns whether the
-// server accepted the change. Separate from updateProject so a config sync and
-// a visibility toggle never get conflated.
-export async function setProjectVisibility(token: string, isPublic: boolean): Promise<boolean> {
+// Outcome of a visibility PATCH: whether the server accepted it, plus the
+// current share token after the change. Re-publishing (private → public)
+// rotates publicToken server-side, so the caller must adopt the returned value.
+export interface VisibilityResult {
+  ok: boolean;
+  publicToken: string | null;
+}
+
+// PATCH a token's share-link visibility (public ⇄ private). Separate from
+// updateProject so a config sync and a visibility toggle never get conflated.
+export async function setProjectVisibility(
+  token: string,
+  isPublic: boolean
+): Promise<VisibilityResult> {
   const res = await fetch(`${API_SERVER_URL}/figma-project/${encodeURIComponent(token)}/visibility`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ isPublic })
   });
-  if (!res.ok) return false;
-  const data = (await res.json().catch(() => null)) as { success?: boolean } | null;
-  return !!data?.success;
+  if (!res.ok) return { ok: false, publicToken: null };
+  const data = (await res.json().catch(() => null)) as
+    | { success?: boolean; publicToken?: string }
+    | null;
+  return { ok: !!data?.success, publicToken: data?.publicToken ?? null };
 }


### PR DESCRIPTION
## Problem

In the Figma plugin, the pairing QR (what a designer scans to mirror the design on their phone) and the share link given to reviewers both used the same read-only `public_token`. Making the share link **private** revoked that token server-side — which also broke the live preview of any designer who had paired their **own** phone via the QR, since both read through the same token.

## Fix

Split the read token into two:

- **`public_token`** — the share link. Honours the public/private toggle and is **rotated** on every private→public re-publish, so a revoked link stays dead when re-shared.
- **`preview_token`** — the pairing QR. **Always serves** (ignores the toggle) and is **never rotated**, so a paired phone's live preview survives the share link going private or being re-shared.

Both read tokens flow through the same `GET /figma-project/public/:readToken` (the WebView only carries an opaque `?token=`); the server resolves either column and applies the right visibility rule.

### Plugin changes
- Pairing now resolves the **private** preview token and no longer flips the link's visibility.
- The live-update relay targets the preview token (so a paired phone refetches through the always-on path).
- Explicit share actions and the visibility toggle adopt the **rotated** `public_token`.
- New `pulsar:previewPrivateTokens` clientStorage map, recovered from the server when missing, with a fallback to the share token against a pre-split server.

## Server dependency

Requires the matching server change in **software-mansion-labs/pulsar-private** (adds the `preview_token` column, the combined read route, and `public_token` rotation). That PR includes updated + new server tests.

## Verification
- `npm run typecheck` and `npm run build` pass for the plugin.