### PR TITLE
Add Pulsar Studio to the docs landing page

### DIFF
--- a/docs/src/components/landing/StudioSection/StudioSection.module.scss
+++ b/docs/src/components/landing/StudioSection/StudioSection.module.scss
@@ -1,0 +1,135 @@
+.section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 40px;
+  width: 100%;
+  box-sizing: border-box;
+
+  @media (max-width: 1024px) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 30px;
+  }
+
+  @media (max-width: 768px) {
+    gap: 20px;
+  }
+}
+
+.left {
+  flex: 1;
+
+  @media (max-width: 1024px) {
+    width: 100%;
+  }
+}
+
+.highlights {
+  list-style: none;
+  margin: 24px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  gap: 10px 28px;
+
+  @media (max-width: 1024px) {
+    justify-content: center;
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+    justify-content: stretch;
+  }
+
+  li {
+    position: relative;
+    padding-left: 24px;
+    font-size: var(--font-size-sm);
+    color: var(--color-primary);
+
+    // Checkmark bullet.
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.15em;
+      width: 15px;
+      height: 15px;
+      background-color: var(--color-primary);
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E") center / contain no-repeat;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E") center / contain no-repeat;
+
+      @media (max-width: 1024px) {
+        display: none;
+      }
+    }
+
+    @media (max-width: 1024px) {
+      padding-left: 0;
+    }
+  }
+}
+
+.actions {
+  margin-top: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+
+  @media (max-width: 1024px) {
+    justify-content: center;
+  }
+}
+
+.right {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+// ── Editor preview card ──────────────────────────────────────────────────────
+.preview {
+  width: 100%;
+  max-width: 420px;
+  background-color: var(--color-blue-10);
+  border: 2px solid var(--color-blue-50);
+  border-radius: 8px;
+  box-shadow: -6px 6px 0 var(--color-blue-50);
+  overflow: hidden;
+}
+
+.previewBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 2px solid var(--color-blue-50);
+
+  .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: var(--color-blue-50);
+  }
+
+  .previewTitle {
+    margin-left: 8px;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary);
+  }
+}
+
+.previewBody {
+  padding: 28px 24px;
+  background-color: #fbfeff;
+}
+
+.wave {
+  display: block;
+  width: 100%;
+  height: auto;
+}

