### PR TITLE
refactor(app): split ConnectionsContext into focused units

### DIFF
--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -1,5 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as Linking from 'expo-linking';
 import { usePostHog } from 'posthog-react-native';
 import React, {
   createContext,
@@ -10,113 +8,38 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
-import { AppState } from 'react-native';
 import { Presets, usePatternComposer, type Pattern } from 'react-native-pulsar';
 
-import { SOCKET_SERVER_URL } from '@/constants/Connection';
-import { playPattern } from '@/src/haptics/playPattern';
+import { handleServerMessage, type ServerMessageHandlers } from '@/src/connections/serverMessages';
+import { loadPersistedConnections, persistConnections } from '@/src/connections/storage';
+import { useDeepLinkPairing } from '@/src/connections/useDeepLinkPairing';
+import { useForegroundReconnect } from '@/src/connections/useForegroundReconnect';
+import { useLiveSockets } from '@/src/connections/useLiveSockets';
+import { useReceivedNotice } from '@/src/connections/useReceivedNotice';
 
-// Where the list of paired producers is persisted. Replaces the single-token
-// `connectionToken` key the pre-multi-connection app used; that legacy key is
-// migrated into this list once on first launch (see the load effect).
-const STORAGE_KEY = 'connections';
-const LEGACY_TOKEN_KEY = 'connectionToken';
-const PING_INTERVAL_MS = 25_000;
-const CONNECT_TIMEOUT_MS = 15_000;
+import type {
+  AddByCodeOptions,
+  Connection,
+  PreviewUpdate,
+  ReceivedPattern,
+  Track,
+} from '@/src/connections/types';
 
-export type ConnectionStatus =
-  | 'connecting' // socket opening, no server ack yet
-  | 'waiting' // on the server, producer not present (peer away / not paired yet)
-  | 'connected' // paired with the producer — broadcasts will play
-  | 'offline' // socket closed cleanly (e.g. backgrounded) — will reconnect
-  | 'error'; // connection attempt failed
-
-export type ProducerType = 'figma' | 'browser';
-
-export interface Connection {
-  // Stable local id for the row + persistence; survives socket churn and app
-  // restarts (persisted alongside the token).
-  id: string;
-  // Strong-channel token, known once `connection_established` arrives. Null
-  // while a fresh pairing is still in flight.
-  token: string | null;
-  // Human label shown in the list. Provisional until the server relays the
-  // producer's advertised name (e.g. "Figma Plugin macOS").
-  name: string;
-  status: ConnectionStatus;
-  // Figma preview share token relayed by the producer, if any — lets the row
-  // offer "Open preview".
-  previewToken?: string;
-  // What kind of producer paired with us, relayed at (re)establish. Absent on
-  // older producers — fall back to inferring from `previewToken` (see
-  // `connectionType`).
-  producerType?: ProducerType;
-  // Human-readable Figma file/project name (`figma.root.name`), relayed by the
-  // Figma plugin. Absent for browsers and older plugins.
-  figmaProjectName?: string;
-  // User-edited label. Takes precedence over the relayed name so a rename isn't
-  // overwritten by `connection_restored` on the next reconnect.
-  customName?: string;
-  // When this connection was first added (epoch ms). Shown in the edit modal.
-  createdAt: number;
-}
-
-interface PersistedConnection {
-  id: string;
-  token: string;
-  name: string;
-  previewToken?: string;
-  producerType?: ProducerType;
-  figmaProjectName?: string;
-  customName?: string;
-  createdAt?: number;
-}
-
-// What kind of producer a connection is. Prefer the relayed `producerType`;
-// fall back to the presence of a preview token (only the Figma plugin sends one).
-export function connectionType(c: Connection): ProducerType {
-  return c.producerType ?? (c.previewToken ? 'figma' : 'browser');
-}
-
-// The label to show in the list: a user rename wins, then the Figma project
-// name, then the producer-advertised name.
-export function connectionDisplayName(c: Connection): string {
-  return c.customName?.trim() || c.figmaProjectName || c.name;
-}
-
-export interface ReceivedPattern {
-  found: boolean;
-  name: string;
-}
-
-// A live haptics-config update relayed by the Figma plugin over the paired
-// channel, destined for an open live preview. The payload is forwarded verbatim
-// to the WebView (figma.tsx); we only read `previewToken` (to match the right
-// open preview) here. `nonce` is monotonic so an identical repeat still
-// re-triggers the consumer effect.
-export interface PreviewUpdate {
-  kind: 'preview-haptics-diff' | 'preview-haptics-refetch' | 'preview-frame-focus';
-  previewToken?: string;
-  fromRevision?: number;
-  toRevision?: number;
-  diff?: unknown;
-  // Set only on 'preview-frame-focus': the top-level frame the designer focused,
-  // which the open live preview should present, plus its human-readable name for
-  // the preview's "current screen" indicator.
-  nodeId?: string;
-  frameName?: string;
-  nonce: number;
-}
+export { connectionDisplayName, connectionType } from '@/src/connections/types';
+export type {
+  Connection,
+  ConnectionStatus,
+  PreviewUpdate,
+  ProducerType,
+  ReceivedPattern,
+} from '@/src/connections/types';
 
 interface ConnectionsContextValue {
   connections: Connection[];
   // Pair a new producer from a 4-digit code (manual entry or a scanned QR). A
   // Figma QR also carries the preview token + type up front, so the row is
   // tagged Figma and can reopen the preview without waiting on the server relay.
-  addByCode: (
-    code: string,
-    opts?: { name?: string; previewToken?: string; producerType?: ProducerType },
-  ) => void;
+  addByCode: (code: string, opts?: AddByCodeOptions) => void;
   // Drop a connection: close its socket and forget its token.
   remove: (id: string) => void;
   // Re-open a closed/errored connection from its stored token.
@@ -132,240 +55,73 @@ interface ConnectionsContextValue {
 
 const ConnectionsContext = createContext<ConnectionsContextValue | undefined>(undefined);
 
-// One live socket + its timers per connection id, kept out of React state so
-// socket churn doesn't trigger re-renders.
-interface LiveSocket {
-  socket: WebSocket;
-  ping: ReturnType<typeof setInterval> | null;
-  timeout: ReturnType<typeof setTimeout> | null;
-}
-
 export function ConnectionsProvider({ children }: { children: ReactNode }) {
   const posthog = usePostHog();
   const [connections, setConnections] = useState<Connection[]>([]);
-  const [lastReceived, setLastReceived] = useState<ReceivedPattern | null>(null);
   const [lastPreviewUpdate, setLastPreviewUpdate] = useState<PreviewUpdate | null>(null);
   // Gate persistence until the initial load runs, so the first (empty) render
   // doesn't clobber the stored list before it's restored.
   const [didLoad, setDidLoad] = useState(false);
 
-  const live = useRef<Map<string, LiveSocket>>(new Map());
+  const { lastReceived, notify } = useReceivedNotice();
+
   const connectionsRef = useRef<Connection[]>([]);
+  connectionsRef.current = connections;
   const idCounter = useRef(0);
-  const appStateRef = useRef(AppState.currentState);
-  const notifyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lastUrlRef = useRef<string | null>(null);
   // Monotonic counter so two identical preview updates still re-trigger the
   // preview consumer (e.g. a binding toggled back and forth).
-  const previewNonceRef = useRef(0);
+  const previewNonce = useRef(0);
 
-  // One composer for playing full JSON presets pushed over a broadcast (Pulsar
-  // Studio's "Play on device"). `parse`/`play` are stable, but the socket handler
-  // is a useCallback closure, so read the composer through a ref that every render
-  // keeps current rather than closing over the first one.
+  // The message handler closes over the composer, so read it through a ref that
+  // every render keeps current rather than closing over the first one.
   const composer = usePatternComposer(undefined);
   const composerRef = useRef(composer);
   composerRef.current = composer;
 
-  useEffect(() => {
-    connectionsRef.current = connections;
-  }, [connections]);
-
-  const newId = useCallback(
-    () => `conn-${Date.now().toString(36)}-${idCounter.current++}`,
-    [],
-  );
+  const newId = useCallback(() => `conn-${Date.now().toString(36)}-${idCounter.current++}`, []);
 
   const patchConnection = useCallback((id: string, patch: Partial<Connection>) => {
     setConnections((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
   }, []);
 
-  const notify = useCallback((found: boolean, name: string) => {
-    setLastReceived({ found, name });
-    if (notifyTimeout.current) clearTimeout(notifyTimeout.current);
-    notifyTimeout.current = setTimeout(() => setLastReceived(null), 1200);
-  }, []);
-
-  // Close + forget the live socket for an id without letting its handlers patch
-  // state (used when replacing a socket or removing a connection).
-  const teardownLive = useCallback((id: string) => {
-    const entry = live.current.get(id);
-    if (!entry) return;
-    if (entry.ping) clearInterval(entry.ping);
-    if (entry.timeout) clearTimeout(entry.timeout);
-    entry.socket.onopen = null;
-    entry.socket.onmessage = null;
-    entry.socket.onerror = null;
-    entry.socket.onclose = null;
-    try {
-      entry.socket.close(1000);
-    } catch {
-      // already closing/closed
-    }
-    live.current.delete(id);
-  }, []);
-
-  // Open a receiver socket for `conn`, either a fresh pairing (`new` + code) or
-  // a reconnect (`reuse` + token), and wire up the shared message handling +
-  // keepalive. Mirrors the single-connection lifecycle the home screen used to
-  // own, but scoped to one row of the list.
-  const openSocket = useCallback(
-    (conn: Connection, kind: 'new' | 'reuse', value: string) => {
-      teardownLive(conn.id);
-      const query =
-        kind === 'new'
-          ? `type=receiver&action=new_connection&code=${encodeURIComponent(value)}`
-          : `type=receiver&action=reuse_connection&token=${encodeURIComponent(value)}`;
-      const socket = new WebSocket(`${SOCKET_SERVER_URL}?${query}`);
-      const entry: LiveSocket = { socket, ping: null, timeout: null };
-      live.current.set(conn.id, entry);
-      patchConnection(conn.id, { status: 'connecting' });
-
-      entry.timeout = setTimeout(() => {
-        if (live.current.get(conn.id)?.socket === socket) {
-          socket.close();
-          patchConnection(conn.id, { status: 'error' });
-        }
-      }, CONNECT_TIMEOUT_MS);
-
-      socket.onopen = () => {
-        if (entry.timeout) {
-          clearTimeout(entry.timeout);
-          entry.timeout = null;
-        }
-        // On the server, but not yet paired with the producer.
-        patchConnection(conn.id, { status: 'waiting' });
-        entry.ping = setInterval(() => {
-          if (socket.readyState === WebSocket.OPEN) {
-            socket.send(JSON.stringify({ type: 'ping' }));
-          }
-        }, PING_INTERVAL_MS);
-      };
-
-      socket.onmessage = (event) => {
-        const payload = typeof event.data === 'string' ? event.data : '';
-        let json: {
-          type?: string;
-          token?: string;
-          message?: unknown;
-          name?: string;
-          previewToken?: string;
-          producerType?: ProducerType;
-          figmaProjectName?: string;
-        };
-        try {
-          json = JSON.parse(payload);
-        } catch {
-          return;
-        }
-        switch (json.type) {
-          case 'connection_established':
-            if (json.token) {
-              patchConnection(conn.id, {
-                token: json.token,
-                status: 'connected',
-                ...(json.name ? { name: json.name } : {}),
-                ...(json.previewToken ? { previewToken: json.previewToken } : {}),
-                ...(json.producerType ? { producerType: json.producerType } : {}),
-                ...(json.figmaProjectName ? { figmaProjectName: json.figmaProjectName } : {}),
-              });
-              // A short buzz confirms the new pairing to the user.
-              Presets.breakingWave();
-              posthog?.capture('device_connected', { connection_type: 'new' });
-            }
-            break;
-          case 'connection_restored':
-            // Silent (no buzz): this is a background reconnect, not a user action.
-            patchConnection(conn.id, {
-              status: 'connected',
-              ...(json.name ? { name: json.name } : {}),
-              ...(json.previewToken ? { previewToken: json.previewToken } : {}),
-              ...(json.producerType ? { producerType: json.producerType } : {}),
-              ...(json.figmaProjectName ? { figmaProjectName: json.figmaProjectName } : {}),
-            });
-            posthog?.capture('device_connected', { connection_type: 'restored' });
-            break;
-          case 'peer_disconnected':
-            patchConnection(conn.id, { status: 'waiting' });
-            break;
-          case 'pong':
-            break;
-          case 'broadcast': {
-            // A producer sends either a preset *name* (a string, to play now) or
-            // a structured live-preview update (an object). Branch on the shape
-            // so neither path can throw on the other's payload.
-            const msg = json.message;
-            if (typeof msg === 'string') {
-              const found = playPattern(msg);
-              notify(found, msg);
-            } else if (
-              msg &&
-              typeof msg === 'object' &&
-              (msg as { kind?: unknown }).kind === 'haptic-preset' &&
-              (msg as { pattern?: unknown }).pattern
-            ) {
-              // A full JSON preset pushed from Pulsar Studio. Unlike the string
-              // path, this ALWAYS plays the supplied waveform via the composer —
-              // never a same-named built-in — so an edited preset plays as edited.
-              // Older app builds don't match this branch (the object isn't a
-              // 'preview-*'), so they harmlessly ignore it: the backward-compat seam.
-              const preset = msg as { kind: string; name?: string; pattern: Pattern };
-              let played = false;
-              try {
-                composerRef.current.parse(preset.pattern);
-                composerRef.current.play();
-                played = true;
-              } catch {
-                played = false;
-              }
-              notify(played, preset.name ?? 'Haptic preset');
-            } else if (
-              msg &&
-              typeof msg === 'object' &&
-              typeof (msg as { kind?: unknown }).kind === 'string' &&
-              // Covers both the haptics-config relay (diff/refetch) and the
-              // designer-focus frame jump (preview-frame-focus).
-              (msg as { kind: string }).kind.startsWith('preview-')
-            ) {
-              // Forwarded verbatim to the open live preview (figma.tsx). Match on
-              // the producer-supplied previewToken, falling back to the one this
-              // connection advertised at pairing time.
-              const update = msg as Omit<PreviewUpdate, 'nonce'>;
-              const fallbackToken =
-                connectionsRef.current.find((c) => c.id === conn.id)?.previewToken ??
-                conn.previewToken;
-              setLastPreviewUpdate({
-                ...update,
-                previewToken: update.previewToken ?? fallbackToken,
-                nonce: ++previewNonceRef.current,
-              });
-            }
-            break;
-          }
-        }
-      };
-
-      socket.onerror = () => {
-        if (live.current.get(conn.id)?.socket !== socket) return;
-        patchConnection(conn.id, { status: 'error' });
-        posthog?.capture('device_connection_failed', { connection_action: kind });
-      };
-
-      socket.onclose = (e) => {
-        if (live.current.get(conn.id)?.socket !== socket) return;
-        if (entry.ping) clearInterval(entry.ping);
-        if (entry.timeout) clearTimeout(entry.timeout);
-        live.current.delete(conn.id);
-        // Clean close (e.g. backgrounded) → offline and reconnectable; an
-        // unclean close means the attempt failed.
-        patchConnection(conn.id, { status: e.code === 1000 ? 'offline' : 'error' });
-      };
-    },
-    [teardownLive, patchConnection, notify, posthog],
+  const track = useCallback<Track>(
+    (event, properties) => posthog?.capture(event, properties),
+    [posthog],
   );
 
+  const messageHandlers: ServerMessageHandlers = {
+    patchConnection,
+    notify,
+    playPreset: (pattern: Pattern) => {
+      try {
+        composerRef.current.parse(pattern);
+        composerRef.current.play();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    emitPreviewUpdate: (id, update) => {
+      // Match on the producer-supplied previewToken, falling back to the one
+      // this connection advertised at pairing time.
+      const fallback = connectionsRef.current.find((c) => c.id === id)?.previewToken;
+      setLastPreviewUpdate({
+        ...update,
+        previewToken: update.previewToken ?? fallback,
+        nonce: ++previewNonce.current,
+      });
+    },
+    track,
+  };
+
+  const sockets = useLiveSockets({
+    onStatus: (id, status) => patchConnection(id, { status }),
+    onMessage: (id, raw) => handleServerMessage(id, raw, messageHandlers),
+    onFailed: (id, kind) => track('device_connection_failed', { connection_action: kind }),
+  });
+
   const addByCode = useCallback(
-    (code: string, opts?: { name?: string; previewToken?: string; producerType?: ProducerType }) => {
+    (code: string, opts?: AddByCodeOptions) => {
       const trimmed = code.trim();
       if (!trimmed) return;
       const conn: Connection = {
@@ -380,177 +136,73 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
         ...(opts?.producerType ? { producerType: opts.producerType } : {}),
       };
       setConnections((prev) => [...prev, conn]);
-      openSocket(conn, 'new', trimmed);
-      posthog?.capture('device_connection_initiated', { connection_action: 'new_connection' });
+      // Keep the ref authoritative before the re-render lands, so a broadcast
+      // that beats it can still resolve this connection (e.g. its previewToken).
+      connectionsRef.current = [...connectionsRef.current, conn];
+      sockets.open(conn.id, 'new', trimmed);
+      track('device_connection_initiated', { connection_action: 'new_connection' });
     },
-    [newId, openSocket, posthog],
+    [newId, sockets, track],
   );
 
   const reconnect = useCallback(
     (id: string) => {
-      const conn = connectionsRef.current.find((c) => c.id === id);
-      if (!conn?.token) return;
-      openSocket(conn, 'reuse', conn.token);
+      const token = connectionsRef.current.find((c) => c.id === id)?.token;
+      if (token) sockets.open(id, 'reuse', token);
     },
-    [openSocket],
+    [sockets],
   );
 
   const remove = useCallback(
     (id: string) => {
-      teardownLive(id);
+      sockets.teardown(id);
       setConnections((prev) => prev.filter((c) => c.id !== id));
       Presets.powerDown();
-      posthog?.capture('device_disconnected');
+      track('device_disconnected');
     },
-    [teardownLive, posthog],
+    [sockets, track],
   );
 
-  // Set (or clear, when blank) a user-chosen label for a connection. Stored as
-  // `customName` so it survives reconnects without being clobbered by the
-  // producer-relayed name.
+  // Stored as `customName` so a rename survives the producer-relayed name on the
+  // next reconnect.
   const rename = useCallback(
     (id: string, name: string) => {
-      const trimmed = name.trim();
-      patchConnection(id, { customName: trimmed || undefined });
-      posthog?.capture('connection_renamed');
+      patchConnection(id, { customName: name.trim() || undefined });
+      track('connection_renamed');
     },
-    [patchConnection, posthog],
+    [patchConnection, track],
   );
 
-  // Initial load: restore the persisted list (or migrate the legacy single
-  // token) and reconnect each established connection.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      let persisted: PersistedConnection[] = [];
-      try {
-        const raw = await AsyncStorage.getItem(STORAGE_KEY);
-        if (raw) persisted = JSON.parse(raw);
-      } catch {
-        persisted = [];
-      }
-      if (persisted.length === 0) {
-        // One-time migration from the pre-multi-connection single token so an
-        // already-paired install keeps working after the update.
-        try {
-          const legacy = await AsyncStorage.getItem(LEGACY_TOKEN_KEY);
-          if (legacy && legacy.length > 0) {
-            persisted = [{ id: newId(), token: legacy, name: 'Saved device', createdAt: Date.now() }];
-          }
-        } catch {
-          // ignore — nothing to migrate
-        }
-      }
+    loadPersistedConnections(newId).then((restored) => {
       if (cancelled) return;
-      if (persisted.length > 0) {
-        const restored: Connection[] = persisted.map((p) => ({
-          id: p.id,
-          token: p.token,
-          name: p.name,
-          previewToken: p.previewToken,
-          producerType: p.producerType,
-          figmaProjectName: p.figmaProjectName,
-          customName: p.customName,
-          createdAt: p.createdAt ?? Date.now(),
-          status: 'connecting',
-        }));
+      if (restored.length > 0) {
         setConnections(restored);
-        restored.forEach((c) => c.token && openSocket(c, 'reuse', c.token));
+        restored.forEach((c) => c.token && sockets.open(c.id, 'reuse', c.token));
       }
       setDidLoad(true);
-    })();
+    });
     return () => {
       cancelled = true;
     };
-    // openSocket/newId are stable; run once.
+    // sockets.open/newId are stable; run once.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Persist the established connections (those with a token) on every change,
-  // once the initial load has run.
   useEffect(() => {
-    if (!didLoad) return;
-    const toPersist: PersistedConnection[] = connections
-      .filter((c) => c.token)
-      .map((c) => ({
-        id: c.id,
-        token: c.token as string,
-        name: c.name,
-        createdAt: c.createdAt,
-        ...(c.previewToken ? { previewToken: c.previewToken } : {}),
-        ...(c.producerType ? { producerType: c.producerType } : {}),
-        ...(c.figmaProjectName ? { figmaProjectName: c.figmaProjectName } : {}),
-        ...(c.customName ? { customName: c.customName } : {}),
-      }));
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist)).catch(() => {});
+    if (didLoad) persistConnections(connections);
   }, [connections, didLoad]);
 
-  // Reconnect any dropped connection when the app returns to the foreground.
-  useEffect(() => {
-    const sub = AppState.addEventListener('change', (next) => {
-      if (appStateRef.current.match(/inactive|background/) && next === 'active') {
-        for (const c of connectionsRef.current) {
-          if (!c.token) continue;
-          const entry = live.current.get(c.id);
-          const open =
-            entry &&
-            (entry.socket.readyState === WebSocket.OPEN ||
-              entry.socket.readyState === WebSocket.CONNECTING);
-          if (!open) openSocket(c, 'reuse', c.token);
-        }
+  useForegroundReconnect(
+    useCallback(() => {
+      for (const c of connectionsRef.current) {
+        if (c.token && !sockets.isOpen(c.id)) sockets.open(c.id, 'reuse', c.token);
       }
-      appStateRef.current = next;
-    });
-    return () => sub.remove();
-  }, [openSocket]);
-
-  // Deep links carrying a pairing `code` (`pulsarapp://connect?code=…` or the
-  // unified `pulsarapp://figma?token=…&code=…`) add a connection. The `token`
-  // for the preview is consumed separately by the Figma route.
-  useEffect(() => {
-    const handle = (url: string) => {
-      if (!url || lastUrlRef.current === url) return;
-      lastUrlRef.current = url;
-      const parsed = Linking.parse(url);
-      const code = parsed.queryParams?.code;
-      if (code) {
-        const name = parsed.queryParams?.name;
-        // A `token` means this is the unified Figma link — capture it as the
-        // connection's preview token + Figma type so the row reopens the preview.
-        const token = parsed.queryParams?.token;
-        const previewToken = token ? token.toString() : undefined;
-        addByCode(code.toString(), {
-          name: name ? name.toString() : undefined,
-          ...(previewToken ? { previewToken, producerType: 'figma' as const } : {}),
-        });
-        posthog?.capture('deep_link_connection_initiated', { has_code: true });
-      }
-    };
-    const sub = Linking.addEventListener('url', ({ url }) => handle(url));
-    Linking.getInitialURL().then((url) => {
-      if (url) handle(url);
-    });
-    return () => sub.remove();
-  }, [addByCode, posthog]);
-
-  // Tear everything down on unmount (root provider — rare, but keep it clean).
-  useEffect(
-    () => () => {
-      for (const [, entry] of live.current) {
-        if (entry.ping) clearInterval(entry.ping);
-        if (entry.timeout) clearTimeout(entry.timeout);
-        entry.socket.onclose = null;
-        try {
-          entry.socket.close();
-        } catch {
-          // already closing/closed
-        }
-      }
-      live.current.clear();
-      if (notifyTimeout.current) clearTimeout(notifyTimeout.current);
-    },
-    [],
+    }, [sockets]),
   );
+
+  useDeepLinkPairing(addByCode, track);
 
   return (
     <ConnectionsContext.Provider

--- a/PulsarApp/src/connections/serverMessages.ts
+++ b/PulsarApp/src/connections/serverMessages.ts
@@ -1,0 +1,104 @@
+import { Presets, type Pattern } from 'react-native-pulsar';
+
+import { playPattern } from '@/src/haptics/playPattern';
+
+import type { Connection, PreviewUpdate, ProducerType, Track } from './types';
+
+interface ServerMessage {
+  type?: string;
+  token?: string;
+  message?: unknown;
+  name?: string;
+  previewToken?: string;
+  producerType?: ProducerType;
+  figmaProjectName?: string;
+}
+
+export interface ServerMessageHandlers {
+  patchConnection: (id: string, patch: Partial<Connection>) => void;
+  notify: (found: boolean, name: string) => void;
+  playPreset: (pattern: Pattern) => boolean;
+  emitPreviewUpdate: (id: string, update: Omit<PreviewUpdate, 'nonce'>) => void;
+  track: Track;
+}
+
+// The identity fields a producer may relay at (re)establish. Only the ones
+// actually present are patched, so a reconnect never blanks a known value.
+function relayedIdentity(json: ServerMessage): Partial<Connection> {
+  return {
+    ...(json.name ? { name: json.name } : {}),
+    ...(json.previewToken ? { previewToken: json.previewToken } : {}),
+    ...(json.producerType ? { producerType: json.producerType } : {}),
+    ...(json.figmaProjectName ? { figmaProjectName: json.figmaProjectName } : {}),
+  };
+}
+
+// A producer sends either a preset *name* (a string, to play now) or a
+// structured live-preview update (an object). Branch on the shape so neither
+// path can throw on the other's payload.
+function handleBroadcast(id: string, message: unknown, handlers: ServerMessageHandlers) {
+  if (typeof message === 'string') {
+    handlers.notify(playPattern(message), message);
+    return;
+  }
+  if (!message || typeof message !== 'object') return;
+
+  const kind = (message as { kind?: unknown }).kind;
+
+  if (kind === 'haptic-preset' && (message as { pattern?: unknown }).pattern) {
+    // A full JSON preset pushed from Pulsar Studio. Unlike the string path, this
+    // ALWAYS plays the supplied waveform via the composer — never a same-named
+    // built-in — so an edited preset plays as edited. Older app builds don't
+    // match this branch (the object isn't a 'preview-*'), so they harmlessly
+    // ignore it: the backward-compat seam.
+    const preset = message as { kind: string; name?: string; pattern: Pattern };
+    handlers.notify(handlers.playPreset(preset.pattern), preset.name ?? 'Haptic preset');
+    return;
+  }
+
+  // Covers both the haptics-config relay (diff/refetch) and the designer-focus
+  // frame jump (preview-frame-focus). Forwarded verbatim to the live preview.
+  if (typeof kind === 'string' && kind.startsWith('preview-')) {
+    handlers.emitPreviewUpdate(id, message as Omit<PreviewUpdate, 'nonce'>);
+  }
+}
+
+export function handleServerMessage(id: string, raw: string, handlers: ServerMessageHandlers) {
+  let json: ServerMessage;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  switch (json.type) {
+    case 'connection_established':
+      if (!json.token) break;
+      handlers.patchConnection(id, {
+        token: json.token,
+        status: 'connected',
+        ...relayedIdentity(json),
+      });
+      // A short buzz confirms the new pairing to the user.
+      Presets.breakingWave();
+      handlers.track('device_connected', { connection_type: 'new' });
+      break;
+
+    case 'connection_restored':
+      // Silent (no buzz): this is a background reconnect, not a user action.
+      handlers.patchConnection(id, { status: 'connected', ...relayedIdentity(json) });
+      handlers.track('device_connected', { connection_type: 'restored' });
+      break;
+
+    case 'peer_disconnected':
+      handlers.patchConnection(id, { status: 'waiting' });
+      break;
+
+    case 'pong':
+      break;
+
+    case 'broadcast':
+      handleBroadcast(id, json.message, handlers);
+      break;
+  }
+}

--- a/PulsarApp/src/connections/storage.ts
+++ b/PulsarApp/src/connections/storage.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import type { Connection, PersistedConnection } from './types';
+
+// Where the list of paired producers is persisted. Replaces the single-token
+// `connectionToken` key the pre-multi-connection app used; that legacy key is
+// migrated into this list once on first launch (see `loadPersistedConnections`).
+const STORAGE_KEY = 'connections';
+const LEGACY_TOKEN_KEY = 'connectionToken';
+
+export async function loadPersistedConnections(newId: () => string): Promise<Connection[]> {
+  let persisted: PersistedConnection[] = [];
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) persisted = JSON.parse(raw);
+  } catch {
+    persisted = [];
+  }
+
+  if (persisted.length === 0) {
+    // One-time migration from the pre-multi-connection single token, so an
+    // already-paired install keeps working after the update.
+    try {
+      const legacy = await AsyncStorage.getItem(LEGACY_TOKEN_KEY);
+      if (legacy && legacy.length > 0) {
+        persisted = [{ id: newId(), token: legacy, name: 'Saved device', createdAt: Date.now() }];
+      }
+    } catch {
+      // ignore — nothing to migrate
+    }
+  }
+
+  return persisted.map((p) => ({
+    id: p.id,
+    token: p.token,
+    name: p.name,
+    previewToken: p.previewToken,
+    producerType: p.producerType,
+    figmaProjectName: p.figmaProjectName,
+    customName: p.customName,
+    createdAt: p.createdAt ?? Date.now(),
+    status: 'connecting',
+  }));
+}
+
+export function persistConnections(connections: Connection[]): void {
+  const toPersist: PersistedConnection[] = connections
+    .filter((c) => c.token)
+    .map((c) => ({
+      id: c.id,
+      token: c.token as string,
+      name: c.name,
+      createdAt: c.createdAt,
+      ...(c.previewToken ? { previewToken: c.previewToken } : {}),
+      ...(c.producerType ? { producerType: c.producerType } : {}),
+      ...(c.figmaProjectName ? { figmaProjectName: c.figmaProjectName } : {}),
+      ...(c.customName ? { customName: c.customName } : {}),
+    }));
+  AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist)).catch(() => {});
+}

--- a/PulsarApp/src/connections/types.ts
+++ b/PulsarApp/src/connections/types.ts
@@ -1,0 +1,90 @@
+export type ConnectionStatus =
+  | 'connecting' // socket opening, no server ack yet
+  | 'waiting' // on the server, producer not present (peer away / not paired yet)
+  | 'connected' // paired with the producer — broadcasts will play
+  | 'offline' // socket closed cleanly (e.g. backgrounded) — will reconnect
+  | 'error'; // connection attempt failed
+
+export type ProducerType = 'figma' | 'browser';
+
+export interface Connection {
+  id: string;
+  // Strong-channel token, known once `connection_established` arrives. Null
+  // while a fresh pairing is still in flight.
+  token: string | null;
+  // Human label shown in the list. Provisional until the server relays the
+  // producer's advertised name (e.g. "Figma Plugin macOS").
+  name: string;
+  status: ConnectionStatus;
+  // Figma preview share token relayed by the producer, if any — lets the row
+  // offer "Open preview".
+  previewToken?: string;
+  // What kind of producer paired with us, relayed at (re)establish. Absent on
+  // older producers — fall back to inferring from `previewToken` (see
+  // `connectionType`).
+  producerType?: ProducerType;
+  // `figma.root.name`, relayed by the Figma plugin. Absent for browsers and
+  // older plugins.
+  figmaProjectName?: string;
+  // User-edited label. Takes precedence over the relayed name so a rename isn't
+  // overwritten by `connection_restored` on the next reconnect.
+  customName?: string;
+  createdAt: number;
+}
+
+export interface PersistedConnection {
+  id: string;
+  token: string;
+  name: string;
+  previewToken?: string;
+  producerType?: ProducerType;
+  figmaProjectName?: string;
+  customName?: string;
+  createdAt?: number;
+}
+
+export interface ReceivedPattern {
+  found: boolean;
+  name: string;
+}
+
+// A live haptics-config update relayed by the Figma plugin over the paired
+// channel, destined for an open live preview. The payload is forwarded verbatim
+// to the WebView (figma.tsx); we only read `previewToken` (to match the right
+// open preview) here. `nonce` is monotonic so an identical repeat still
+// re-triggers the consumer effect.
+export interface PreviewUpdate {
+  kind: 'preview-haptics-diff' | 'preview-haptics-refetch' | 'preview-frame-focus';
+  previewToken?: string;
+  fromRevision?: number;
+  toRevision?: number;
+  diff?: unknown;
+  // Set only on 'preview-frame-focus': the top-level frame the designer focused,
+  // which the open live preview should present, plus its human-readable name for
+  // the preview's "current screen" indicator.
+  nodeId?: string;
+  frameName?: string;
+  nonce: number;
+}
+
+// Identity a QR/deep link carries up front, ahead of the server relay.
+export interface AddByCodeOptions {
+  name?: string;
+  previewToken?: string;
+  producerType?: ProducerType;
+}
+
+// Narrowed to the JSON values PostHog accepts.
+export type Track = (event: string, properties?: Record<string, string | number | boolean>) => void;
+
+// What kind of producer a connection is. Prefer the relayed `producerType`;
+// fall back to the presence of a preview token (only the Figma plugin sends one).
+export function connectionType(c: Connection): ProducerType {
+  return c.producerType ?? (c.previewToken ? 'figma' : 'browser');
+}
+
+// The label to show in the list: a user rename wins, then the Figma project
+// name, then the producer-advertised name.
+export function connectionDisplayName(c: Connection): string {
+  return c.customName?.trim() || c.figmaProjectName || c.name;
+}

--- a/PulsarApp/src/connections/useDeepLinkPairing.ts
+++ b/PulsarApp/src/connections/useDeepLinkPairing.ts
@@ -1,0 +1,40 @@
+import * as Linking from 'expo-linking';
+import { useEffect, useRef } from 'react';
+
+import type { AddByCodeOptions, Track } from './types';
+
+// Deep links carrying a pairing `code` (`pulsarapp://connect?code=…` or the
+// unified `pulsarapp://figma?token=…&code=…`) add a connection. The `token` for
+// the preview is consumed separately by the Figma route.
+export function useDeepLinkPairing(
+  addByCode: (code: string, opts?: AddByCodeOptions) => void,
+  track: Track,
+) {
+  const lastUrl = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handle = (url: string) => {
+      if (!url || lastUrl.current === url) return;
+      lastUrl.current = url;
+
+      const { queryParams } = Linking.parse(url);
+      const code = queryParams?.code;
+      if (!code) return;
+
+      // A `token` means this is the unified Figma link — capture it as the
+      // connection's preview token + Figma type so the row reopens the preview.
+      const previewToken = queryParams?.token?.toString();
+      addByCode(code.toString(), {
+        name: queryParams?.name?.toString(),
+        ...(previewToken ? { previewToken, producerType: 'figma' as const } : {}),
+      });
+      track('deep_link_connection_initiated', { has_code: true });
+    };
+
+    const sub = Linking.addEventListener('url', ({ url }) => handle(url));
+    Linking.getInitialURL().then((url) => {
+      if (url) handle(url);
+    });
+    return () => sub.remove();
+  }, [addByCode, track]);
+}

--- a/PulsarApp/src/connections/useForegroundReconnect.ts
+++ b/PulsarApp/src/connections/useForegroundReconnect.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+
+// Calls `onForeground` once per background → active transition.
+export function useForegroundReconnect(onForeground: () => void) {
+  const appState = useRef(AppState.currentState);
+
+  // Read through a ref so a re-created callback doesn't re-subscribe.
+  const handler = useRef(onForeground);
+  handler.current = onForeground;
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (appState.current.match(/inactive|background/) && next === 'active') {
+        handler.current();
+      }
+      appState.current = next;
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/PulsarApp/src/connections/useLiveSockets.ts
+++ b/PulsarApp/src/connections/useLiveSockets.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { SOCKET_SERVER_URL } from '@/constants/Connection';
+
+import type { ConnectionStatus } from './types';
+
+const PING_INTERVAL_MS = 25_000;
+const CONNECT_TIMEOUT_MS = 15_000;
+
+export type OpenKind = 'new' | 'reuse';
+
+// One live socket + its timers per connection id, kept out of React state so
+// socket churn doesn't trigger re-renders.
+interface LiveSocket {
+  socket: WebSocket;
+  ping: ReturnType<typeof setInterval> | null;
+  timeout: ReturnType<typeof setTimeout> | null;
+}
+
+interface Callbacks {
+  onStatus: (id: string, status: ConnectionStatus) => void;
+  onMessage: (id: string, raw: string) => void;
+  onFailed: (id: string, kind: OpenKind) => void;
+}
+
+function clearTimers(entry: LiveSocket) {
+  if (entry.ping) clearInterval(entry.ping);
+  if (entry.timeout) clearTimeout(entry.timeout);
+}
+
+export function useLiveSockets({ onStatus, onMessage, onFailed }: Callbacks) {
+  const live = useRef<Map<string, LiveSocket>>(new Map());
+
+  // Read callbacks through a ref so a re-created callback never forces
+  // `openSocket` to change identity (and with it every effect that depends on it).
+  const cbRef = useRef<Callbacks>({ onStatus, onMessage, onFailed });
+  cbRef.current = { onStatus, onMessage, onFailed };
+
+  const teardown = useCallback((id: string) => {
+    const entry = live.current.get(id);
+    if (!entry) return;
+    clearTimers(entry);
+    entry.socket.onopen = null;
+    entry.socket.onmessage = null;
+    entry.socket.onerror = null;
+    entry.socket.onclose = null;
+    try {
+      entry.socket.close(1000);
+    } catch {
+      // already closing/closed
+    }
+    live.current.delete(id);
+  }, []);
+
+  const open = useCallback(
+    (id: string, kind: OpenKind, value: string) => {
+      teardown(id);
+      const query =
+        kind === 'new'
+          ? `type=receiver&action=new_connection&code=${encodeURIComponent(value)}`
+          : `type=receiver&action=reuse_connection&token=${encodeURIComponent(value)}`;
+      const socket = new WebSocket(`${SOCKET_SERVER_URL}?${query}`);
+      const entry: LiveSocket = { socket, ping: null, timeout: null };
+      live.current.set(id, entry);
+      cbRef.current.onStatus(id, 'connecting');
+
+      // Ignore handlers from a socket that has already been replaced.
+      const isCurrent = () => live.current.get(id)?.socket === socket;
+
+      entry.timeout = setTimeout(() => {
+        if (!isCurrent()) return;
+        socket.close();
+        cbRef.current.onStatus(id, 'error');
+      }, CONNECT_TIMEOUT_MS);
+
+      socket.onopen = () => {
+        if (entry.timeout) {
+          clearTimeout(entry.timeout);
+          entry.timeout = null;
+        }
+        cbRef.current.onStatus(id, 'waiting');
+        entry.ping = setInterval(() => {
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: 'ping' }));
+          }
+        }, PING_INTERVAL_MS);
+      };
+
+      socket.onmessage = (event) => {
+        if (typeof event.data === 'string') cbRef.current.onMessage(id, event.data);
+      };
+
+      socket.onerror = () => {
+        if (!isCurrent()) return;
+        cbRef.current.onStatus(id, 'error');
+        cbRef.current.onFailed(id, kind);
+      };
+
+      socket.onclose = (e) => {
+        if (!isCurrent()) return;
+        clearTimers(entry);
+        live.current.delete(id);
+        // Clean close (e.g. backgrounded) → offline and reconnectable; an
+        // unclean close means the attempt failed.
+        cbRef.current.onStatus(id, e.code === 1000 ? 'offline' : 'error');
+      };
+    },
+    [teardown],
+  );
+
+  const isOpen = useCallback((id: string) => {
+    const entry = live.current.get(id);
+    return (
+      !!entry &&
+      (entry.socket.readyState === WebSocket.OPEN ||
+        entry.socket.readyState === WebSocket.CONNECTING)
+    );
+  }, []);
+
+  const sockets = live;
+  useEffect(
+    () => () => {
+      for (const [, entry] of sockets.current) {
+        clearTimers(entry);
+        entry.socket.onclose = null;
+        try {
+          entry.socket.close();
+        } catch {
+          // already closing/closed
+        }
+      }
+      sockets.current.clear();
+    },
+    [sockets],
+  );
+
+  return useMemo(() => ({ open, teardown, isOpen }), [open, teardown, isOpen]);
+}

--- a/PulsarApp/src/connections/useReceivedNotice.ts
+++ b/PulsarApp/src/connections/useReceivedNotice.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ReceivedPattern } from './types';
+
+const NOTICE_MS = 1200;
+
+// The transient "preset received" banner: set on every hit, auto-cleared shortly
+// after the last one.
+export function useReceivedNotice() {
+  const [lastReceived, setLastReceived] = useState<ReceivedPattern | null>(null);
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const notify = useCallback((found: boolean, name: string) => {
+    setLastReceived({ found, name });
+    if (timeout.current) clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => setLastReceived(null), NOTICE_MS);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (timeout.current) clearTimeout(timeout.current);
+    },
+    [],
+  );
+
+  return { lastReceived, notify };
+}


