### PR TITLE
fix(flutter): name the iOS podspec after the pub package (pulsar_haptics)

### DIFF
--- a/.github/workflows/_build-ios-flutter.yml
+++ b/.github/workflows/_build-ios-flutter.yml
@@ -43,20 +43,17 @@ jobs:
           fi
 
       # Why we point the path dep at a uniquely-named symlink instead of
-      # `iOS/Pulsar` directly. Flutter 3.44.1's plugin SPM integration
-      # mirrors the plugin under `<App>/ios/Flutter/ephemeral/Packages/
-      # .packages/pulsar` — the *podspec* name (`flutter/pulsar/ios/
-      # pulsar.podspec` is named `pulsar`), not the Dart name
-      # (`pulsar_haptics`). Pointing the path dep at `iOS/Pulsar`
-      # collides with that symlink's last path component on macOS's
-      # case-insensitive filesystem under SPM tools-5.9: SPM derives
-      # the same identity `pulsar` from both and reports a self-cycle
+      # `iOS/Pulsar` directly. Flutter's plugin SPM integration mirrors
+      # the plugin under `<App>/ios/Flutter/ephemeral/Packages/
+      # .packages/<plugin>`, which was `pulsar` while the podspec was:
+      # SPM then derived the identity `pulsar` from `iOS/Pulsar` too on
+      # macOS's case-insensitive filesystem and reported a self-cycle
       # with the misleading "cyclic dependency between packages
       # FlutterGeneratedPluginSwiftPackage -> pulsar_haptics ->
-      # pulsar_haptics requires tools-version 6.0 or later" wording.
-      # The `name:` alias on the dep isn't honored as a tie-breaker
-      # under tools-5.9. Route through `$RUNNER_TEMP/pulsar-sdk-source`
-      # so the resolved path ends in a unique component.
+      # pulsar_haptics requires tools-version 6.0 or later" wording
+      # (the `name:` alias is no tie-breaker under tools-5.9). The
+      # mirror is `pulsar_haptics` now, so keep the symlink only as a
+      # guard against the next name that collides.
       - name: Patch plugin SPM dep to local iOS/Pulsar sources
         env:
           PULSAR_ABS_PATH: ${{ github.workspace }}/iOS/Pulsar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ pulsar/
 
 The iOS and Android SDKs are standalone native libraries. The React Native (Turbo Module) and Flutter (method-channel plugin) SDKs each ship a thin bridge and consume the published native artifacts rather than vendoring a copy of the native sources:
 
-- **iOS:** the bridge podspec (`react-native/react-native-pulsar/Pulsar.podspec`, `flutter/pulsar/ios/pulsar.podspec`) depends on the published `Pulsar-haptics` CocoaPod by default. For local development in the example app, set `USE_LOCAL_PULSAR_IOS=1` before `pod install` to use `iOS/Pulsar/` instead.
+- **iOS:** the bridge podspec (`react-native/react-native-pulsar/Pulsar.podspec`, `flutter/pulsar/ios/pulsar_haptics.podspec`) depends on the published `Pulsar-haptics` CocoaPod by default. For local development in the example app, set `USE_LOCAL_PULSAR_IOS=1` before `pod install` to use `iOS/Pulsar/` instead.
 - **Android:** the bridge Gradle module (`react-native/react-native-pulsar/android/build.gradle`, `flutter/pulsar/android/build.gradle.kts`) depends on the published `com.swmansion:pulsar` Maven artifact by default. For local development, set `USE_LOCAL_PULSAR_ANDROID=1` to compile against `Android/Pulsar/src/main/java/` instead.
 
 The Kotlin Multiplatform SDK (`kmp/Pulsar/library`) follows the same convention on Android:

