### PR TITLE
perf(figma): zustand + memoized leaf components for hot lists

### DIFF
--- a/figma/package-lock.json
+++ b/figma/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@figma/plugin-typings": "^1.108.0",
@@ -1216,7 +1217,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qrcode": {
@@ -1233,7 +1234,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1484,7 +1485,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2397,6 +2398,35 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/figma/package.json
+++ b/figma/package.json
@@ -10,9 +10,9 @@
   },
   "devDependencies": {
     "@figma/plugin-typings": "^1.108.0",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@types/qrcode": "^1.5.5",
     "@vitejs/plugin-react": "^4.3.4",
     "concurrently": "^9.1.0",
     "typescript": "^5.6.3",
@@ -22,6 +22,7 @@
   "dependencies": {
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.14"
   }
 }

--- a/figma/preview/package-lock.json
+++ b/figma/preview/package-lock.json
@@ -11,7 +11,8 @@
         "pulsar-haptics": "file:../../web/Pulsar",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@types/qrcode": "^1.5.6",
@@ -1229,7 +1230,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qrcode": {
@@ -1246,7 +1247,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1438,7 +1439,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2224,6 +2225,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/figma/preview/package.json
+++ b/figma/preview/package.json
@@ -15,7 +15,8 @@
     "pulsar-haptics": "file:../../web/Pulsar",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.6",

--- a/figma/preview/src/App.tsx
+++ b/figma/preview/src/App.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { FrameInfo, NodeBox, PresetData, PreviewPayload } from './types';
-import { getTokenFromUrl, readPayload } from './lib/payload';
+import { readPayload } from './lib/payload';
 import { normalizeId } from './lib/ids';
 import { applyDiff, type HapticsDiff } from './lib/applyDiff';
 import { useHostUpdates } from './lib/useHostUpdates';
@@ -8,7 +8,9 @@ import { useFigmaMessages } from './lib/useFigmaMessages';
 import { useFullscreen } from './lib/useFullscreen';
 import { useIsMobile } from './lib/useIsMobile';
 import { getHostBridge, isAppHost as detectAppHost } from './lib/hostBridge';
+import { getTokenFromUrl } from './lib/payload';
 import { playPreset, stopAll } from './audio/player';
+import { usePreviewStore } from './store';
 import { Header } from './components/Header';
 import { PrototypeView } from './components/PrototypeView';
 import { HapticList } from './components/HapticList';
@@ -17,7 +19,6 @@ import { PresetDetailsModal } from './components/PresetDetailsModal';
 import fullscreenExitIcon from './assets/icon-fullscreen-exit.svg';
 import fullscreenIcon from './assets/icon-fullscreen.svg';
 
-const ACTIVE_MS = 900;
 const TAP_DEBOUNCE_MS = 250;
 // Reads to ride out read-after-write lag when a minimum revision is required.
 const REFETCH_ATTEMPTS = 4;
