### PR TITLE
feat(figma): per-frame live preview — follow designer focus + preset navigation

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -104,6 +104,10 @@ function FigmaPreviewWebView({ token }: { token: string }) {
         fromRevision: update.fromRevision,
         toRevision: update.toRevision,
         diff: update.diff,
+        // Set only for 'preview-frame-focus'; undefined keys are dropped by
+        // JSON.stringify so the haptics diff/refetch envelopes are unchanged.
+        nodeId: update.nodeId,
+        frameName: update.frameName,
       })
     );
   }, [lastPreviewUpdate, token]);

--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -95,11 +95,16 @@ export interface ReceivedPattern {
 // open preview) here. `nonce` is monotonic so an identical repeat still
 // re-triggers the consumer effect.
 export interface PreviewUpdate {
-  kind: 'preview-haptics-diff' | 'preview-haptics-refetch';
+  kind: 'preview-haptics-diff' | 'preview-haptics-refetch' | 'preview-frame-focus';
   previewToken?: string;
   fromRevision?: number;
   toRevision?: number;
   diff?: unknown;
+  // Set only on 'preview-frame-focus': the top-level frame the designer focused,
+  // which the open live preview should present, plus its human-readable name for
+  // the preview's "current screen" indicator.
+  nodeId?: string;
+  frameName?: string;
   nonce: number;
 }
 
@@ -289,7 +294,9 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
               msg &&
               typeof msg === 'object' &&
               typeof (msg as { kind?: unknown }).kind === 'string' &&
-              (msg as { kind: string }).kind.startsWith('preview-haptics-')
+              // Covers both the haptics-config relay (diff/refetch) and the
+              // designer-focus frame jump (preview-frame-focus).
+              (msg as { kind: string }).kind.startsWith('preview-')
             ) {
               // Forwarded verbatim to the open live preview (figma.tsx). Match on
               // the producer-supplied previewToken, falling back to the one this

--- a/figma/AGENT_CONTEXT.md
+++ b/figma/AGENT_CONTEXT.md
@@ -182,6 +182,52 @@ When `isAppHost` is true, taps post:
 .play()` for custom (user-defined) presets whose names don't match anything
 in `Presets`.
 
+### Live-preview relay → paired phone (per-frame sync)
+
+The plugin pushes three kinds of update to a paired phone over the same
+`/broadcast` relay (`broadcastChannel` is a transparent JSON relay — **no server
+change** is needed to add a kind). They flow plugin → `/broadcast` →
+phone socket (`ConnectionsContext` → `lastPreviewUpdate`) → WebView injection
+(`figma.tsx` → `buildPreviewInjection`) → preview (`useHostUpdates`):
+
+- `preview-haptics-diff` / `preview-haptics-refetch` — config changes (binding
+  edits). Applied in place, no iframe reload.
+- `preview-frame-focus` — the designer focused a different top-level frame
+  (selection, or an edit to a node inside another frame). Carries `nodeId` (the
+  top-level frame). The preview presents that frame (`currentNodeId` →
+  `PrototypeView`). Emitted by `pushFrameFocus()` in `code.ts` (deduped to actual
+  frame changes), broadcast from `App.tsx` only when a phone is connected.
+
+  Frame switching can't use the Embed API's inbound `NAVIGATE_TO_FRAME` message —
+  it's *documented* but a **no-op in practice** for these prototype embeds
+  (verified against a live embed; even Figma's own example forward button doesn't
+  move via postMessage). So each frame is its own iframe, selected by `node-id`.
+  To avoid a reload on every switch, `PrototypeView` keeps a small **keep-alive
+  cache** (LRU, `MAX_LIVE_FRAMES`): visited frames stay mounted but hidden
+  (`display:none`, which preserves the browsing context in Chromium/WebKit — the
+  app WebView + Chrome; Firefox is the lone exception), so the first visit to a
+  frame loads and revisits are instant. Two invariants the cache must keep (see
+  the comments there): never reorder a mounted iframe (DOM reparent = reload), and
+  re-label a slot when the embed navigates internally (a hotspot tap) so the cache
+  stays accurate — which is why `PRESENTED_NODE_CHANGED` is handled inside
+  `PrototypeView` (attributed to the active iframe by `event.source`), not in
+  App's global figma-message listener.
+
+This is a **phone-only** channel: only PulsarApp's WebView is a socket receiver,
+so the standalone web preview never sees focus changes. The web preview instead
+navigates on an **explicit preset tap** in the "Haptic elements" list
+(`HapticList` → `onOpenFrame` → `navigateToFrame`), which drives the same
+`navNodeId` → iframe `node-id` path. `navNodeId` is distinct from
+`currentNodeId`: in-prototype taps move `currentNodeId` (overlay) without
+reloading; a deliberate jump sets both and reloads the embed.
+
+When extending the relay vocabulary, the kind string must start with `preview-`
+(the phone's broadcast guard in `ConnectionsContext` matches that prefix) and be
+added to: `figma/src/ui/lib/diffPayload.ts` (`PreviewUpdateMessage`),
+`PulsarApp/contexts/ConnectionsContext.tsx` (`PreviewUpdate`),
+`PulsarApp/app/(tabs)/figma.tsx` (injection), and
+`figma/preview/src/lib/useHostUpdates.ts` (consumer).
+
 ### Preview ↔ docs `/figma-preview` page (srcdoc iframe)
 
 Docs at `docs/src/components/preview/Preview.astro` embeds the

--- a/figma/preview/src/App.tsx
+++ b/figma/preview/src/App.tsx
@@ -107,8 +107,6 @@ export default function App() {
     [refetch]
   );
   const onRefetch = useCallback((toRevision: number) => void refetch(toRevision), [refetch]);
-  const hostHandlers = useMemo(() => ({ onDiff, onRefetch }), [onDiff, onRefetch]);
-  useHostUpdates(hostHandlers);
 
   // Derived lookup maps (stable across renders).
   const { bindings, ownerMap, presentedId, frames } = useMemo(() => {
@@ -170,13 +168,47 @@ export default function App() {
         : 'Waiting for a design - open one from the Pulsar plugin.'
     );
   }, [payloadLoaded, payload, isPrivate]);
+  // The frame currently presented. Drives both which embed iframe is shown
+  // (PrototypeView keeps a keep-alive cache keyed off this) and the overlay
+  // grouping. Moved by a deliberate jump - the designer focusing a frame
+  // (relayed from the app) or a preset tap in the list - and by in-prototype
+  // navigation (a hotspot tap), which PrototypeView reports via
+  // onPresentedNodeChange. Switching frames doesn't reload an already-visited
+  // one; the Embed API's inbound NAVIGATE_TO_FRAME message is a no-op in
+  // practice (verified against a live embed), so each frame is its own iframe
+  // and revisits just un-hide the cached one.
   const [currentNodeId, setCurrentNodeId] = useState(presentedId);
-  // Sync currentNodeId when the payload arrives later (async token fetch). The
-  // useState initializer above only runs once with whatever presentedId was on
-  // first render, which is the empty string before the fetch resolves.
+  // Sync when the payload arrives later (async token fetch). The useState
+  // initializer above only runs once with whatever presentedId was on first
+  // render, which is the empty string before the fetch resolves.
   useEffect(() => {
     setCurrentNodeId(presentedId);
   }, [presentedId]);
+
+  // Names for frames the app relayed a focus to. The payload's `frames` map only
+  // covers frames that have bindings, so a designer focusing a binding-less frame
+  // arrives with no name there - we keep the relayed name to label the indicator.
+  const [relayedFrameNames, setRelayedFrameNames] = useState<Record<string, string>>({});
+
+  // Jump to a specific top-level frame (designer focus relay / preset tap).
+  // Idempotent - re-selecting the current frame is a no-op. `frameName` is only
+  // passed by the focus relay; preset taps resolve the name from the frames map.
+  const navigateToFrame = useCallback((frameId: string, frameName?: string) => {
+    const norm = normalizeId(frameId);
+    if (!norm) return;
+    setCurrentNodeId(norm);
+    if (frameName) {
+      setRelayedFrameNames((prev) => (prev[norm] === frameName ? prev : { ...prev, [norm]: frameName }));
+    }
+  }, []);
+
+  // Host-relayed updates, only injected when running inside PulsarApp's WebView:
+  // incremental config diffs, full refetches, and designer-focus frame jumps.
+  const hostHandlers = useMemo(
+    () => ({ onDiff, onRefetch, onFocusFrame: navigateToFrame }),
+    [onDiff, onRefetch, navigateToFrame]
+  );
+  useHostUpdates(hostHandlers);
   const [highlightsOn, setHighlightsOn] = useState(true);
   const [activeId, setActiveId] = useState('');
   const [detailsId, setDetailsId] = useState<string>('');
@@ -222,6 +254,9 @@ export default function App() {
   // covers the lower strip. This toggle asks the native host to hide/show that
   // tab bar so the prototype can run edge-to-edge. No-op outside the app host.
   const [navBarHidden, setNavBarHidden] = useState(false);
+  // Whether the in-app "current screen" indicator is collapsed to an icon-only
+  // dot. The viewer can tuck it away when they don't need the screen name.
+  const [indicatorCollapsed, setIndicatorCollapsed] = useState(false);
   const toggleNavBar = useCallback(() => {
     setNavBarHidden((prev) => {
       const next = !prev;
@@ -284,7 +319,9 @@ export default function App() {
         setStatus('Tap a highlighted element to feel its haptic.');
         setLoaded(true);
       },
-      onPresentedNodeChanged: (id: string) => setCurrentNodeId(normalizeId(id)),
+      // PRESENTED_NODE_CHANGED is handled inside PrototypeView instead, where it
+      // can be attributed to the active iframe (the keep-alive cache mounts
+      // several) and re-label its cache slot.
       onLoginScreen: () => setStatus('This file requires Figma login to embed.'),
       onMousePressOrRelease: (targetNodeId: string) => {
         const norm = normalizeId(targetNodeId);
@@ -374,6 +411,11 @@ export default function App() {
   const showHighlights =
     highlightsOn && !fullscreen && currentFrame !== null && visibleElements.length > 0;
 
+  // Name of the frame on screen, for the in-app "current screen" indicator.
+  // Prefer the payload's frames map (frames with bindings); fall back to the name
+  // the app relayed with a focus (covers binding-less frames the designer focused).
+  const currentFrameName = frames.get(currentNodeId)?.name ?? relayedFrameNames[currentNodeId] ?? '';
+
   return (
     <>
       {!fullscreen && (
@@ -382,7 +424,7 @@ export default function App() {
       <main className={`main${fullscreen ? ' fullscreen' : ''}`}>
         <PrototypeView
           fileKey={payload.fileKey}
-          nodeId={payload.nodeId}
+          nodeId={currentNodeId}
           frame={currentFrame}
           elements={visibleElements}
           showHighlights={showHighlights}
@@ -390,6 +432,7 @@ export default function App() {
           fullscreen={fullscreen}
           deviceFrame={!isMobile}
           loaded={loaded}
+          onPresentedNodeChange={(id) => setCurrentNodeId(normalizeId(id))}
         />
         {!fullscreen && (
           <HapticList
@@ -401,11 +444,46 @@ export default function App() {
             activeId={activeId}
             onActivate={setActiveId}
             onPlay={playFromList}
+            onOpenFrame={navigateToFrame}
             onShowDetails={setDetailsId}
             footer={openOnPhoneLink ? <OpenOnPhone deepLink={openOnPhoneLink} /> : undefined}
           />
         )}
       </main>
+
+      {/* In-app only: a small badge naming the screen on view. The app
+          auto-switches frames as the designer focuses them, so without this the
+          viewer can lose track of which screen they're feeling. Tap to collapse
+          it to an icon-only dot. Hidden in true-fullscreen (nav bar toggled off)
+          to keep that view uncluttered. */}
+      {isAppHost && currentFrameName && !navBarHidden && (
+        <button
+          type="button"
+          className={`frame-indicator${indicatorCollapsed ? ' collapsed' : ''}`}
+          onClick={() => setIndicatorCollapsed((c) => !c)}
+          aria-expanded={!indicatorCollapsed}
+          aria-label={indicatorCollapsed ? `Current screen: ${currentFrameName}` : 'Hide screen name'}
+          title={indicatorCollapsed ? currentFrameName : 'Hide screen name'}
+        >
+          {/* Screen/frame glyph - the persistent affordance when collapsed. */}
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="4" width="18" height="16" rx="2" />
+            <path d="M3 9h18" />
+          </svg>
+          {!indicatorCollapsed && <span className="frame-indicator-name">{currentFrameName}</span>}
+        </button>
+      )}
+
       {detailsId && bindings.get(detailsId) && (
         <PresetDetailsModal
           data={bindings.get(detailsId)!}

--- a/figma/preview/src/components/HapticList.tsx
+++ b/figma/preview/src/components/HapticList.tsx
@@ -10,6 +10,7 @@ export function HapticList({
   activeId,
   onActivate,
   onPlay,
+  onOpenFrame,
   onShowDetails,
   footer
 }: {
@@ -21,6 +22,9 @@ export function HapticList({
   activeId: string;
   onActivate: (id: string) => void;
   onPlay: (id: string) => void;
+  // Open the frame this element lives in (the preview jumps to that screen).
+  // Optional so the list can render without navigation wired up.
+  onOpenFrame?: (frameId: string) => void;
   onShowDetails: (id: string) => void;
   // Optional pinned content below the scrollable list (e.g. the open-on-phone QR).
   footer?: ReactNode;
@@ -100,7 +104,12 @@ export function HapticList({
                   className={`el-row${activeId === el.id ? ' active' : ''}`}
                   onMouseEnter={() => onActivate(el.id)}
                   onMouseLeave={() => onActivate('')}
-                  onClick={() => onPlay(el.id)}
+                  onClick={() => {
+                    // Tapping a preset opens the screen it belongs to, then
+                    // plays its haptic so the developer can feel it in context.
+                    if (el.frameId) onOpenFrame?.(el.frameId);
+                    onPlay(el.id);
+                  }}
                 >
                   <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
                     <div style={{ flex: 1, minWidth: 0 }}>

--- a/figma/preview/src/components/PrototypeView.tsx
+++ b/figma/preview/src/components/PrototypeView.tsx
@@ -1,9 +1,28 @@
-import { useMemo, useRef } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import type { ElementInfo, NodeBox } from '../types';
-import { buildEmbedSrc } from '../lib/embed';
+import { buildEmbedSrc, FIGMA_ORIGINS, type FigmaEmbedEvent } from '../lib/embed';
+import { normalizeId } from '../lib/ids';
 import { useElementSize } from '../lib/useElementSize';
 import { HighlightOverlay } from './HighlightOverlay';
 import { PrototypeLoader } from './PrototypeLoader';
+
+// How many visited frames to keep mounted (active + recent). Each one is a full
+// Figma embed, so this is a memory/CPU vs. snappiness trade-off - keep it modest
+// for mobile WebViews. Tune here if designers routinely hop across more screens.
+const MAX_LIVE_FRAMES = 5;
+
+// One mounted embed. `key` is a stable synthetic id used as the React key and
+// ref handle - it never changes for the iframe's lifetime, so the element is
+// never reparented (which would reload it). `mountNode` is the node-id the embed
+// URL was built with; it never changes either, so the `src` is stable and the
+// iframe never reloads. `node` is the frame the iframe is *currently* showing -
+// it starts as `mountNode` and is re-labelled when the user navigates inside the
+// prototype, so cache lookups (by shown frame) stay accurate without touching src.
+interface Slot {
+  key: string;
+  mountNode: string;
+  node: string;
+}
 
 export function PrototypeView({
   fileKey,
@@ -14,9 +33,15 @@ export function PrototypeView({
   activeId,
   fullscreen = false,
   deviceFrame,
-  loaded
+  loaded,
+  onPresentedNodeChange
 }: {
   fileKey: string;
+  // The frame to present (already normalized). The Embed API's inbound
+  // NAVIGATE_TO_FRAME message is a no-op in practice (see embed.ts), so each
+  // distinct frame is its own iframe selected by node-id. To avoid a reload on
+  // every switch we keep a small keep-alive cache of visited frames: the *first*
+  // visit loads an iframe; revisits just un-hide the already-loaded one (instant).
   nodeId: string | null;
   frame: NodeBox | null;
   elements: ElementInfo[];
@@ -25,18 +50,115 @@ export function PrototypeView({
   fullscreen?: boolean;
   deviceFrame: boolean;
   loaded: boolean;
+  // The prototype navigated (a hotspot tap inside the embed). Reported up so the
+  // overlay can follow. Owned here, not in App's global figma-message listener,
+  // so we can attribute the event to the *active* iframe by its window - a late
+  // event from a hidden, still-loading cached iframe must not move the view.
+  onPresentedNodeChange: (nodeId: string) => void;
 }) {
   const stageRef = useRef<HTMLDivElement>(null);
   const size = useElementSize(stageRef);
-  const src = useMemo(
-    () => buildEmbedSrc(fileKey, nodeId, deviceFrame),
-    [fileKey, nodeId, deviceFrame]
-  );
+
+  const activeFrameId = nodeId ?? '';
+
+  // Keep-alive cache. `slots` is append-only / filter-removed - never reordered,
+  // because moving an iframe in the DOM reloads it. Recency (for LRU eviction)
+  // lives in a ref so it doesn't perturb mount order.
+  const [slots, setSlots] = useState<Slot[]>(() => [
+    { key: 'f0', mountNode: activeFrameId, node: activeFrameId }
+  ]);
+  const counterRef = useRef(1); // next synthetic key suffix ('f0' is taken)
+  const recencyRef = useRef<string[]>(['f0']); // slot keys, most-recent last
+  const iframesRef = useRef(new Map<string, HTMLIFrameElement>());
+  // Mirrors of render state for the (once-bound) message listener below.
+  const slotsRef = useRef(slots);
+  slotsRef.current = slots;
+
+  const activeKey = slots.find((s) => s.node === activeFrameId)?.key;
+  const activeKeyRef = useRef(activeKey);
+  activeKeyRef.current = activeKey;
+  const onPresentedRef = useRef(onPresentedNodeChange);
+  onPresentedRef.current = onPresentedNodeChange;
+
+  // Reconcile the cache to the requested frame *before paint* (useLayoutEffect),
+  // so a cache hit shows instantly and a miss never paints a blank gap. A hit
+  // just bumps recency; a miss mounts a new iframe and evicts the least-recently
+  // shown one when over the cap.
+  useLayoutEffect(() => {
+    const existing = slotsRef.current.find((s) => s.node === activeFrameId);
+    const key = existing ? existing.key : `f${counterRef.current++}`;
+    recencyRef.current = [...recencyRef.current.filter((k) => k !== key), key];
+    if (existing) return; // already mounted - no DOM change, no reload
+    setSlots((prev) => {
+      // append only - never reparent; mountNode fixes the src for its lifetime
+      let next = [...prev, { key, mountNode: activeFrameId, node: activeFrameId }];
+      if (next.length > MAX_LIVE_FRAMES) {
+        const lru = recencyRef.current.find((k) => k !== key && next.some((s) => s.key === k));
+        if (lru) {
+          iframesRef.current.delete(lru);
+          next = next.filter((s) => s.key !== lru); // filter-remove keeps the rest in place
+        }
+      }
+      return next;
+    });
+  }, [activeFrameId]);
+
+  // A different prototype or device bezel changes every embed URL, so the cached
+  // iframes are stale - drop them and start fresh on the current frame.
+  useLayoutEffect(() => {
+    counterRef.current = 1;
+    recencyRef.current = ['f0'];
+    iframesRef.current.clear();
+    setSlots([{ key: 'f0', mountNode: activeFrameId, node: activeFrameId }]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileKey, deviceFrame]);
+
+  // Track in-prototype navigation, but only from the *active* iframe's window -
+  // a hidden cached iframe that finishes loading late must not steal the view.
+  // Re-label the active slot to the frame it navigated to so the cache stays
+  // accurate (a later explicit jump back to the original frame then reloads it
+  // fresh instead of showing the navigated-away content).
+  useLayoutEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (!FIGMA_ORIGINS.includes(event.origin)) return;
+      const msg = event.data as FigmaEmbedEvent;
+      if (!msg || msg.type !== 'PRESENTED_NODE_CHANGED') return;
+      const active = activeKeyRef.current ? iframesRef.current.get(activeKeyRef.current) : undefined;
+      if (!active || event.source !== active.contentWindow) return;
+      const next = normalizeId(msg.data?.presentedNodeId ?? '');
+      if (!next) return;
+      const key = activeKeyRef.current!;
+      setSlots((prev) =>
+        prev
+          .map((s) => (s.key === key ? { ...s, node: next } : s))
+          // Drop any other slot that was showing this frame - it's now a stale duplicate.
+          .filter((s) => s.key === key || s.node !== next)
+      );
+      onPresentedRef.current(next);
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
 
   return (
     <div className={`frame-wrap${fullscreen ? ' fullscreen' : ''}`}>
       <div className="stage" ref={stageRef}>
-        <iframe title="Figma prototype" src={src} allow="fullscreen" allowFullScreen />
+        {slots.map((slot) => (
+          <iframe
+            key={slot.key}
+            ref={(el) => {
+              if (el) iframesRef.current.set(slot.key, el);
+              else iframesRef.current.delete(slot.key);
+            }}
+            title="Figma prototype"
+            src={buildEmbedSrc(fileKey, slot.mountNode, deviceFrame)}
+            allow="fullscreen"
+            allowFullScreen
+            // Inline display wins over the `.stage iframe { display: block }`
+            // rule; only the active frame is shown, the rest stay warm + hidden.
+            style={{ display: slot.key === activeKey ? 'block' : 'none' }}
+          />
+        ))}
         {showHighlights && frame && (
           <HighlightOverlay frame={frame} elements={elements} size={size} activeId={activeId} />
         )}

--- a/figma/preview/src/lib/embed.ts
+++ b/figma/preview/src/lib/embed.ts
@@ -27,6 +27,13 @@ export function buildEmbedSrc(
   return `https://embed.figma.com/proto/${fileKey}/preview?${params.toString()}`;
 }
 