### PR DESCRIPTION
## Why

`PulsarApp/contexts/ConnectionsContext.tsx` had grown to ~570 lines that mixed socket lifecycle, wire-message semantics, persistence, deep-link pairing and app-state handling in a single file — with a ~100-line `onmessage` closure at its centre. Hard to read, hard to change safely.

## What changed

Internals moved to `PulsarApp/src/connections/`, split by concern:

| File | Owns |
|---|---|
| `types.ts` | The `Connection`/`PreviewUpdate` shapes plus `connectionType`/`connectionDisplayName` |
| `storage.ts` | Storage keys, the legacy-token migration, load/persist |
| `serverMessages.ts` | What each server frame *means* (established/restored/broadcast), free of React |
| `useLiveSockets.ts` | Socket lifecycle: open, keepalive ping, connect timeout, teardown |
| `useReceivedNotice.ts` | The transient "preset received" banner and its timer |
| `useForegroundReconnect.ts` | The background → active transition |
| `useDeepLinkPairing.ts` | Parsing `pulsarapp://…?code=` links |

The provider drops to ~230 lines of mostly wiring. The main win: socket *lifecycle* and message *semantics* are no longer interleaved — `handleServerMessage` is a flat switch over an explicit handler surface (`patchConnection`, `notify`, `playPreset`, `emitPreviewUpdate`, `track`), so it's readable and testable without a WebSocket.

`contexts/ConnectionsContext.tsx` stays the public entry and re-exports every type and helper it exported before, so **none of the six consumers changed** (`app/(tabs)/index.tsx`, `figma.tsx`, `editConnectionModal.tsx`, `ConnectionRow`, `ConnectionList`, `NowPlayingToast`).

## Reviewer notes

Behaviour is meant to be unchanged. Two things worth a close look:

- **One real seam.** The preview-token fallback previously read the `Connection` captured when the socket opened; the id-based lookup goes through the connections ref, which is a render behind right after `addByCode`. `addByCode` now updates that ref alongside `setConnections` so a broadcast that beats the re-render still resolves the token.
- The `posthog?.capture` calls are consolidated behind a `track` callback typed to PostHog's JSON-only property values — the old `Record<string, unknown>` wouldn't typecheck through the new boundary.

## Testing

`tsc --noEmit` reports nothing for these files, and `expo lint` is unchanged from baseline (34 problems / 21 errors — the `Cannot access refs during render` and `global` errors are pre-existing patterns elsewhere in the repo).

**Not exercised at runtime** — that needs a full RN build on a device/simulator. Pairing, reconnect-on-foreground, and Figma live preview are the flows to smoke before merging.