@@ -33,31 +34,37 @@ function boxCenterInside(inner: NodeBox, outer: NodeBox): boolean {
 }
 
 export default function App() {
-  // Payload now arrives asynchronously (token → server fetch). Hold null while
-  // the request is in flight; the empty-state UI handles both "no payload yet"
-  // and "no payload at all".
-  const [payload, setPayload] = useState<PreviewPayload | null>(null);
-  const [payloadLoaded, setPayloadLoaded] = useState(false);
-  // Set when the server reports the share link was made private (403). Drives a
-  // dedicated empty state distinct from "no design loaded".
-  const [isPrivate, setIsPrivate] = useState(false);
-  // The server revision our current `payload` reflects, and a mirror of the
-  // payload itself - both in refs so the (stable) host-update handlers below can
-  // read the latest values without re-binding the window message listener.
-  const revisionRef = useRef(0);
-  const payloadRef = useRef<PreviewPayload | null>(null);
-  useEffect(() => {
-    payloadRef.current = payload;
-  }, [payload]);
+  // App subscribes to the *config* slice (payload) + the current frame - the
+  // things it derives lookup maps from. It deliberately does NOT read activeId /
+  // detailsId / highlightsOn / nav toggles: those are consumed by store-connected
+  // leaf components below, so a hover or a toggle never re-renders App or the
+  // iframe host. (Contrast the old version, where all of that lived in App's
+  // useState and every change re-rendered the whole tree.)
+  const payload = usePreviewStore((s) => s.payload);
+  const isPrivate = usePreviewStore((s) => s.isPrivate);
+  const payloadLoaded = usePreviewStore((s) => s.payloadLoaded);
+  const currentNodeId = usePreviewStore((s) => s.currentNodeId);
+  const status = usePreviewStore((s) => s.status);
+  const loaded = usePreviewStore((s) => s.loaded);
+  // Store actions are stable references, so passing them to memoized children
+  // never breaks memoization.
+  const navigateToFrame = usePreviewStore((s) => s.navigateToFrame);
+  const setDetailsId = usePreviewStore((s) => s.setDetailsId);
 
+  // Initial payload load. Writes straight into the store; no payload/revision
+  // refs to keep in sync anymore - handlers below read getState() when they need
+  // the latest value.
   useEffect(() => {
     let cancelled = false;
     readPayload().then((res) => {
       if (cancelled) return;
-      if (res.status === 'ok') revisionRef.current = res.revision;
-      setPayload(res.status === 'ok' ? res.payload : null);
-      setIsPrivate(res.status === 'private');
-      setPayloadLoaded(true);
+      const st = usePreviewStore.getState();
+      if (res.status === 'ok') {
+        st.setConfig({ payload: res.payload, revision: res.revision, isPrivate: false });
+      } else {
+        st.setConfig({ payload: null, isPrivate: res.status === 'private' });
+      }
+      st.setPayloadLoaded(true);
     });
     return () => {
       cancelled = true;
@@ -66,10 +73,9 @@ export default function App() {
 
   // Re-pull the whole config from the server in place (no iframe reload). When a
   // minimum revision is known, retry briefly to ride out read-after-write lag so
-  // we never settle on a snapshot older than the change that triggered us.
+  // we never settle on a snapshot older than the change that triggered us. Stable
+  // (no state deps) because it reads/writes the store directly.
   const refetch = useCallback(async (minRevision?: number) => {
-    // Up to REFETCH_ATTEMPTS reads; the last one is accepted even if the server
-    // is still behind minRevision (better a slightly stale snapshot than none).
     for (let attempt = 0; attempt < REFETCH_ATTEMPTS; attempt++) {
       const res = await readPayload();
       if (res.status === 'ok') {
@@ -78,18 +84,15 @@ export default function App() {
           await new Promise((r) => setTimeout(r, 250));
           continue;
         }
-        revisionRef.current = res.revision;
-        payloadRef.current = res.payload;
-        setPayload(res.payload);
-        setIsPrivate(false);
-        setPayloadLoaded(true);
+        const st = usePreviewStore.getState();
+        st.setConfig({ payload: res.payload, revision: res.revision, isPrivate: false });
+        st.setPayloadLoaded(true);
         return;
       }
       if (res.status === 'private') {
-        payloadRef.current = null;
-        setPayload(null);
-        setIsPrivate(true);
-        setPayloadLoaded(true);
+        const st = usePreviewStore.getState();
+        st.setConfig({ payload: null, isPrivate: true });
+        st.setPayloadLoaded(true);
       }
       // 'missing' / 'no-token': leave the current state as-is and stop retrying.
       return;
@@ -97,23 +100,22 @@ export default function App() {
   }, []);
 
   // Apply a relayed delta in place when our revision is exactly the one the diff
-  // was computed against; otherwise we've missed an update (a gap) - refetch.
+  // was computed against; otherwise we've missed an update (a gap) - refetch. No
+  // refs: getState() gives us the freshest payload/revision at call time.
   const onDiff = useCallback(
     (fromRevision: number, toRevision: number, diff: HapticsDiff) => {
-      if (!payloadRef.current || revisionRef.current !== fromRevision) {
+      const { payload: cur, revision } = usePreviewStore.getState();
+      if (!cur || revision !== fromRevision) {
         void refetch(toRevision);
         return;
       }
-      const next = applyDiff(payloadRef.current, diff);
-      payloadRef.current = next;
-      revisionRef.current = toRevision;
-      setPayload(next);
+      usePreviewStore.getState().setConfig({ payload: applyDiff(cur, diff), revision: toRevision });
     },
     [refetch]
   );
   const onRefetch = useCallback((toRevision: number) => void refetch(toRevision), [refetch]);
 
-  // Derived lookup maps (stable across renders).
+  // Derived lookup maps (stable across renders, recomputed only when payload changes).
   const { bindings, ownerMap, presentedId, frames } = useMemo(() => {
     const binds = new Map<string, PresetData>();
     const owner = new Map<string, string>();
@@ -152,15 +154,13 @@ export default function App() {
     [payload]
   );
 
-  const [status, setStatus] = useState('Waiting for a design - open one from the Pulsar plugin.');
   // Once we know the payload state, refresh the status accordingly. Done in an
   // effect so the user briefly sees "loading" while the token fetch is in
   // flight rather than a flash of the empty state.
   useEffect(() => {
+    const setStatus = usePreviewStore.getState().setStatus;
     if (!payloadLoaded) {
-      if (new URLSearchParams(location.search).has('token')) {
-        setStatus('Loading preview…');
-      }
+      if (new URLSearchParams(location.search).has('token')) setStatus('Loading preview…');
       return;
     }
     if (isPrivate) {
@@ -173,108 +173,32 @@ export default function App() {
         : 'Waiting for a design - open one from the Pulsar plugin.'
     );
   }, [payloadLoaded, payload, isPrivate]);
-  // The frame currently presented. Drives both which embed iframe is shown
-  // (PrototypeView keeps a keep-alive cache keyed off this) and the overlay
-  // grouping. Moved by a deliberate jump - the designer focusing a frame
-  // (relayed from the app) or a preset tap in the list - and by in-prototype
-  // navigation (a hotspot tap), which PrototypeView reports via
-  // onPresentedNodeChange. Switching frames doesn't reload an already-visited
-  // one; the Embed API's inbound NAVIGATE_TO_FRAME message is a no-op in
-  // practice (verified against a live embed), so each frame is its own iframe
-  // and revisits just un-hide the cached one.
-  const [currentNodeId, setCurrentNodeId] = useState(presentedId);
-  // Sync when the payload arrives later (async token fetch). The useState
-  // initializer above only runs once with whatever presentedId was on first
-  // render, which is the empty string before the fetch resolves.
+
+  // Sync the presented frame when the payload arrives later (async token fetch).
   useEffect(() => {
-    setCurrentNodeId(presentedId);
+    usePreviewStore.getState().setCurrentNodeId(presentedId);
   }, [presentedId]);
 
-  // Names for frames the app relayed a focus to. The payload's `frames` map only
-  // covers frames that have bindings, so a designer focusing a binding-less frame
-  // arrives with no name there - we keep the relayed name to label the indicator.
-  const [relayedFrameNames, setRelayedFrameNames] = useState<Record<string, string>>({});
-
-  // Jump to a specific top-level frame (designer focus relay / preset tap).
-  // Idempotent - re-selecting the current frame is a no-op. `frameName` is only
-  // passed by the focus relay; preset taps resolve the name from the frames map.
-  const navigateToFrame = useCallback((frameId: string, frameName?: string) => {
-    const norm = normalizeId(frameId);
-    if (!norm) return;
-    setCurrentNodeId(norm);
-    if (frameName) {
-      setRelayedFrameNames((prev) => (prev[norm] === frameName ? prev : { ...prev, [norm]: frameName }));
-    }
-  }, []);
-
-  // Host-relayed updates, only injected when running inside PulsarApp's WebView:
-  // incremental config diffs, full refetches, and designer-focus frame jumps.
+  // Host-relayed updates, only injected when running inside PulsarApp's WebView.
+  // Every handler is stable now (no state deps), so this listener binds once.
   const hostHandlers = useMemo(
     () => ({ onDiff, onRefetch, onFocusFrame: navigateToFrame }),
     [onDiff, onRefetch, navigateToFrame]
   );
   useHostUpdates(hostHandlers);
-  const [highlightsOn, setHighlightsOn] = useState(true);
-  const [activeId, setActiveId] = useState('');
-  const [detailsId, setDetailsId] = useState<string>('');
-  const [loaded, setLoaded] = useState(false);
 
-  const activeTimer = useRef<number | undefined>(undefined);
   const lastPlayed = useRef(new Map<string, number>());
 
-  const setActiveTransient = useCallback((id: string) => {
-    setActiveId(id);
-    if (activeTimer.current) clearTimeout(activeTimer.current);
-    activeTimer.current = window.setTimeout(() => setActiveId(''), ACTIVE_MS);
-  }, []);
-
-  // When the preview is loaded inside the PulsarApp WebView the
-  // `window.ReactNativeWebView` bridge is injected by react-native-webview.
-  // That single check is authoritative: if it's present we postMessage the
-  // preset payload to the native host (which plays the real device haptic via
-  // react-native-pulsar); if it isn't, we fall back to the in-page audio
-  // generator. We always send the full pattern so the host can fall back to
-  // PatternComposer for custom (user-defined) presets whose names don't match
-  // anything in react-native-pulsar.Presets. (We used to also gate on a
-  // `?host=app` URL param, but that's redundant with the bridge check and
-  // broke whenever someone hardcoded the preview URL in PulsarApp for local
-  // dev.)
-  //
-  // The bridge may live on `window` (preview served directly) or on
-  // `window.parent` (the docs /figma-preview page embeds us in an <iframe
-  // srcdoc>); getHostBridge/detectAppHost resolve either - see lib/hostBridge.
+  // See the long note in the original: the bridge check is authoritative for
+  // "are we inside the app?"; when present we postMessage the pattern to native,
+  // otherwise we fall back to the in-page audio generator.
   const isAppHost = useMemo(() => detectAppHost(), []);
 
-  // Deep link that opens this same preview in the Pulsar mobile app, carrying
-  // the current share token. Rendered as a QR in the sidebar so a desktop user
-  // can hop to their phone; pointless when we're already running inside the app.
   const openOnPhoneLink = useMemo(() => {
     if (isAppHost) return null;
     const token = getTokenFromUrl();
     return token ? `pulsarapp://figma?token=${encodeURIComponent(token)}` : null;
   }, [isAppHost]);
-
-  // When running inside the PulsarApp WebView the preview already fills the
-  // WebView (mobile → implicit fullscreen), but the app's bottom tab bar still
-  // covers the lower strip. This toggle asks the native host to hide/show that
-  // tab bar so the prototype can run edge-to-edge. No-op outside the app host.
-  const [navBarHidden, setNavBarHidden] = useState(false);
-  // Whether the in-app "current screen" indicator is collapsed to an icon-only
-  // dot. The viewer can tuck it away when they don't need the screen name.
-  const [indicatorCollapsed, setIndicatorCollapsed] = useState(false);
-  const toggleNavBar = useCallback(() => {
-    setNavBarHidden((prev) => {
-      const next = !prev;
-      try {
-        getHostBridge()?.postMessage(
-          JSON.stringify({ type: 'set-tab-bar-hidden', hidden: next })
-        );
-      } catch {
-        // No bridge - nothing to toggle.
-      }
-      return next;
-    });
-  }, []);
 
   const play = useCallback(
     (id: string) => {
@@ -288,9 +212,6 @@ export default function App() {
             JSON.stringify({
               type: 'play-preset',
               presetName: data.name,
-              // PresetData's discrete/continuous shape is structurally identical
-              // to react-native-pulsar's Pattern type - see
-              // react-native/react-native-pulsar/src/types.ts.
               pattern: {
                 discretePattern: data.discretePattern,
                 continuousPattern: data.continuousPattern
@@ -298,7 +219,6 @@ export default function App() {
             })
           );
         } catch {
-          // If the bridge isn't there for some reason, fall through to audio.
           stopAll();
           playPreset(data).catch(() => {});
         }
@@ -310,24 +230,24 @@ export default function App() {
     [bindings, isAppHost]
   );
 
+  // Play a preset from the list and flash its highlight. Stable-ish (changes only
+  // when the binding set changes), so memoized rows don't churn on it.
   const playFromList = useCallback(
     (id: string) => {
       play(id);
-      setActiveTransient(id);
+      usePreviewStore.getState().setActiveTransient(id);
     },
-    [play, setActiveTransient]
+    [play]
   );
 
   const handlers = useMemo(
     () => ({
       onInitialLoad: () => {
-        setStatus('Tap a highlighted element to feel its haptic.');
-        setLoaded(true);
+        const st = usePreviewStore.getState();
+        st.setStatus('Tap a highlighted element to feel its haptic.');
+        st.setLoaded(true);
       },
-      // PRESENTED_NODE_CHANGED is handled inside PrototypeView instead, where it
-      // can be attributed to the active iframe (the keep-alive cache mounts
-      // several) and re-label its cache slot.
-      onLoginScreen: () => setStatus('This file requires Figma login to embed.'),
+      onLoginScreen: () => usePreviewStore.getState().setStatus('This file requires Figma login to embed.'),
       onMousePressOrRelease: (targetNodeId: string) => {
         const norm = normalizeId(targetNodeId);
         if (!norm || !bindings.has(norm)) return;
@@ -336,20 +256,18 @@ export default function App() {
         lastPlayed.current.set(norm, now);
         const ownerId = ownerMap.get(norm) ?? norm;
         play(ownerId);
-        setActiveTransient(ownerId);
+        usePreviewStore.getState().setActiveTransient(ownerId);
       }
     }),
-    [bindings, ownerMap, play, setActiveTransient]
+    [bindings, ownerMap, play]
   );
   useFigmaMessages(handlers);
 
   const { isFullscreen, enter: enterFullscreen, exit: exitFullscreen } = useFullscreen();
   const isMobile = useIsMobile();
-  // On mobile we always run fullscreen (content fills the screen, no chrome).
   const fullscreen = isFullscreen || isMobile;
 
-  // The owner revoked this share link. Don't leak that a design ever existed -
-  // just explain the link is private and how to regain access.
+  // The owner revoked this share link. Don't leak that a design ever existed.
   if (isPrivate) {
     return (
       <>
@@ -387,39 +305,18 @@ export default function App() {
     );
   }
 
-  // Pick the frame + element subset that match what Figma is currently showing.
-  // When the user taps a button whose prototype interaction navigates to another
-  // frame, Figma fires PRESENTED_NODE_CHANGED and `currentNodeId` shifts. We use
-  // the per-frame box map the plugin sends to keep the overlay aligned on the
-  // new frame instead of hiding every highlight. Backward-compat: payloads
-  // created before the `frames` field exists fall through to the original
-  // present-frame box.
+  // Pick the frame + element subset that match what Figma is currently showing
+  // (see the long note in the original for the containment fallback).
   const hasFrameMap = frames.size > 0;
   const currentFrame: NodeBox | null =
     (hasFrameMap ? frames.get(currentNodeId)?.box ?? null : null) ??
     (currentNodeId === presentedId ? payload.frame : null);
-  // Filter elements to those that belong to the currently-presented frame.
-  // Prefer the explicit `frameId` when present (new payloads); for older
-  // payloads - and for any element the plugin didn't tag - fall back to a
-  // canvas-coordinate containment check against the current frame's box. This
-  // matters because the plugin collects bound nodes from the whole page, not
-  // just the present frame, so without filtering we'd paint highlights for
-  // off-frame elements over the wrong screen area of the iframe.
   const visibleElements = currentFrame
     ? elements.filter((e) => {
         if (e.frameId) return e.frameId === currentNodeId;
         return e.box ? boxCenterInside(e.box, currentFrame) : false;
       })
     : [];
-  // In fullscreen we show only the Figma content - no header, panel, highlights,
-  // or card chrome.
-  const showHighlights =
-    highlightsOn && !fullscreen && currentFrame !== null && visibleElements.length > 0;
-
-  // Name of the frame on screen, for the in-app "current screen" indicator.
-  // Prefer the payload's frames map (frames with bindings); fall back to the name
-  // the app relayed with a focus (covers binding-less frames the designer focused).
-  const currentFrameName = frames.get(currentNodeId)?.name ?? relayedFrameNames[currentNodeId] ?? '';
 
   return (
     <>
@@ -432,22 +329,16 @@ export default function App() {
           nodeId={currentNodeId}
           frame={currentFrame}
           elements={visibleElements}
-          showHighlights={showHighlights}
-          activeId={activeId}
           fullscreen={fullscreen}
           deviceFrame={!isMobile}
           loaded={loaded}
-          onPresentedNodeChange={(id) => setCurrentNodeId(normalizeId(id))}
+          onPresentedNodeChange={(id) => usePreviewStore.getState().setCurrentNodeId(normalizeId(id))}
         />
         {!fullscreen && (
           <HapticList
             elements={elements}
             frames={frames}
             currentFrameId={currentNodeId}
-            highlightsOn={highlightsOn}
-            onToggleHighlights={setHighlightsOn}
-            activeId={activeId}
-            onActivate={setActiveId}
             onPlay={playFromList}
             onOpenFrame={navigateToFrame}
             onShowDetails={setDetailsId}
@@ -457,47 +348,9 @@ export default function App() {
         )}
       </main>
 
-      {/* In-app only: a small badge naming the screen on view. The app
-          auto-switches frames as the designer focuses them, so without this the
-          viewer can lose track of which screen they're feeling. Tap to collapse
-          it to an icon-only dot. Hidden in true-fullscreen (nav bar toggled off)
-          to keep that view uncluttered. */}
-      {isAppHost && currentFrameName && !navBarHidden && (
-        <button
-          type="button"
-          className={`frame-indicator${indicatorCollapsed ? ' collapsed' : ''}`}
-          onClick={() => setIndicatorCollapsed((c) => !c)}
-          aria-expanded={!indicatorCollapsed}
-          aria-label={indicatorCollapsed ? `Current screen: ${currentFrameName}` : 'Hide screen name'}
-          title={indicatorCollapsed ? currentFrameName : 'Hide screen name'}
-        >
-          {/* Screen/frame glyph - the persistent affordance when collapsed. */}
-          <svg
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="3" y="4" width="18" height="16" rx="2" />
-            <path d="M3 9h18" />
-          </svg>
-          {!indicatorCollapsed && <span className="frame-indicator-name">{currentFrameName}</span>}
-        </button>
-      )}
+      {isAppHost && <FrameIndicator frames={frames} />}
 
-      {detailsId && bindings.get(detailsId) && (
-        <PresetDetailsModal
-          data={bindings.get(detailsId)!}
-          elementName={elements.find((e) => e.id === detailsId)?.name}
-          isCustom={elements.find((e) => e.id === detailsId)?.isCustom}
-          onClose={() => setDetailsId('')}
-        />
-      )}
+      <DetailsModalHost bindings={bindings} elements={elements} />
 
       {/* Manual fullscreen on desktop can be exited; mobile fullscreen is implicit. */}
       {isFullscreen && !isMobile && (
@@ -506,23 +359,94 @@ export default function App() {
         </button>
       )}
 
-      {/* In-app only: hide/show the native bottom tab bar for a true full-screen
-          prototype. Lives at the bottom corner, above where the tab bar sits. */}
-      {isAppHost && (
-        <button
-          className="nav-toggle"
-          onClick={toggleNavBar}
-          title={navBarHidden ? 'Show navigation bar' : 'Hide navigation bar'}
-          aria-pressed={navBarHidden}
-        >
-          <img
-            src={navBarHidden ? fullscreenExitIcon : fullscreenIcon}
-            alt={navBarHidden ? 'Show navigation bar' : 'Hide navigation bar'}
-            width={16}
-            height={16}
-          />
-        </button>
-      )}
+      {isAppHost && <NavToggle />}
     </>
+  );
+}
+
+// --- Store-connected leaf hosts ------------------------------------------------
+// Each subscribes to just its own slice of view state, so the high-frequency
+// interactions they own (opening details, collapsing the indicator, toggling the
+// nav bar) never re-render App or the iframe host.
+
+// The preset-details modal. Subscribes to detailsId; App passes the (payload-
+// derived) lookups. Renders nothing until a row's ⋯ is tapped.
+function DetailsModalHost({
+  bindings,
+  elements
+}: {
+  bindings: Map<string, PresetData>;
+  elements: { id: string; name: string; isCustom?: boolean }[];
+}) {
+  const detailsId = usePreviewStore((s) => s.detailsId);
+  const setDetailsId = usePreviewStore((s) => s.setDetailsId);
+  const data = detailsId ? bindings.get(detailsId) : undefined;
+  if (!data) return null;
+  return (
+    <PresetDetailsModal
+      data={data}
+      elementName={elements.find((e) => e.id === detailsId)?.name}
+      isCustom={elements.find((e) => e.id === detailsId)?.isCustom}
+      onClose={() => setDetailsId('')}
+    />
+  );
+}
+
+// In-app "current screen" badge. Subscribes to the frame + indicator slices so it
+// updates on navigation / collapse without touching the rest of the tree.
+function FrameIndicator({ frames }: { frames: Map<string, FrameInfo> }) {
+  const currentNodeId = usePreviewStore((s) => s.currentNodeId);
+  const relayedName = usePreviewStore((s) => s.relayedFrameNames[currentNodeId]);
+  const navBarHidden = usePreviewStore((s) => s.navBarHidden);
+  const collapsed = usePreviewStore((s) => s.indicatorCollapsed);
+  const toggleIndicator = usePreviewStore((s) => s.toggleIndicator);
+  const name = frames.get(currentNodeId)?.name ?? relayedName ?? '';
+  if (!name || navBarHidden) return null;
+  return (
+    <button
+      type="button"
+      className={`frame-indicator${collapsed ? ' collapsed' : ''}`}
+      onClick={toggleIndicator}
+      aria-expanded={!collapsed}
+      aria-label={collapsed ? `Current screen: ${name}` : 'Hide screen name'}
+      title={collapsed ? name : 'Hide screen name'}
+    >
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M3 9h18" />
+      </svg>
+      {!collapsed && <span className="frame-indicator-name">{name}</span>}
+    </button>
+  );
+}
+
+// In-app hide/show the native bottom tab bar for a true full-screen prototype.
+function NavToggle() {
+  const navBarHidden = usePreviewStore((s) => s.navBarHidden);
+  const toggleNavBar = usePreviewStore((s) => s.toggleNavBar);
+  return (
+    <button
+      className="nav-toggle"
+      onClick={toggleNavBar}
+      title={navBarHidden ? 'Show navigation bar' : 'Hide navigation bar'}
+      aria-pressed={navBarHidden}
+    >
+      <img
+        src={navBarHidden ? fullscreenExitIcon : fullscreenIcon}
+        alt={navBarHidden ? 'Show navigation bar' : 'Hide navigation bar'}
+        width={16}
+        height={16}
+      />
+    </button>
   );
 }

--- a/figma/preview/src/components/HapticList.tsx
+++ b/figma/preview/src/components/HapticList.tsx
@@ -1,18 +1,85 @@
-import { useMemo, type ReactNode } from 'react';
+import { memo, useMemo, type ReactNode } from 'react';
 import type { ElementInfo, FrameInfo } from '../types';
+import { usePreviewStore } from '../store';
 
 // Synthetic bucket id for bindings with no owning frame. Not a real Figma
 // node-id, so it can't be opened in the prototype.
 const UNASSIGNED = '__unassigned';
 
+// The "Highlight" checkbox. Subscribes to highlightsOn on its own so toggling it
+// re-renders only this control (and the iframe host that shows/hides the overlay),
+// not the whole list.
+function HighlightToggle() {
+  const highlightsOn = usePreviewStore((s) => s.highlightsOn);
+  const setHighlightsOn = usePreviewStore((s) => s.setHighlightsOn);
+  return (
+    <label className="toggle">
+      <input
+        type="checkbox"
+        checked={highlightsOn}
+        onChange={(e) => setHighlightsOn(e.target.checked)}
+      />
+      Highlight
+    </label>
+  );
+}
+
+// One list row. Memoized + subscribes to whether *this* row is active, so a hover
+// re-renders only the row gaining the highlight (and the one losing it) rather
+// than the whole list + App + iframe host. The callbacks come from App as stable
+// references (store actions / useCallback), so memo holds across activeId churn.
+const HapticRow = memo(function HapticRow({
+  el,
+  onPlay,
+  onOpenFrame,
+  onShowDetails
+}: {
+  el: ElementInfo;
+  onPlay: (id: string) => void;
+  onOpenFrame?: (frameId: string, frameName?: string) => void;
+  onShowDetails: (id: string) => void;
+}) {
+  const active = usePreviewStore((s) => s.activeId === el.id);
+  const setActiveId = usePreviewStore((s) => s.setActiveId);
+  return (
+    <div
+      className={`el-row${active ? ' active' : ''}`}
+      onMouseEnter={() => setActiveId(el.id)}
+      onMouseLeave={() => setActiveId('')}
+      onClick={() => {
+        // Tapping a preset opens the screen it belongs to, then plays its haptic
+        // so the developer can feel it in context.
+        if (el.frameId) onOpenFrame?.(el.frameId);
+        onPlay(el.id);
+      }}
+    >
+      <div className="el-row-inner">
+        <div className="el-row-main">
+          <div className="el-haptic">
+            <span className="el-haptic-name">{el.presetName}</span>
+            {el.isCustom && <span className="tag tag-custom">Custom</span>}
+          </div>
+          <div className="el-name">{el.name}</div>
+        </div>
+        <button
+          className="details-btn"
+          title="Show preset details"
+          onClick={(e) => {
+            e.stopPropagation();
+            onShowDetails(el.id);
+          }}
+        >
+          ⋯
+        </button>
+      </div>
+    </div>
+  );
+});
+
 export function HapticList({
   elements,
   frames,
   currentFrameId,
-  highlightsOn,
-  onToggleHighlights,
-  activeId,
-  onActivate,
   onPlay,
   onOpenFrame,
   onShowDetails,
@@ -22,10 +89,6 @@ export function HapticList({
   elements: ElementInfo[];
   frames: Map<string, FrameInfo>;
   currentFrameId: string;
-  highlightsOn: boolean;
-  onToggleHighlights: (on: boolean) => void;
-  activeId: string;
-  onActivate: (id: string) => void;
   onPlay: (id: string) => void;
   // Open a frame in the prototype (the preview jumps to that screen). Passing the
   // name lets the host label the screen while it loads. Optional so the list can
@@ -84,14 +147,7 @@ export function HapticList({
     <aside className="aside">
       <div className="aside-head">
         <h2>Haptic elements</h2>
-        <label className="toggle">
-          <input
-            type="checkbox"
-            checked={highlightsOn}
-            onChange={(e) => onToggleHighlights(e.target.checked)}
-          />
-          Highlight
-        </label>
+        <HighlightToggle />
       </div>
       <div className="list">
         {elements.length === 0 ? (
@@ -123,38 +179,13 @@ export function HapticList({
                 <span className="screen-count">{group.items.length}</span>
               </div>
               {group.items.map((el) => (
-                <div
+                <HapticRow
                   key={el.id}
-                  className={`el-row${activeId === el.id ? ' active' : ''}`}
-                  onMouseEnter={() => onActivate(el.id)}
-                  onMouseLeave={() => onActivate('')}
-                  onClick={() => {
-                    // Tapping a preset opens the screen it belongs to, then
-                    // plays its haptic so the developer can feel it in context.
-                    if (el.frameId) onOpenFrame?.(el.frameId);
-                    onPlay(el.id);
-                  }}
-                >
-                  <div className="el-row-inner">
-                    <div className="el-row-main">
-                      <div className="el-haptic">
-                        <span className="el-haptic-name">{el.presetName}</span>
-                        {el.isCustom && <span className="tag tag-custom">Custom</span>}
-                      </div>
-                      <div className="el-name">{el.name}</div>
-                    </div>
-                    <button
-                      className="details-btn"
-                      title="Show preset details"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onShowDetails(el.id);
-                      }}
-                    >
-                      ⋯
-                    </button>
-                  </div>
-                </div>
+                  el={el}
+                  onPlay={onPlay}
+                  onOpenFrame={onOpenFrame}
+                  onShowDetails={onShowDetails}
+                />
               ))}
             </div>
           ))

--- a/figma/preview/src/components/HighlightOverlay.tsx
+++ b/figma/preview/src/components/HighlightOverlay.tsx
@@ -1,5 +1,6 @@
-import type { CSSProperties } from 'react';
+import { memo, type CSSProperties } from 'react';
 import type { ElementInfo, NodeBox } from '../types';
+import { usePreviewStore } from '../store';
 
 // The iframe fills the whole stage (100%×100%); Figma renders the frame with
 // scaling=contain, which fits the frame INSIDE the iframe and centers it, but
@@ -42,31 +43,43 @@ function boxStyle(
   };
 }
 
+// One highlight box. Memoized + subscribes to whether *this* element is the
+// active one, so lighting up a highlight on hover re-renders only the box that
+// gains (and the one that loses) the active state - not the whole overlay.
+const HighlightBox = memo(function HighlightBox({
+  id,
+  presetName,
+  style
+}: {
+  id: string;
+  presetName: string;
+  style: CSSProperties;
+}) {
+  const active = usePreviewStore((s) => s.activeId === id);
+  return (
+    <div className={`hl${active ? ' active' : ''}`} style={style}>
+      <span className="hl-label">{presetName}</span>
+    </div>
+  );
+});
+
+// The overlay container no longer subscribes to activeId, so it re-renders only
+// when the frame / elements / size change (navigation, resize) - never on a hover.
 export function HighlightOverlay({
   frame,
   elements,
-  size,
-  activeId
+  size
 }: {
   frame: NodeBox;
   elements: ElementInfo[];
   size: { width: number; height: number };
-  activeId: string;
 }) {
   return (
     <div className="overlay">
       {elements.map((el) => {
         const style = boxStyle(el, frame, size);
         if (!style) return null;
-        return (
-          <div
-            key={el.id}
-            className={`hl${activeId === el.id ? ' active' : ''}`}
-            style={style}
-          >
-            <span className="hl-label">{el.presetName}</span>
-          </div>
-        );
+        return <HighlightBox key={el.id} id={el.id} presetName={el.presetName} style={style} />;
       })}
     </div>
   );

--- a/figma/preview/src/components/PrototypeView.tsx
+++ b/figma/preview/src/components/PrototypeView.tsx
@@ -5,6 +5,7 @@ import { normalizeId } from '../lib/ids';
 import { useElementSize } from '../lib/useElementSize';
 import { HighlightOverlay } from './HighlightOverlay';
 import { PrototypeLoader } from './PrototypeLoader';
+import { usePreviewStore } from '../store';
 
 // How many visited frames to keep mounted (active + recent). Each one is a full
 // Figma embed, so this is a memory/CPU vs. snappiness trade-off - keep it modest
@@ -29,8 +30,6 @@ export function PrototypeView({
   nodeId,
   frame,
   elements,
-  showHighlights,
-  activeId,
   fullscreen = false,
   deviceFrame,
   loaded,
@@ -45,8 +44,6 @@ export function PrototypeView({
   nodeId: string | null;
   frame: NodeBox | null;
   elements: ElementInfo[];
-  showHighlights: boolean;
-  activeId: string;
   fullscreen?: boolean;
   deviceFrame: boolean;
   loaded: boolean;
@@ -58,6 +55,12 @@ export function PrototypeView({
 }) {
   const stageRef = useRef<HTMLDivElement>(null);
   const size = useElementSize(stageRef);
+
+  // `highlightsOn` is the only view-state PrototypeView needs; reading it here
+  // (rather than receiving showHighlights as a prop) means toggling it doesn't
+  // go through App. activeId is not read at all - the individual HighlightBoxes
+  // subscribe to it, so a hover never re-renders this iframe host.
+  const highlightsOn = usePreviewStore((s) => s.highlightsOn);
 
   const activeFrameId = nodeId ?? '';
 
@@ -140,6 +143,9 @@ export function PrototypeView({
     return () => window.removeEventListener('message', onMessage);
   }, []);
 
+  // In fullscreen we show only the Figma content - no overlay/highlights.
+  const showHighlights = highlightsOn && !fullscreen && frame !== null && elements.length > 0;
+
   return (
     <div className={`frame-wrap${fullscreen ? ' fullscreen' : ''}`}>
       <div className="stage" ref={stageRef}>
@@ -160,7 +166,7 @@ export function PrototypeView({
           />
         ))}
         {showHighlights && frame && (
-          <HighlightOverlay frame={frame} elements={elements} size={size} activeId={activeId} />
+          <HighlightOverlay frame={frame} elements={elements} size={size} />
         )}
       </div>
       <PrototypeLoader loaded={loaded} />

--- a/figma/preview/src/store.ts
+++ b/figma/preview/src/store.ts
@@ -1,0 +1,126 @@
+import { create } from 'zustand';
+import type { PreviewPayload } from './types';
+import { normalizeId } from './lib/ids';
+import { getHostBridge } from './lib/hostBridge';
+
+// Single store for the preview app. It holds two kinds of state:
+//
+//   • config  - the server payload + the revision it reflects. Previously this
+//     lived as `payload`/`revision` useState PLUS `payloadRef`/`revisionRef`
+//     mirrors, because the (stable) host-update handlers needed to read the
+//     latest value without re-binding. A store makes that duplication go away:
+//     `usePreviewStore.getState()` is always fresh, so the handlers read it
+//     directly and never need refs or dependency arrays.
+//
+//   • view    - the interaction state (active highlight, current frame, panel
+//     toggles). Keeping it here lets leaf components subscribe to just the slice
+//     they render (e.g. one list row subscribes to `activeId === id`), so a
+//     hover no longer re-renders App, the iframe host, and all 24 rows.
+
+const ACTIVE_MS = 900;
+
+// Transient-highlight timer. Module-level (not a ref) because the store outlives
+// any single component and there is only ever one active highlight.
+let activeTimer: ReturnType<typeof setTimeout> | undefined;
+
+interface PreviewState {
+  // --- config (server payload) ---
+  payload: PreviewPayload | null;
+  revision: number;
+  isPrivate: boolean;
+  payloadLoaded: boolean;
+
+  // --- interaction / view state ---
+  // The top-level frame currently presented (drives which embed iframe shows and
+  // which elements the overlay groups). Moved by a deliberate jump (designer
+  // focus / preset tap) or by in-prototype navigation.
+  currentNodeId: string;
+  // The element whose highlight is lit right now (hover or a transient tap flash).
+  activeId: string;
+  highlightsOn: boolean;
+  // The element whose preset-details modal is open ('' = closed).
+  detailsId: string;
+  navBarHidden: boolean;
+  indicatorCollapsed: boolean;
+  // Names for frames the app relayed a focus to but that aren't in the payload's
+  // frames map (a binding-less frame the designer focused).
+  relayedFrameNames: Record<string, string>;
+  loaded: boolean;
+  status: string;
+
+  // --- actions ---
+  setConfig: (next: { payload: PreviewPayload | null; revision?: number; isPrivate?: boolean }) => void;
+  setPayloadLoaded: (v: boolean) => void;
+  setActiveId: (id: string) => void;
+  // Light the highlight and auto-clear it after ACTIVE_MS (the tap flash).
+  setActiveTransient: (id: string) => void;
+  setHighlightsOn: (on: boolean) => void;
+  setDetailsId: (id: string) => void;
+  setCurrentNodeId: (id: string) => void;
+  // Jump to a specific top-level frame. Idempotent - re-selecting the current
+  // frame is a no-op. `frameName` (focus relay only) labels binding-less frames.
+  navigateToFrame: (frameId: string, frameName?: string) => void;
+  toggleNavBar: () => void;
+  toggleIndicator: () => void;
+  setLoaded: (v: boolean) => void;
+  setStatus: (s: string) => void;
+}
+
+export const usePreviewStore = create<PreviewState>((set, get) => ({
+  payload: null,
+  revision: 0,
+  isPrivate: false,
+  payloadLoaded: false,
+
+  currentNodeId: '',
+  activeId: '',
+  highlightsOn: true,
+  detailsId: '',
+  navBarHidden: false,
+  indicatorCollapsed: false,
+  relayedFrameNames: {},
+  loaded: false,
+  status: 'Waiting for a design - open one from the Pulsar plugin.',
+
+  setConfig: ({ payload, revision, isPrivate }) =>
+    set((s) => ({
+      payload,
+      revision: revision ?? s.revision,
+      isPrivate: isPrivate ?? s.isPrivate
+    })),
+  setPayloadLoaded: (payloadLoaded) => set({ payloadLoaded }),
+
+  setActiveId: (activeId) => set({ activeId }),
+  setActiveTransient: (id) => {
+    set({ activeId: id });
+    if (activeTimer) clearTimeout(activeTimer);
+    activeTimer = setTimeout(() => set({ activeId: '' }), ACTIVE_MS);
+  },
+  setHighlightsOn: (highlightsOn) => set({ highlightsOn }),
+  setDetailsId: (detailsId) => set({ detailsId }),
+  setCurrentNodeId: (currentNodeId) => set({ currentNodeId }),
+  navigateToFrame: (frameId, frameName) => {
+    const norm = normalizeId(frameId);
+    if (!norm) return;
+    set((s) => ({
+      currentNodeId: norm,
+      relayedFrameNames:
+        frameName && s.relayedFrameNames[norm] !== frameName
+          ? { ...s.relayedFrameNames, [norm]: frameName }
+          : s.relayedFrameNames
+    }));
+  },
+  toggleNavBar: () =>
+    set((s) => {
+      const hidden = !s.navBarHidden;
+      try {
+        getHostBridge()?.postMessage(JSON.stringify({ type: 'set-tab-bar-hidden', hidden }));
+      } catch {
+        // No bridge - nothing to toggle.
+      }
+      return { navBarHidden: hidden };
+    }),
+  toggleIndicator: () => set((s) => ({ indicatorCollapsed: !s.indicatorCollapsed })),
+  setLoaded: (loaded) => set({ loaded }),
+  setStatus: (status) => set({ status })
+}));

--- a/figma/src/ui/App.tsx
+++ b/figma/src/ui/App.tsx
@@ -1,6 +1,7 @@
 import styles from './App.module.css';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import PRESETS from './presets-data';
+import { usePresetsUiStore } from './store';
 import type { BoundItem, CatalogEntry, SelectionInfo, Settings } from '../shared/types';
 import { onMessage, send } from './figmaBridge';
 import { applyFilter, filterRevealing, useFilterStateInit, type FilterState } from './components/Filters';
@@ -24,7 +25,6 @@ import ResizeHandle from './components/ResizeHandle';
 import { useToast } from './components/Toast';
 import { usePreviewSync } from './hooks/usePreviewSync';
 import { usePersistOnChange } from './hooks/usePersistOnChange';
-import { toggleInSet } from './lib/collections';
 import { DEFAULT_SETTINGS, DEV_MODE } from './lib/settings';
 import { isFileKeyValid } from './lib/fileKey';
 import { playPreset, stopAll } from './audio/player';
@@ -45,16 +45,28 @@ export default function App() {
   // makes sense while the phone is actually connected, not merely paired.
   const [phoneConnected, setPhoneConnected] = useState(false);
 
-  const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [tab, setTab] = useState<Tab>('presets');
   // First-run onboarding tour. Auto-opens once (gated on the persisted
   // `onboardingSeen` flag from init); the Help tab can relaunch it any time.
   const [showOnboarding, setShowOnboarding] = useState(false);
-  const [openId, setOpenId] = useState<string | null>(null);
-  const [tagsGuideOpen, setTagsGuideOpen] = useState(false);
   const [filter, setFilter] = useState<FilterState>(useFilterStateInit());
-  const [favourites, setFavourites] = useState<Set<string>>(new Set());
   const [favouritesOnly, setFavouritesOnly] = useState(false);
+
+  // Presets-tab interaction state lives in the store so individual PresetCards
+  // can subscribe to just their own favourite/bound flag (see store.ts). App
+  // reads the whole values here (for filtering, the selection bar, the modal);
+  // the actions are stable references safe to pass to memoized children.
+  const selection = usePresetsUiStore((s) => s.selection);
+  const openId = usePresetsUiStore((s) => s.openId);
+  const tagsGuideOpen = usePresetsUiStore((s) => s.tagsGuideOpen);
+  const favourites = usePresetsUiStore((s) => s.favourites);
+  const scrollToId = usePresetsUiStore((s) => s.scrollToId);
+  const setSelection = usePresetsUiStore((s) => s.setSelection);
+  const setOpenId = usePresetsUiStore((s) => s.setOpenId);
+  const setTagsGuideOpen = usePresetsUiStore((s) => s.setTagsGuideOpen);
+  const setFavourites = usePresetsUiStore((s) => s.setFavourites);
+  const toggleFavourite = usePresetsUiStore((s) => s.toggleFavourite);
+  const setScrollToId = usePresetsUiStore((s) => s.setScrollToId);
   const [boundItems, setBoundItems] = useState<BoundItem[]>([]);
   const [customPresets, setCustomPresets] = useState<CatalogEntry[]>([]);
   // The real Figma file key (or share URL) for this document - needed for the
@@ -62,8 +74,6 @@ export default function App() {
   const [figmaFileKey, setFigmaFileKey] = useState('');
   // The Figma document name, advertised to the phone as the connection label.
   const [documentName, setDocumentName] = useState('');
-  // Set when jumping to a preset from the selection bar; PresetsTab scrolls to it.
-  const [scrollToId, setScrollToId] = useState<string | null>(null);
 
   // Custom presets first, then the bundled catalogue.
   const allPresets = useMemo(() => [...customPresets, ...PRESETS], [customPresets]);
@@ -159,8 +169,6 @@ export default function App() {
   const removeCustomPreset = (id: string) =>
     setCustomPresets((prev) => prev.filter((e) => e.id !== id));
 
-  const toggleFavourite = (id: string) => setFavourites((prev) => toggleInSet(prev, id));
-
   // The play-preset handler captured stale settings/token on mount. Rebind it on changes.
   useEffect(() => {
     const off = onMessage((m) => {
@@ -203,13 +211,18 @@ export default function App() {
   // - the two steps of the Live preview configurator. Gates the Presets-tab reminder.
   const liveConfigComplete = isFileKeyValid(figmaFileKey) && hapticsToken != null;
 
-  const playEntry = (e: CatalogEntry) => {
-    stopAll();
-    if (hapticsToken && phoneConnected) broadcastToPhone(hapticsToken, e.data.name);
-    if (settings.soundInEdit) playPreset(e.id, e.data).catch(() => {});
-  };
+  // Stable across favourite/selection changes (deps only shift on pairing/settings)
+  // so the memoized PresetCards don't re-render when an unrelated card is favourited.
+  const playEntry = useCallback(
+    (e: CatalogEntry) => {
+      stopAll();
+      if (hapticsToken && phoneConnected) broadcastToPhone(hapticsToken, e.data.name);
+      if (settings.soundInEdit) playPreset(e.id, e.data).catch(() => {});
+    },
+    [hapticsToken, phoneConnected, settings.soundInEdit]
+  );
 
-  const bindEntry = (e: CatalogEntry) => {
+  const bindEntry = useCallback((e: CatalogEntry) => {
     send({
       type: 'bind-preset',
       // Inline the pattern for custom presets so a binding survives even if the
@@ -220,7 +233,7 @@ export default function App() {
         ...(e.category === 'custom' ? { customPattern: e.data } : {})
       }
     });
-  };
+  }, []);
 
   // Jump from the selection bar to a bound preset: switch to the list, clear any
   // filters hiding it, play it, and ask PresetsTab to scroll it into view.
@@ -330,8 +343,6 @@ export default function App() {
           settings={settings}
           onSettingsChange={setSettings}
           filtered={filtered}
-          favourites={favourites}
-          selection={selection}
           onToggleFavourite={toggleFavourite}
           onPlay={playEntry}
           onBind={bindEntry}

--- a/figma/src/ui/components/PresetCard.tsx
+++ b/figma/src/ui/components/PresetCard.tsx
@@ -1,6 +1,8 @@
+import { memo } from 'react';
 import styles from './PresetCard.module.css';
 import type { CatalogEntry } from '../../shared/types';
 import Visualization from './Visualization';
+import { usePresetsUiStore } from '../store';
 import iconPlay from '../assets/icon-play.svg';
 import iconClock from '../assets/icon-clock.svg';
 import iconInfo from '../assets/icon-info.svg';
@@ -8,11 +10,13 @@ import iconInfo from '../assets/icon-info.svg';
 const formatDuration = (ms: number) =>
   ms >= 1000 ? `${(ms / 1000).toFixed(ms % 1000 === 0 ? 0 : 1)} s` : `${Math.round(ms)} ms`;
 
-export default function PresetCard({
+// Memoized + subscribes to just "am I favourited / bound?" from the store, so a
+// favourite toggle or a selection change re-renders only the affected card(s),
+// not the whole 151-card grid. The callbacks take the entry/id (not a per-card
+// closure) so the parent can pass stable references that don't break memo.
+const PresetCard = memo(function PresetCard({
   entry,
   compact,
-  isBound,
-  isFavourite,
   onToggleFavourite,
   onPlay,
   onBind,
@@ -20,13 +24,13 @@ export default function PresetCard({
 }: {
   entry: CatalogEntry;
   compact: boolean;
-  isBound: boolean;
-  isFavourite: boolean;
-  onToggleFavourite: () => void;
-  onPlay: () => void;
-  onBind: () => void;
-  onOpen: () => void;
+  onToggleFavourite: (id: string) => void;
+  onPlay: (entry: CatalogEntry) => void;
+  onBind: (entry: CatalogEntry) => void;
+  onOpen: (id: string) => void;
 }) {
+  const isFavourite = usePresetsUiStore((s) => s.favourites.has(entry.id));
+  const isBound = usePresetsUiStore((s) => s.selection?.binding?.presetId === entry.id);
   const { data } = entry;
 
   // Lighter, borderless favourite star - shared by both layouts.
@@ -35,7 +39,7 @@ export default function PresetCard({
       className={styles['fav-plain']}
       title={isFavourite ? 'Remove from favourites' : 'Add to favourites'}
       aria-pressed={isFavourite}
-      onClick={onToggleFavourite}
+      onClick={() => onToggleFavourite(entry.id)}
     >
       <span className="star">{isFavourite ? '★' : '☆'}</span>
     </button>
@@ -49,10 +53,10 @@ export default function PresetCard({
     // One dense bordered line: play · name · scrolling tags · duration · fav · bind.
     return (
       <div className={styles['preset-row-compact']} data-preset-id={entry.id}>
-        <button className="ghost icon" onClick={onPlay} title="Play">
+        <button className="ghost icon" onClick={() => onPlay(entry)} title="Play">
           <img src={iconPlay} alt="" width={14} height={14} />
         </button>
-        <span className={styles['preset-row-compact-name']} onClick={onOpen} title={data.name}>
+        <span className={styles['preset-row-compact-name']} onClick={() => onOpen(entry.id)} title={data.name}>
           {data.name}
         </span>
         {boundBadge}
@@ -65,7 +69,7 @@ export default function PresetCard({
           {formatDuration(data.duration)}
         </span>
         {favButton}
-        <button className="primary" onClick={onBind} title="Bind to selection" aria-label="Bind to selection">
+        <button className="primary" onClick={() => onBind(entry)} title="Bind to selection" aria-label="Bind to selection">
           Add
         </button>
       </div>
@@ -85,13 +89,13 @@ export default function PresetCard({
           {formatDuration(data.duration)}
         </span>
         {favButton}
-        <button className="ghost icon" onClick={onOpen} title="Details" aria-label="Open details">
+        <button className="ghost icon" onClick={() => onOpen(entry.id)} title="Details" aria-label="Open details">
           <img src={iconInfo} alt="" width={14} height={14} />
         </button>
-        <button className="ghost icon" onClick={onPlay} title="Play" aria-label="Play">
+        <button className="ghost icon" onClick={() => onPlay(entry)} title="Play" aria-label="Play">
           <img src={iconPlay} alt="" width={14} height={14} />
         </button>
-        <button className="primary" onClick={onBind} title="Bind to selection" aria-label="Bind to selection">
+        <button className="primary" onClick={() => onBind(entry)} title="Bind to selection" aria-label="Bind to selection">
           Add
         </button>
       </div>
@@ -107,4 +111,6 @@ export default function PresetCard({
       </div>
     </div>
   );
-}
+});
+
+export default PresetCard;

--- a/figma/src/ui/components/PresetsTab.tsx
+++ b/figma/src/ui/components/PresetsTab.tsx
@@ -1,6 +1,6 @@
 import styles from './PresetsTab.module.css';
 import { useEffect, useRef, useState } from 'react';
-import type { BoundItem, CatalogEntry, SelectionInfo, Settings } from '../../shared/types';
+import type { BoundItem, CatalogEntry, Settings } from '../../shared/types';
 import Filters, { type FilterState } from './Filters';
 import PresetCard from './PresetCard';
 import AddCustomPreset from './AddCustomPreset';
@@ -26,8 +26,6 @@ export default function PresetsTab({
   settings,
   onSettingsChange,
   filtered,
-  favourites,
-  selection,
   onToggleFavourite,
   onPlay,
   onBind,
@@ -57,8 +55,6 @@ export default function PresetsTab({
   settings: Settings;
   onSettingsChange: (settings: Settings) => void;
   filtered: CatalogEntry[];
-  favourites: Set<string>;
-  selection: SelectionInfo | null;
   onToggleFavourite: (id: string) => void;
   onPlay: (entry: CatalogEntry) => void;
   onBind: (entry: CatalogEntry) => void;
@@ -172,12 +168,10 @@ export default function PresetsTab({
               key={e.id}
               entry={e}
               compact={settings.compactLayout}
-              isBound={selection?.binding?.presetId === e.id}
-              isFavourite={favourites.has(e.id)}
-              onToggleFavourite={() => onToggleFavourite(e.id)}
-              onPlay={() => onPlay(e)}
-              onBind={() => onBind(e)}
-              onOpen={() => onOpen(e.id)}
+              onToggleFavourite={onToggleFavourite}
+              onPlay={onPlay}
+              onBind={onBind}
+              onOpen={onOpen}
             />
           ))}
           {filtered.length === 0 && (

--- a/figma/src/ui/store.ts
+++ b/figma/src/ui/store.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+import type { SelectionInfo } from '../shared/types';
+import { toggleInSet } from './lib/collections';
+
+// Store for the plugin UI's presets-tab interaction state - the slices that
+// leaf components (PresetCard) subscribe to individually. Keeping `favourites`
+// and `selection` here (rather than in App's useState, prop-drilled through
+// PresetsTab) lets each card read just "am I favourited / bound?" via a
+// selector, so toggling one star re-renders that one card instead of all 151
+// cards + their SVG visualizations.
+//
+// Deliberately scoped: the server-sync / phone-pairing machinery in
+// usePreviewSync / usePhoneConnection is untouched (it's delicate, ref-based by
+// design, and can't be exercised outside Figma), and persisted/hook-input state
+// (settings, figmaFileKey, hapticsToken, customPresets) stays in App.
+
+interface PresetsUiState {
+  // Favourited preset ids. Seeded from the plugin's persisted data on `init` and
+  // written back on change (App owns that bridge wiring); the store is the single
+  // source of truth the UI reads.
+  favourites: Set<string>;
+  // The node currently selected on the Figma canvas (+ its binding, if any).
+  // Drives the selection bar and each card's "● selected" badge.
+  selection: SelectionInfo | null;
+  // The preset whose detail modal is open (null = closed).
+  openId: string | null;
+  // Whether the "Tags guide" modal is open.
+  tagsGuideOpen: boolean;
+  // When set, PresetsTab scrolls that preset into view + flashes it, then clears
+  // it via setScrollToId(null).
+  scrollToId: string | null;
+
+  setFavourites: (ids: Set<string>) => void;
+  toggleFavourite: (id: string) => void;
+  setSelection: (selection: SelectionInfo | null) => void;
+  setOpenId: (id: string | null) => void;
+  setTagsGuideOpen: (open: boolean) => void;
+  setScrollToId: (id: string | null) => void;
+}
+
+export const usePresetsUiStore = create<PresetsUiState>((set) => ({
+  favourites: new Set(),
+  selection: null,
+  openId: null,
+  tagsGuideOpen: false,
+  scrollToId: null,
+
+  setFavourites: (favourites) => set({ favourites }),
+  toggleFavourite: (id) => set((s) => ({ favourites: toggleInSet(s.favourites, id) })),
+  setSelection: (selection) => set({ selection }),
+  setOpenId: (openId) => set({ openId }),
+  setTagsGuideOpen: (tagsGuideOpen) => set({ tagsGuideOpen }),
+  setScrollToId: (scrollToId) => set({ scrollToId })
+}));


### PR DESCRIPTION
## What

Moves the **preview app** (`figma/preview`) and the **plugin UI** (`figma/src/ui`) off `App`-owned, prop-drilled state onto small zustand stores, and memoizes the leaf components that render the hot lists. The result: a cosmetic interaction re-renders only the piece that changed instead of the whole subtree.

## Why

Neither app memoized its list items, so every state change in `App` re-rendered the entire prop-drilled tree — including the expensive iframe host and the full card/row lists. Zustand selectors + `React.memo` let each leaf subscribe to just its own slice.

## Changes

**Preview app (`figma/preview`)**
- New `store.ts`: interaction state (`activeId`, `highlightsOn`, `detailsId`, `currentNodeId`, nav/indicator toggles) + config (`payload`, `revision`).
- `HapticRow` / `HighlightBox` are `React.memo` and subscribe to their own slice.
- Removes the `payloadRef`/`revisionRef` mirror duplication; host-update handlers read `getState()`, so `useHostUpdates` binds once.

**Plugin UI (`figma/src/ui`)**
- New `store.ts`: presets-tab state (`favourites`, `selection`, `openId`, `tagsGuideOpen`, `scrollToId`).
- `PresetCard` is `React.memo` and reads its own `isFavourite`/`isBound` via selectors; handlers take `entry`/`id` so props stay stable.

## Measured impact

Render fan-out per interaction (measured via a temporary `?bench` harness that was stripped before this PR):

| Interaction | Before | After |
|---|---|---|
| Preview: hover a row | App + iframe host + overlay + 24-row list | 1 row + 1 box |
| Preview: 16-hover sweep | 64 renders / 13.5ms | 32 renders / ~1ms |
| Preview: open details modal | 4 heavy renders | 0 |
| Plugin: toggle 1 favourite | 151 cards + 151 SVGs = 305 / 34ms | **1 card = 5 / 4ms** |
| Plugin: search filter (→13) | 28 renders | 2 renders |

## Reviewer notes

- The perf win comes from **`memo` + selectors together**, not zustand alone — the components had to be memoized so they can skip parent-driven re-renders.
- **Scope was deliberately limited.** In the plugin, only the presets-tab UI state moved to the store; the delicate `usePreviewSync` (743 lines) and `usePhoneConnection` (329 lines) sync/pairing state machines are **untouched** — they're ref-based by design and can't be exercised outside Figma.
- Verified: both apps typecheck; preview and plugin render and behave correctly when served standalone (favourite toggles, tabs switch, no console errors). The plugin serves headless because its 206-preset catalogue is a bundled import.
- Behavior is intended to be identical; this is a rendering/state-plumbing refactor with no user-facing changes.