--- a/flutter/PulsarApp/ios/Podfile
+++ b/flutter/PulsarApp/ios/Podfile
@@ -28,7 +28,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  # No `use_frameworks!`: CocoaPods compares module names case-insensitively, so
+  # the `pulsar_haptics` pod collides with `Pulsar-haptics`'s `Pulsar_haptics`.
+  # Re-enable once the native pod declares `s.module_name = 'Pulsar'`.
 
   if ENV['USE_LOCAL_PULSAR_IOS'] == '1'
     Pod::UI.puts 'Using local Pulsar-haptics pod from iOS/Pulsar'.green

--- a/flutter/PulsarApp/ios/Podfile.lock
+++ b/flutter/PulsarApp/ios/Podfile.lock
@@ -1,22 +1,29 @@
 PODS:
   - Flutter (1.0.0)
-  - pulsar (0.0.1):
+  - Pulsar-haptics (1.1.2)
+  - pulsar_haptics (0.0.3):
     - Flutter
+    - Pulsar-haptics (= 1.1.2)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - pulsar (from `.symlinks/plugins/pulsar/ios`)
+  - pulsar_haptics (from `.symlinks/plugins/pulsar_haptics/ios`)
+
+SPEC REPOS:
+  trunk:
+    - Pulsar-haptics
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  pulsar:
-    :path: ".symlinks/plugins/pulsar/ios"
+  pulsar_haptics:
+    :path: ".symlinks/plugins/pulsar_haptics/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  pulsar: 9bed0645c2937650a3252df9ed531e52730f572f
+  Pulsar-haptics: 1adbf9d10edc35c68aa03c0871cc6b9f2217d121
+  pulsar_haptics: 254e582a25ef6b02586aa6df058892c000db3987
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: 64ff3ed00f29d41c4253cb06bf23da3065a98024
 
 COCOAPODS: 1.16.2