+// NOTE: The Figma Embed API documents inbound control messages
+// (NAVIGATE_TO_FRAME_AND_CLOSE_OVERLAYS, NAVIGATE_FORWARD, …) posted to the
+// iframe's contentWindow. We tried these to switch frames without reloading, but
+// they're a no-op in practice for these embeds - even Figma's own example's
+// forward button doesn't move the prototype via postMessage. So a frame change
+// goes through the iframe's node-id (a reload) instead; see PrototypeView.
+
 // Events the embedded prototype posts to the parent window.
 export interface FigmaEmbedEvent {
   type:

--- a/figma/preview/src/lib/useHostUpdates.ts
+++ b/figma/preview/src/lib/useHostUpdates.ts
@@ -6,18 +6,25 @@ import type { HapticsDiff } from './applyDiff';
 // plugin relays a live haptics-config change over the paired socket.
 interface HapticsUpdateEnvelope {
   type: 'pulsar-haptics-update';
-  kind: 'preview-haptics-diff' | 'preview-haptics-refetch';
+  kind: 'preview-haptics-diff' | 'preview-haptics-refetch' | 'preview-frame-focus';
   fromRevision?: number;
   toRevision?: number;
   diff?: HapticsDiff;
+  // Set only on 'preview-frame-focus': the top-level frame the preview should
+  // present (the designer focused it in Figma), plus its name for the indicator.
+  nodeId?: string;
+  frameName?: string;
 }
 
 // Listen for host-relayed config updates. Pass stable handlers (useMemo/
 // useCallback) so the listener doesn't re-bind every render. `onDiff` applies an
-// incremental delta; `onRefetch` re-pulls the whole config from the server.
+// incremental delta; `onRefetch` re-pulls the whole config from the server;
+// `onFocusFrame` jumps the embed to the frame the designer focused (app-only -
+// the host only injects this when running inside PulsarApp's WebView).
 export function useHostUpdates(handlers: {
   onDiff: (fromRevision: number, toRevision: number, diff: HapticsDiff) => void;
   onRefetch: (toRevision: number) => void;
+  onFocusFrame: (nodeId: string, frameName?: string) => void;
 }) {
   useEffect(() => {
     const listener = (event: MessageEvent) => {
@@ -32,6 +39,8 @@ export function useHostUpdates(handlers: {
         handlers.onDiff(data.fromRevision, data.toRevision, data.diff);
       } else if (data.kind === 'preview-haptics-refetch' && typeof data.toRevision === 'number') {
         handlers.onRefetch(data.toRevision);
+      } else if (data.kind === 'preview-frame-focus' && typeof data.nodeId === 'string') {
+        handlers.onFocusFrame(data.nodeId, data.frameName);
       }
     };
     window.addEventListener('message', listener);

--- a/figma/preview/src/styles.css
+++ b/figma/preview/src/styles.css
@@ -219,6 +219,52 @@ body {
 }
 .nav-toggle:active { box-shadow: none; transform: translate(-3px, 3px); }
 
+/* In-app "current screen" indicator: a small centred pill naming the frame on
+   view. Sits below the notch. Tappable to collapse to an icon-only dot so it can
+   be tucked away when the viewer doesn't need it. */
+.frame-indicator {
+  position: fixed;
+  top: calc(8px + env(safe-area-inset-top, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  max-width: 70vw;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 26, 114, 0.82); /* --color-primary, translucent */
+  color: #fff;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 26, 114, 0.25);
+  -webkit-tap-highlight-color: transparent;
+  transition: padding 120ms ease, transform 120ms ease;
+}
+.frame-indicator:active {
+  transform: translateX(-50%) scale(0.94);
+}
+/* Collapsed: icon-only circle. */
+.frame-indicator.collapsed {
+  gap: 0;
+  padding: 6px;
+}
+.frame-indicator svg {
+  display: block;
+  flex: 0 0 auto;
+}
+.frame-indicator-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* On-canvas highlight overlay --------------------------------------------- */
 .overlay { position: absolute; inset: 0; pointer-events: none; z-index: 5; }
 .hl {

--- a/figma/src/main/code.ts
+++ b/figma/src/main/code.ts
@@ -484,6 +484,27 @@ function pushSelection() {
   postToUi({ type: 'selection', node: describeSelection() });
 }
 
+// The top-level frame the live preview should currently present. Tracked so we
+// only relay a focus change to the paired phone when it actually moves to a new
+// frame - selection and edits are both chatty, but the frame rarely changes.
+let lastFocusFrameId: string | null = null;
+
+// Resolve and relay the frame the designer is working in, so a paired phone's
+// live preview can follow along. Priority: the current selection's top-level
+// frame, then an optional hint node (e.g. the node a documentchange touched, for
+// edits that don't move the selection). No-op when neither yields a frame or
+// when the frame hasn't changed since the last relay. Only the phone reacts to
+// this (the web preview is driven by explicit preset taps instead).
+function pushFrameFocus(hint?: BaseNode | null) {
+  let frame: SceneNode | null = null;
+  const sel = figma.currentPage.selection[0];
+  if (sel) frame = topLevelFrameAncestor(sel);
+  if (!frame && hint && !hint.removed) frame = topLevelFrameAncestor(hint);
+  if (!frame || frame.id === lastFocusFrameId) return;
+  lastFocusFrameId = frame.id;
+  postToUi({ type: 'frame-focus', nodeId: frame.id, frameName: frame.name });
+}
+
 function bindToSelection(binding: BindingMeta) {
   const sel = figma.currentPage.selection;
   if (sel.length !== 1) {
@@ -554,7 +575,17 @@ function unbindSelection() {
 // before actually pushing. Covers binding/unbinding (setPluginData fires here)
 // as well as moves/resizes that shift bound-node boxes.
 let docChangedPending = false;
-function onDocumentChange() {
+function onDocumentChange(event: DocumentChangeEvent) {
+  // Follow an edit into a new frame even when the selection doesn't move (e.g.
+  // a binding set programmatically). Read the first changed, still-present node
+  // as a hint; pushFrameFocus prefers the live selection and dedupes by frame.
+  for (const change of event.documentChanges) {
+    const node = 'node' in change ? (change.node as BaseNode | undefined) : undefined;
+    if (node && !node.removed) {
+      pushFrameFocus(node);
+      break;
+    }
+  }
   if (docChangedPending) return;
   docChangedPending = true;
   setTimeout(() => {
@@ -572,6 +603,9 @@ figma
 
 figma.on('selectionchange', () => {
   pushSelection();
+  // Relay the focused frame so a paired phone's live preview follows the
+  // designer's current screen (deduped to actual frame changes inside).
+  pushFrameFocus();
 
   // Edit-mode "click to play": when the user single-clicks a bound node, we forward
   // a play event to the UI which plays via WebAudio. (No native click event in

--- a/figma/src/shared/types.ts
+++ b/figma/src/shared/types.ts
@@ -180,6 +180,10 @@ export type MainToUi =
       onboardingSeen: boolean;
     }
   | { type: 'selection'; node: SelectionInfo | null }
+  // The designer focused (selected or edited a node inside) a top-level frame.
+  // The UI relays this to a paired phone so its live preview follows along and
+  // presents that frame. Only emitted when the focused frame actually changes.
+  | { type: 'frame-focus'; nodeId: string; frameName: string }
   | { type: 'play-preset'; presetId: string } // emitted when a bound node is clicked in editor
   | { type: 'bound-list'; items: BoundItem[] }
   // Reply to `get-project`: this file's persisted token + last cached config

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -210,6 +210,26 @@ export default function App() {
     return off;
   }, [settings.soundInEdit, hapticsToken, phoneConnected, presetById]);
 
+  // Relay the designer's focused frame to the paired phone so its live preview
+  // presents the same screen. Same gating as "play on phone" - only broadcast
+  // into a live channel. Rebinds so it reads the fresh token + connection state.
+  // The web preview deliberately doesn't get this (it's a phone-only channel);
+  // it navigates on explicit preset taps instead.
+  useEffect(() => {
+    const off = onMessage((m) => {
+      if (m.type !== 'frame-focus') return;
+      if (hapticsToken && phoneConnected) {
+        broadcastPreviewUpdate(hapticsToken, {
+          kind: 'preview-frame-focus',
+          previewToken: previewSync.previewToken ?? undefined,
+          nodeId: m.nodeId,
+          frameName: m.frameName
+        });
+      }
+    });
+    return off;
+  }, [hapticsToken, phoneConnected, previewSync.previewToken]);
+
   const filtered = useMemo(() => {
     const base = applyFilter(allPresets, filter);
     return favouritesOnly ? base.filter((e) => favourites.has(e.id)) : base;

--- a/figma/src/ui/lib/diffPayload.ts
+++ b/figma/src/ui/lib/diffPayload.ts
@@ -52,6 +52,18 @@ export type PreviewUpdateMessage =
       kind: 'preview-haptics-refetch';
       previewToken?: string;
       toRevision: number;
+    }
+  // The designer focused a different top-level frame; the paired phone's live
+  // preview should present `nodeId`. Carries no revision - it doesn't change the
+  // haptics config, only which frame the embed shows.
+  | {
+      kind: 'preview-frame-focus';
+      previewToken?: string;
+      nodeId: string;
+      // Human-readable name of the focused frame, shown as the app's "current
+      // screen" indicator. Carried here so binding-less frames (absent from the
+      // payload's `frames` map) still get a label.
+      frameName?: string;
     };
 
 // Diff two record maps by stable value-equality. Returns `{ set, del }` or


### PR DESCRIPTION
## What & why

The Figma live preview previously always showed a single frame, even when a design has many screens. This makes the preview **frame-aware** on both surfaces.

### App (PulsarApp) — follows the designer's focus
The paired phone's live preview now presents whichever frame the designer is working in. When the designer selects a frame — or edits a component inside another frame — the plugin computes the focused top-level frame and relays it over the **existing paired socket**. No server change: the `/broadcast` relay is a transparent JSON channel, so this is just a new `preview-frame-focus` message kind alongside the existing haptics diff/refetch.

A small **collapsible "current screen" indicator** names the frame on view, so the viewer isn't disoriented when the app auto-switches. It's app-only and hidden in true-fullscreen (nav bar toggled off).

### Web preview (developers) — tap a preset to open its screen
Tapping a preset in the **Haptic elements** list now opens the screen that contains it. The web preview deliberately does **not** react to focus changes — focus is a phone-only socket channel; only the app reacts. (Tapping a preset, web-only, navigates locally.)

## How frame switching works

The Figma Embed API's inbound `NAVIGATE_TO_FRAME` message is **documented but a no-op in practice** — verified against a live embed (even Figma's own example forward button doesn't move via postMessage). So a frame is selected via the embed iframe's `node-id`.

To avoid reloading on every switch, `PrototypeView` keeps a small **keep-alive iframe cache** (LRU, max 5):
- First visit to a frame loads its iframe; **revisits just un-hide the cached one (instant)**.
- The cache **never reparents** an iframe (DOM reparent = reload) — append-only with stable synthetic keys.
- In-prototype navigation (a hotspot tap) **re-labels** the active slot so the cache stays accurate; `PRESENTED_NODE_CHANGED` is handled inside `PrototypeView`, attributed to the active iframe by `event.source` (a late event from a hidden, still-loading cached iframe can't hijack the view).

## Data flow (no server change)
`code.ts` (focus) → plugin `App.tsx` broadcast → `/broadcast` relay → phone `ConnectionsContext` → `figma.tsx` WebView injection → preview `useHostUpdates` → `PrototypeView`.

## Files
- **Plugin:** `code.ts` (focus detection), `shared/types.ts`, `ui/App.tsx`, `ui/lib/diffPayload.ts` (relay vocabulary).
- **Preview:** `App.tsx`, `PrototypeView.tsx` (cache), `HapticList.tsx` (preset→frame), `lib/embed.ts`, `lib/useHostUpdates.ts`, `styles.css` (indicator).
- **PulsarApp:** `figma.tsx`, `ConnectionsContext.tsx` (relay the focus message through).
- **Docs:** `figma/AGENT_CONTEXT.md` — relay kinds, embed gotchas, the cache invariants.

## Reviewer notes
- **Plugin must be rebuilt + reimported in Figma** (`code.ts` changed).
- Verified: typecheck + build across plugin, preview, and the edited PulsarApp files; a model test of the cache reconciliation invariants (revisit reuse, no reordering, LRU eviction, relabel-on-internal-nav); and a browser render of the indicator (expanded + collapsed). Full E2E (live token + paired phone) wasn't run in this environment.
- **Firefox caveat:** `display:none` reloads an iframe on re-show there, so the cache speed-up doesn't apply (still functional). The primary target — the app WebView — is WebKit/Chromium, where it's fully fast.