--- a/docs/src/components/landing/StudioSection/StudioSection.tsx
+++ b/docs/src/components/landing/StudioSection/StudioSection.tsx
@@ -1,0 +1,80 @@
+import { Button } from '../Button/Button';
+import { SectionHeader } from '../SectionHeader/SectionHeader';
+import styles from './StudioSection.module.scss';
+import { BASE_PATH } from '../../../../config';
+
+const NAVY = '#001A72';
+
+// What Studio lets you do — short labels echoing the Studio landing feature grid.
+const highlights = [
+  'Design patterns from scratch',
+  'Tweak existing presets',
+  'Generate haptics from audio',
+  'Match your Lottie animations',
+  'Preview on real devices',
+  'Export production-ready code',
+];
+
+// Static preview of the Studio editor: an editable-looking haptic waveform with
+// draggable nodes, in the Pulsar navy line-art style.
+const WAVE_XS = [10, 46, 82, 118, 154, 190, 226];
+const WAVE_YS = [70, 40, 58, 22, 52, 34, 64];
+const WAVE_NODES = [1, 3, 5];
+
+function StudioPreview() {
+  const points = WAVE_XS.map((x, i) => `${x},${WAVE_YS[i]}`).join(' ');
+  return (
+    <div className={styles.preview}>
+      <div className={styles.previewBar}>
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+        <span className={styles.previewTitle}>Pulsar Studio</span>
+      </div>
+      <div className={styles.previewBody}>
+        <svg viewBox="0 0 236 92" className={styles.wave} fill="none" aria-hidden="true">
+          <polyline
+            points={points}
+            stroke={NAVY}
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          {WAVE_NODES.map((i) => (
+            <circle key={i} cx={WAVE_XS[i]} cy={WAVE_YS[i]} r="6" fill="#fff" stroke={NAVY} strokeWidth="3" />
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+export function StudioSection({ className }: { className?: string }) {
+  return (
+    <div className={`${styles.section} ${className || ''}`}>
+      <div className={styles.left}>
+        <SectionHeader
+          title="Design your own with Pulsar Studio"
+          subtitle="An all-in-one tool for designing, tweaking, and generating custom haptics - then exporting production-ready code. Currently in development."
+          align="left"
+        />
+        <ul className={styles.highlights}>
+          {highlights.map((h) => (
+            <li key={h}>{h}</li>
+          ))}
+        </ul>
+        <div className={styles.actions}>
+          <Button
+            label="Join the waitlist"
+            variant="filled"
+            url={`${BASE_PATH}/studio/#waitlist`}
+            onClick={() => window.posthog?.capture('studio_section_waitlist_clicked')}
+          />
+        </div>
+      </div>
+      <div className={styles.right}>
+        <StudioPreview />
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/landing/TopBar/TopBar.tsx
+++ b/docs/src/components/landing/TopBar/TopBar.tsx
@@ -29,6 +29,7 @@ export function TopBar() {
           <a href={`${BASE_PATH}/presets-playground/`}>Presets</a>
           <a href={`${BASE_PATH}/getting-started/`}>Getting started</a>
           <a href={`${BASE_PATH}/sdk/overview/`}>Docs</a>
+          <a href={`${BASE_PATH}/studio/`}>Studio</a>
         </div>
         <a href="https://github.com/software-mansion/pulsar" target="_blank">
           <img className={styles.gitLogo} src={logoGitHub.src} alt="GitHub" />
@@ -63,6 +64,9 @@ export function TopBar() {
               </a>
               <a href={`${BASE_PATH}/sdk/overview/`} onClick={closeMenu}>
                 Docs
+              </a>
+              <a href={`${BASE_PATH}/studio/`} onClick={closeMenu}>
+                Studio
               </a>
             </nav>
             <div className={styles.mobileMenuFooter}>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -9,6 +9,7 @@ import '../styles/index.css';
 import commonStyle from '../components/landing/common.module.scss';
 import { VisitPlayground } from '../components/landing/VisitPlayground/VisitPlayground';
 import { SdkSection } from '../components/landing/SdkSection/SdkSection';
+import { StudioSection } from '../components/landing/StudioSection/StudioSection';
 import { AppShowcase } from '../components/landing/AppShowcase/AppShowcase';
 import { Articles } from '../components/landing/Articles/Articles';
 import { Testimonials } from '../components/landing/Testimonials/Testimonials';
@@ -92,6 +93,10 @@ Presets that you can hear and feel with Live Preview." />
 
     <BasicLayout className={commonStyle.spaceTopLarge}>
       <SdkSection />
+    </BasicLayout>
+
+    <BasicLayout className={commonStyle.spaceTopLarge}>
+      <StudioSection client:visible />
     </BasicLayout>
 
     <BasicLayout className={commonStyle.spaceTopLarge}>


### PR DESCRIPTION
## What

Surfaces Pulsar Studio on the docs landing page.

- **Top nav** — adds a **Studio** link (desktop menu + mobile overlay) pointing to `/studio/`.
- **New landing section** — a dedicated Studio callout placed between the SDKs and App Showcase sections. It has a heading, a short subtitle, six one-line functionality bullets (design from scratch, tweak presets, generate from audio, match Lottie, preview on device, export code), a **Join the waitlist** CTA that deep-links to the Studio waitlist form (`/studio/#waitlist`), and a branded editor-preview card.

## Why

Studio previously had no entry point from the main docs landing page — visitors couldn't discover it or reach the waitlist without a direct URL.

## Notes for reviewers

- New component `StudioSection` follows the existing `SdkSection` two-column layout and reuses `SectionHeader` / `Button`.
- The CTA fires a `studio_section_waitlist_clicked` PostHog event.
- The checkmark bullets use `--color-primary` (navy) rather than `--color-blue-100`, because `--color-blue-100` is only defined on the Studio pages, not the landing page. If we want the studio-blue accent globally, that variable would need to be promoted into `styles/index.css`.

## Verification

Ran the docs dev server locally: nav link and CTA resolve to the correct URLs, section renders in both the two-column (desktop) and stacked (mobile) layouts, `tsc` clean on touched files, no console or build errors.