--- a/flutter/pulsar/ios/pulsar_haptics.podspec
+++ b/flutter/pulsar/ios/pulsar_haptics.podspec
@@ -1,12 +1,15 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint pulsar.podspec` to validate before publishing.
+# Run `pod lib lint pulsar_haptics.podspec` to validate before publishing.
+#
+# File name and `s.name` must stay equal to the pub package name — Flutter
+# derives both the podspec path it looks for and the module it imports from it.
 #
 pulsar_ios_pod_version = ENV['PULSAR_IOS_POD_VERSION'] || '1.1.2' # pulsar-sync:flutter-pulsar-ios
 
 Pod::Spec.new do |s|
-  s.name             = 'pulsar'
-  s.version          = '0.0.1'
+  s.name             = 'pulsar_haptics'
+  s.version          = '0.0.3' # pulsar-sync:flutter-version
   s.summary          = 'Rich haptic feedback for Flutter with presets, pattern playback, and realtime control.'
   s.description      = <<-DESC
 Pulsar gives you 150+ ready-to-play haptic presets, a pattern composer for fully custom

--- a/scripts/sync-sdk-versions.mjs
+++ b/scripts/sync-sdk-versions.mjs
@@ -38,7 +38,8 @@ const markedVersions = [
   { file: 'kmp/Pulsar/library/build.gradle.kts', key: 'kmp-version', version: versions.kmp.version },
   { file: 'kmp/Pulsar/library/build.gradle.kts', key: 'kmp-pulsar-android', version: versions.kmp.pulsarCore.androidMavenVersion },
   { file: 'flutter/pulsar/pubspec.yaml', key: 'flutter-version', version: versions.flutter.version },
-  { file: 'flutter/pulsar/ios/pulsar.podspec', key: 'flutter-pulsar-ios', version: versions.flutter.pulsarCore.iosPodVersion },
+  { file: 'flutter/pulsar/ios/pulsar_haptics.podspec', key: 'flutter-version', version: versions.flutter.version },
+  { file: 'flutter/pulsar/ios/pulsar_haptics.podspec', key: 'flutter-pulsar-ios', version: versions.flutter.pulsarCore.iosPodVersion },
   { file: 'flutter/pulsar/android/build.gradle.kts', key: 'flutter-pulsar-android', version: versions.flutter.pulsarCore.androidMavenVersion },
 ];
 


### PR DESCRIPTION
Fixes #140.

## What was broken

Flutter derives the expected podspec filename from the *pub package name*, so it looked for `flutter/pulsar/ios/pulsar_haptics.podspec`. The file was named `pulsar.podspec`, and because `ios/pulsar_haptics/Package.swift` is present the tooling concluded the plugin is Swift Package Manager only. In an app that uses CocoaPods, `flutter pub get` ends with:

```
Plugin pulsar_haptics is only compatible with Swift Package Manager. Try enabling Swift Package Manager by running "flutter config --enable-swift-package-manager" or remove the plugin as a dependency.
```

The pub name also drives the module `GeneratedPluginRegistrant` imports (`@import pulsar_haptics;`), so even forcing the pod in by hand would have built it under the wrong module name.

## Changes

- Rename `flutter/pulsar/ios/pulsar.podspec` to `ios/pulsar_haptics.podspec` and set `s.name = 'pulsar_haptics'`.
- Tag `s.version` with a `pulsar-sync:flutter-version` marker so `scripts/sync-sdk-versions.mjs` keeps it in step with the pub version — it was stuck at `0.0.1` while the package is at `0.0.3`.
- Point `scripts/sync-sdk-versions.mjs` at the new filename (it would otherwise throw on the old path).
- Drop the stale references to a podspec named `pulsar` from `CONTRIBUTING.md` and from the SPM comment in `_build-ios-flutter.yml` (that workflow's symlink dance is unchanged — the mirror is now `pulsar_haptics`, but routing through a uniquely-named symlink still costs nothing).
- Example app: regenerate `ios/Podfile.lock`, and drop `use_frameworks!` — see below.

## The `use_frameworks!` caveat

CocoaPods' target validator compares product module names case-insensitively, so the plugin pod `pulsar_haptics` collides with the module CocoaPods derives for the native pod `Pulsar-haptics` (`Pulsar_haptics`):

```
[!] The 'Pods-Runner' target has frameworks with conflicting names: pulsar_haptics.
```

This only triggers when the app opts into frameworks; with the default static linkage `pod install` is fine. That's why the example app's Podfile drops `use_frameworks!`, with a comment pointing here.

The real fix is `s.module_name = 'Pulsar'` on `iOS/Pulsar/Pulsar-haptics.podspec` — that is the module name the Swift Package already exposes, and the Flutter bridge's `#if canImport(Pulsar_haptics)` / `#elseif canImport(Pulsar)` shim already accepts both — but it only takes effect once a native pod carrying it is published, so I left it out. Happy to fold it in if you'd rather ship both together.

## Verification

Flutter 3.44.0, Xcode 26.5, CocoaPods 1.16.2, on `flutter/PulsarApp`.

With SPM disabled (`flutter config --no-enable-swift-package-manager`), which is the configuration from the issue:

- `flutter pub get` — succeeds (fails on `main` with the error above)
- `pod install` — installs `Flutter`, `Pulsar-haptics (1.1.2)`, `pulsar_haptics (0.0.3)`
- `flutter build ios --debug --no-codesign --simulator` — builds

With SPM enabled, `flutter build ios --debug --no-codesign --simulator` still builds, so the CI path in `_build-ios-flutter.yml` is unaffected. `node scripts/sync-sdk-versions.mjs` runs clean and leaves the tree unchanged.

## Not included

The CI guard suggested in the issue. The Flutter iOS job in `test-build-apps.yml` is `workflow_dispatch`-only and goes through SPM, so adding a CocoaPods cell (SPM off, `pub get` + `pod install`) is a dispatcher-shape decision I'd rather leave to you — say the word and I'll add it here.

Unrelated drift I noticed while in here: the Flutter plugin pins `Pulsar-haptics` at `1.1.2` while `sdk-versions.json` lists iOS `1.2.0`. Left untouched.
