### PR TITLE
fix(react-native): prefer bundled type declarations

### DIFF
--- a/react-native/react-native-pulsar/package.json
+++ b/react-native/react-native-pulsar/package.json
@@ -6,9 +6,9 @@
   "types": "./lib/typescript/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/typescript/src/index.d.ts",
       "source": "./src/index.tsx",
       "react-native": "./src/index.tsx",
-      "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
     "./jest-mock": "./jest-mock.js",


### PR DESCRIPTION
## Summary

Hi team, loving your work on this package 💕 We have had to patch a very minor issue with our pnpm global virtual store setup, so I thought I'd whip up a PR to fix it upstream too.

### Why?

Expo includes react-native when TypeScript resolves package exports. Pulsar currently lists react-native before types, so TypeScript selects the library’s source files instead of its bundled declarations. This often goes unnoticed when dependencies are hoisted, but pnpm’s global virtual store exposes TS7016 errors because Pulsar’s source cannot access the consumer’s @types/react. Listing types first fixes type resolution without changing the code Metro loads at runtime.

### What this does

Prefer the bundled TypeScript declarations before Pulsar's `source` and `react-native` export conditions.

## Test plan

- [x] Minimal Expo 56 consumer with pnpm global virtual store: published 1.6.1 fails; patched package passes
- [x] React Native package build
- [x] Jest: 2 suites passed, 4 tests passed, 1 todo
- [ ] Package typecheck: current `main` fails on duplicate declarations in `src/__tests__/jest-mock.test.tsx`
- [ ] Package lint: current `main` reports existing Jest-global and formatting errors
