### PR TITLE
feat(android): PWM timing haptics for weak on/off actuators

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -17,6 +17,9 @@ open class RealtimePrimitiveComposer(
     private var minIntervalMs = 10L
     private var maxIntervalMs = 100L
 
+    private val pwmFallback: RealtimePwmComposer? =
+        if (engine.hasPrimitiveSupport()) null else RealtimePwmComposer(engine)
+
     init {
         if (compatibilityMode == CompatibilityMode.LIMITED_SUPPORT) {
             minIntervalMs = 60L
@@ -43,6 +46,11 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun set(amplitude: Float, frequency: Float) {
+        if (pwmFallback != null) {
+            pwmFallback.set(amplitude, frequency)
+            return
+        }
+
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
         currentIntervalMs = (minIntervalMs + (1 - frequency) * (maxIntervalMs - minIntervalMs)).toLong()
@@ -53,6 +61,11 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (pwmFallback != null) {
+            pwmFallback.playDiscrete(amplitude, frequency)
+            return
+        }
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
@@ -61,13 +74,21 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun stop() {
+        if (pwmFallback != null) {
+            pwmFallback.stop()
+            return
+        }
+
         if (!isPlaying.compareAndSet(true, false)) return
 
         handler.removeCallbacks(loopRunnable)
         engine.stop()
     }
 
-    override fun isActive(): Boolean = isPlaying.get()
+    override fun isActive(): Boolean {
+        if (pwmFallback != null) return pwmFallback.isActive()
+        return isPlaying.get()
+    }
 
     private fun loop() {
         if (!isPlaying.get() || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePwmComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePwmComposer.kt
@@ -1,0 +1,86 @@
+package com.swmansion.pulsar.composers
+
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.VibrationEffect
+import androidx.annotation.RequiresApi
+import com.swmansion.pulsar.haptics.HapticEngineWrapper
+import com.swmansion.pulsar.haptics.PwmHapticsGenerator
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.RealtimeComposable
+import java.util.concurrent.atomic.AtomicBoolean
+
+class RealtimePwmComposer(
+    private val engine: HapticEngineWrapper,
+) : RealtimeComposable {
+
+    private val pwm: PwmHapticsGenerator =
+        PwmHapticsGenerator.forActuator(engine.getMinControlPointDurationMillis())
+
+    private val isPlaying = AtomicBoolean(false)
+    @Volatile private var currentAmplitude = 0.0f
+    @Volatile private var currentFrequency = 0.0f
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val loopRunnable = Runnable { loop() }
+
+    override fun set(amplitude: Float, frequency: Float) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
+        val amp = amplitude.coerceIn(0f, 1f)
+        if (amp <= 0f) {
+            stop()
+            return
+        }
+
+        // Only mutate the target; never vibrate here, or a fast stream of set() calls would restart
+        // the pulse mid-flight and never reach the off gap.
+        currentAmplitude = amp
+        currentFrequency = frequency.coerceIn(0f, 1f)
+
+        if (!isPlaying.getAndSet(true)) {
+            loop()
+        }
+    }
+
+    override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val timings = pwm.buildImpulseTimings(
+            listOf(ConfigPoint(time = 0L, amplitude = amplitude, frequency = frequency)),
+        ) ?: return
+        engine.vibrate(VibrationEffect.createWaveform(timings, -1))
+    }
+
+    override fun stop() {
+        if (!isPlaying.compareAndSet(true, false)) return
+        handler.removeCallbacks(loopRunnable)
+        currentAmplitude = 0.0f
+        currentFrequency = 0.0f
+        engine.stop()
+    }
+
+    override fun isActive(): Boolean = isPlaying.get()
+
+    private fun loop() {
+        if (!isPlaying.get() || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
+        val shot = pwm.resolveShotWidth(currentAmplitude, capMs = pwm.maxPulseMs)
+        val pause = pwm.resolvePauseWidth(currentFrequency)
+
+        vibratePulse(shot)
+        // Next pulse a full period later: the motor is on for `shot`, then idle for `pause`.
+        handler.postDelayed(loopRunnable, shot + pause)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun vibratePulse(durationMs: Long) {
+        engine.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+    }
+}

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/HapticBuilder.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/HapticBuilder.kt
@@ -30,6 +30,9 @@ class HapticBuilder(private val engine: HapticEngineWrapper) {
 
   @RequiresApi(Build.VERSION_CODES.O)
   private fun createImpulseFallbackEffect(preset: PatternData): VibrationEffect? {
+    if (vibrationEffectsGenerator.resolvesToTimingWaveform()) {
+      return vibrationEffectsGenerator.convertToImpulseTimingWaveform(preset.discretePattern)
+    }
     val controlLine = convertToControlPoints(preset)
     return vibrationEffectsGenerator.convertToVibrationEffect(controlLine.getLinearPoints())
   }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/PwmHapticsGenerator.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/PwmHapticsGenerator.kt
@@ -1,0 +1,160 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.ControlPoint
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToLong
+
+data class PwmHapticsGenerator(
+    val minPulseMs: Long,
+    val maxPulseMs: Long,
+    val minPauseMs: Long,
+    val maxPauseMs: Long,
+) {
+
+    /**
+     * Pulse width for a given intensity. [capMs] bounds the pulse so it never outruns the room left
+     * in the segment it belongs to (a short segment cannot host a long pulse); it never shrinks the
+     * pulse below [minPulseMs], otherwise the motor would not engage.
+     */
+    fun resolveShotWidth(intensity: Float, capMs: Long): Long {
+        val clamped = intensity.coerceIn(0f, 1f)
+        val maxShot = min(maxPulseMs, max(minPulseMs, capMs))
+        return lerp(minPulseMs, maxShot, clamped)
+    }
+
+    /** Gap after a pulse for a given frequency. Higher frequency → shorter gap → denser train. */
+    fun resolvePauseWidth(frequency: Float): Long {
+        val clamped = frequency.coerceIn(0f, 1f)
+        return lerp(maxPauseMs, minPauseMs, clamped)
+    }
+
+    /**
+     * Turns a continuous control line into a PWM on/off waveform in the shape
+     * `VibrationEffect.createWaveform(timings, -1)` expects: `[off, on, off, on, …]` starting with
+     * an off segment (which may be `0`).
+     *
+     * Each control point contributes pulses at *its* intensity (pulse width) and frequency (gap
+     * width); walking a cursor across the whole timeline makes the pulse train follow the curve.
+     * Silent stretches (intensity `0`) are skipped and become gaps. Returns `null` when there is
+     * nothing playable.
+     */
+    fun buildPwmTimings(points: List<ControlPoint>): LongArray? {
+        if (points.isEmpty()) return null
+
+        val starts = LongArray(points.size)
+        var total = 0L
+        for (i in points.indices) {
+            starts[i] = total
+            total += max(0L, points[i].duration)
+        }
+        if (total <= 0L) return null
+
+        val onSpans = ArrayList<LongArray>()
+        var cursor = 0L
+        var segIndex = 0
+
+        while (cursor < total) {
+            while (
+                segIndex < points.lastIndex &&
+                cursor >= starts[segIndex] + max(0L, points[segIndex].duration)
+            ) {
+                segIndex++
+            }
+
+            val point = points[segIndex]
+            val segEnd = starts[segIndex] + max(0L, point.duration)
+
+            if (point.intensity <= 0f) {
+                // Silence — skip to the end of this stretch; it reads as a gap.
+                cursor = max(segEnd, cursor + 1L)
+                continue
+            }
+
+            val shot = resolveShotWidth(point.intensity, total - cursor)
+            val pause = resolvePauseWidth(point.sharpness)
+            val shotEnd = min(cursor + shot, total)
+
+            val last = onSpans.lastOrNull()
+            if (last != null && cursor <= last[1]) {
+                last[1] = max(last[1], shotEnd)
+            } else {
+                onSpans.add(longArrayOf(cursor, shotEnd))
+            }
+
+            cursor = shotEnd + max(1L, pause)
+        }
+
+        if (onSpans.isEmpty()) return null
+        val timings = spansToTimings(onSpans)
+        return if (hasPlayableWaveform(timings)) timings else null
+    }
+
+    /**
+     * Maps discrete impulses straight to pulses — one felt pulse per impulse, no line building in
+     * between. Intensity sets the pulse width (floored to the felt threshold); the impulse
+     * timestamps set the gaps, and each pulse is capped so it never swallows the next tap. Returns
+     * the `[off, on, off, on, …]` timing array, or `null` when empty.
+     */
+    fun buildImpulseTimings(impulses: List<ConfigPoint>): LongArray? {
+        if (impulses.isEmpty()) return null
+
+        val sorted = impulses.sortedBy { it.time }
+        val timings = ArrayList<Long>()
+        var cursor = 0L
+
+        for (i in sorted.indices) {
+            val impulse = sorted[i]
+            val start = max(cursor, max(0L, impulse.time))
+
+            val cap = if (i < sorted.lastIndex) {
+                max(minPulseMs, (sorted[i + 1].time - start) - minPauseMs)
+            } else {
+                maxPulseMs
+            }
+            val width = resolveShotWidth(impulse.amplitude, cap)
+
+            timings.add(max(0L, start - cursor))
+            timings.add(width)
+            cursor = start + width
+        }
+
+        val array = timings.toLongArray()
+        return if (hasPlayableWaveform(array)) array else null
+    }
+
+    private fun spansToTimings(onSpans: List<LongArray>): LongArray {
+        val timings = ArrayList<Long>()
+        var cursor = 0L
+        for (span in onSpans) {
+            timings.add(max(0L, span[0] - cursor))
+            timings.add(max(0L, span[1] - span[0]))
+            cursor = span[1]
+        }
+        return timings.toLongArray()
+    }
+
+    private fun hasPlayableWaveform(timings: LongArray): Boolean {
+        return timings.isNotEmpty() && timings.any { it > 0L }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_PULSE_MS = 160L
+        const val DEFAULT_MIN_PAUSE_MS = 25L
+        const val DEFAULT_MAX_PAUSE_MS = 160L
+
+        fun forActuator(minPulseMs: Long): PwmHapticsGenerator {
+            val floor = max(1L, minPulseMs)
+            return PwmHapticsGenerator(
+                minPulseMs = floor,
+                maxPulseMs = max(floor, DEFAULT_MAX_PULSE_MS),
+                minPauseMs = DEFAULT_MIN_PAUSE_MS,
+                maxPauseMs = DEFAULT_MAX_PAUSE_MS,
+            )
+        }
+
+        private fun lerp(start: Long, end: Long, amount: Float): Long =
+            (start + (end - start) * amount).roundToLong()
+    }
+}

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/VibrationEffectsGenerator.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/VibrationEffectsGenerator.kt
@@ -5,6 +5,7 @@ import android.os.VibrationEffect
 import android.os.vibrator.VibratorFrequencyProfile
 import androidx.annotation.RequiresApi
 import com.swmansion.pulsar.types.CompatibilityMode
+import com.swmansion.pulsar.types.ConfigPoint
 import com.swmansion.pulsar.types.ControlPoint
 import kotlin.collections.plus
 import kotlin.math.roundToInt
@@ -15,45 +16,61 @@ class VibrationEffectsGenerator(val engine: HapticEngineWrapper) {
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun convertToVibrationEffect(controlLine: ControlLineBuilder) : VibrationEffect? {
-        return if (
+        if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
             && engine.isEnvelopeSupported()
             && forcedCompatibilityMode >= CompatibilityMode.STANDARD_SUPPORT
         ) {
-            val points = controlLine.getLinearPoints()
-            if (engine.isFrequencyProfileSupported() && forcedCompatibilityMode == CompatibilityMode.ADVANCED_SUPPORT) {
-                convertToAdvanceEnvelope(points)
-            } else {
-                convertToBasicEnvelope(points)
-            }
+            return buildEnvelope(controlLine.getLinearPoints())
+        }
+
+        val points = controlLine.getStepsPoints()
+        return if (usesAmplitudeWaveform()) {
+            convertToAmplitudeWaveform(points)
         } else {
-            val points = controlLine.getStepsPoints()
-            if (engine.isAmplitudeSupported() && forcedCompatibilityMode >= CompatibilityMode.LIMITED_SUPPORT) {
-                convertToAmplitudeWaveform(points)
-            } else {
-                convertToTimingWaveform(points)
-            }
+            convertToPwmWaveform(points)
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun convertToVibrationEffect(points: List<ControlPoint>) : VibrationEffect? {
-        return if (
+        if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
             && engine.isEnvelopeSupported()
             && forcedCompatibilityMode >= CompatibilityMode.STANDARD_SUPPORT
         ) {
-            if (engine.isFrequencyProfileSupported() && forcedCompatibilityMode == CompatibilityMode.ADVANCED_SUPPORT) {
-                convertToAdvanceEnvelope(points)
-            } else {
-                convertToBasicEnvelope(points)
-            }
+            return buildEnvelope(points)
+        }
+
+        return if (usesAmplitudeWaveform()) {
+            convertToAmplitudeWaveform(points)
         } else {
-            if (engine.isAmplitudeSupported() && forcedCompatibilityMode >= CompatibilityMode.LIMITED_SUPPORT) {
-                convertToAmplitudeWaveform(points)
-            } else {
-                convertToTimingWaveform(points)
-            }
+            convertToPwmWaveform(points)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun convertToImpulseTimingWaveform(impulses: List<ConfigPoint>): VibrationEffect? {
+        val timings = pwmGenerator.buildImpulseTimings(impulses) ?: return null
+        return VibrationEffect.createWaveform(timings, -1)
+    }
+
+    fun resolvesToTimingWaveform(): Boolean {
+        val usesEnvelope = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA &&
+            engine.isEnvelopeSupported() &&
+            forcedCompatibilityMode >= CompatibilityMode.STANDARD_SUPPORT
+        return !usesEnvelope && !usesAmplitudeWaveform()
+    }
+
+    private fun usesAmplitudeWaveform(): Boolean =
+        engine.isAmplitudeSupported() && forcedCompatibilityMode >= CompatibilityMode.STANDARD_SUPPORT
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun buildEnvelope(points: List<ControlPoint>): VibrationEffect {
+        return if (engine.isFrequencyProfileSupported() && forcedCompatibilityMode == CompatibilityMode.ADVANCED_SUPPORT) {
+            convertToAdvanceEnvelope(points)
+        } else {
+            convertToBasicEnvelope(points)
         }
     }
 
@@ -128,28 +145,13 @@ class VibrationEffectsGenerator(val engine: HapticEngineWrapper) {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun convertToTimingWaveform(controlPoints: List<ControlPoint>): VibrationEffect? {
-        var timings = longArrayOf(0)
-        var isVibrating = false
-
-        controlPoints.forEach {
-            val duration = it.duration
-            val shouldVibrate = it.intensity > 0
-
-            if (shouldVibrate != isVibrating) {
-            timings += duration
-            isVibrating = shouldVibrate
-            } else if (timings.isNotEmpty()) {
-            timings[timings.lastIndex] += duration
-            }
-        }
-
-        if (!hasPlayableWaveform(timings)) {
-            return null
-        }
-
+    private fun convertToPwmWaveform(controlPoints: List<ControlPoint>): VibrationEffect? {
+        val timings = pwmGenerator.buildPwmTimings(controlPoints) ?: return null
         return VibrationEffect.createWaveform(timings, -1)
     }
+
+    private val pwmGenerator: PwmHapticsGenerator =
+        PwmHapticsGenerator.forActuator(engine.getMinControlPointDurationMillis())
 
     private fun hasPlayableWaveform(timings: LongArray): Boolean {
         return timings.isNotEmpty() && timings.any { it > 0L }

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PwmHapticsGeneratorTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PwmHapticsGeneratorTest.kt
@@ -1,0 +1,202 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.ControlPoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The timing-only rendering that stands in for amplitude/frequency on a bare on/off actuator.
+ *
+ * [PwmHapticsGenerator] both holds the pulse/pause profile (intensity widens the pulse, frequency
+ * shortens the gap) and turns control lines / impulses into the `[off, on, off, on, …]` array that
+ * `VibrationEffect.createWaveform(timings, -1)` wants:
+ *  - [PwmHapticsGenerator.buildPwmTimings] turns a continuous intensity/frequency line into a
+ *    pulse-width-modulated train — the fix for continuous presets flattening into one monotonous
+ *    buzz.
+ *  - [PwmHapticsGenerator.buildImpulseTimings] maps discrete impulses straight to pulses, one per
+ *    impulse, without building a line in between.
+ */
+class PwmHapticsGeneratorTest {
+
+    /** The weak-ERM profile these behaviours are tuned for (the moto g05 tier). */
+    private val generator = PwmHapticsGenerator.forActuator(
+        HapticEngineWrapper.WEAK_ACTUATOR_MIN_CONTROL_POINT_DURATION_MS,
+    )
+
+    private fun offs(timings: LongArray): List<Long> = timings.filterIndexed { i, _ -> i % 2 == 0 }
+    private fun ons(timings: LongArray): List<Long> = timings.filterIndexed { i, _ -> i % 2 == 1 }
+
+    /** Gaps between pulses — drops the leading off, which is only the start delay. */
+    private fun interiorGaps(timings: LongArray): List<Long> = offs(timings).drop(1)
+
+    // region intensity -> width, frequency -> gap
+
+    @Test
+    fun pulseWidthGrowsWithIntensity() {
+        val weak = generator.resolveShotWidth(0.0f, capMs = 500L)
+        val strong = generator.resolveShotWidth(1.0f, capMs = 500L)
+
+        assertEquals(generator.minPulseMs, weak)
+        assertEquals(generator.maxPulseMs, strong)
+        assertTrue("a stronger tap must be a wider pulse", strong > weak)
+    }
+
+    @Test
+    fun pulseNeverDropsBelowTheFeltFloor() {
+        // Even the faintest non-silent point must still spin the motor up.
+        val faint = generator.resolveShotWidth(0.01f, capMs = 500L)
+        assertTrue("pulse below the felt floor: $faint ms", faint >= generator.minPulseMs)
+    }
+
+    @Test
+    fun pulseIsCappedToTheRoomAvailable() {
+        // A short segment cannot host a long pulse, but the floor still wins over the cap.
+        assertEquals(80L, generator.resolveShotWidth(1.0f, capMs = 80L))
+        assertEquals(generator.minPulseMs, generator.resolveShotWidth(1.0f, capMs = 10L))
+    }
+
+    @Test
+    fun gapShrinksAsFrequencyRises() {
+        val slow = generator.resolvePauseWidth(0.0f)
+        val fast = generator.resolvePauseWidth(1.0f)
+
+        assertEquals(generator.maxPauseMs, slow)
+        assertEquals(generator.minPauseMs, fast)
+        assertTrue("higher frequency must pack pulses closer together", fast < slow)
+    }
+
+    @Test
+    fun actuatorFloorSetsTheMinimumPulse() {
+        val weak = PwmHapticsGenerator.forActuator(35L)
+        val fast = PwmHapticsGenerator.forActuator(12L)
+
+        assertEquals(35L, weak.minPulseMs)
+        assertEquals(12L, fast.minPulseMs)
+        assertTrue(weak.maxPulseMs >= weak.minPulseMs)
+    }
+
+    // endregion
+
+    // region discrete impulses -> pulses
+
+    @Test
+    fun mapsEachImpulseToItsOwnFeltPulse() {
+        // Stomp: three full-power taps at 0 / 75 / 150 ms.
+        val stomp = listOf(
+            ConfigPoint(time = 0L, amplitude = 1.0f, frequency = 0.3f),
+            ConfigPoint(time = 75L, amplitude = 1.0f, frequency = 0.3f),
+            ConfigPoint(time = 150L, amplitude = 1.0f, frequency = 0.3f),
+        )
+
+        val timings = generator.buildImpulseTimings(stomp)!!
+
+        val pulses = ons(timings)
+        assertEquals("one pulse per impulse, not a merged buzz", 3, pulses.size)
+        pulses.forEach {
+            assertTrue("pulse too narrow to spin up the motor: $it ms", it >= generator.minPulseMs)
+        }
+
+        val gaps = interiorGaps(timings)
+        assertEquals(2, gaps.size)
+        gaps.forEach {
+            assertTrue("gap too short to read as separate taps: $it ms", it >= generator.minPauseMs)
+        }
+    }
+
+    @Test
+    fun impulsePulseWidthTracksAmplitude() {
+        fun firstPulse(amplitude: Float): Long {
+            val impulses = listOf(
+                ConfigPoint(time = 0L, amplitude = amplitude, frequency = 0.3f),
+                ConfigPoint(time = 300L, amplitude = amplitude, frequency = 0.3f),
+            )
+            return ons(generator.buildImpulseTimings(impulses)!!).first()
+        }
+
+        assertTrue("a stronger impulse must be a wider pulse", firstPulse(1.0f) > firstPulse(0.2f))
+    }
+
+    @Test
+    fun impulseBuilderIgnoresEmptyInput() {
+        assertNull(generator.buildImpulseTimings(emptyList()))
+    }
+
+    // endregion
+
+    // region continuous line -> PWM train
+
+    @Test
+    fun continuousRunBecomesAPulseTrainNotOneBuzz() {
+        // The regression this whole change is about: a solid continuous segment used to collapse
+        // into a single on. It must now be chopped into a modulated train.
+        val timings = generator.buildPwmTimings(
+            listOf(ControlPoint(intensity = 0.5f, sharpness = 0.5f, duration = 400L)),
+        )!!
+
+        assertTrue("continuous run must pulse, got ${ons(timings)}", ons(timings).size >= 2)
+        interiorGaps(timings).forEach {
+            assertTrue("pulses must be separated by real silence: $it ms", it > 0L)
+        }
+    }
+
+    @Test
+    fun pulseWidthFollowsIntensity() {
+        val strong = generator.buildPwmTimings(
+            listOf(ControlPoint(intensity = 1.0f, sharpness = 0.5f, duration = 600L)),
+        )!!
+        val weak = generator.buildPwmTimings(
+            listOf(ControlPoint(intensity = 0.2f, sharpness = 0.5f, duration = 600L)),
+        )!!
+
+        assertTrue(
+            "higher intensity must widen the pulses",
+            ons(strong).maxOrNull()!! > ons(weak).maxOrNull()!!,
+        )
+    }
+
+    @Test
+    fun gapWidthFollowsFrequency() {
+        val dense = generator.buildPwmTimings(
+            listOf(ControlPoint(intensity = 0.5f, sharpness = 1.0f, duration = 600L)),
+        )!!
+        val sparse = generator.buildPwmTimings(
+            listOf(ControlPoint(intensity = 0.5f, sharpness = 0.0f, duration = 600L)),
+        )!!
+
+        assertTrue(
+            "higher frequency must pack the pulses closer together",
+            interiorGaps(dense).maxOrNull()!! < interiorGaps(sparse).maxOrNull()!!,
+        )
+    }
+
+    @Test
+    fun silentStretchesBecomeGaps() {
+        val timings = generator.buildPwmTimings(
+            listOf(
+                ControlPoint(intensity = 0.3f, sharpness = 1.0f, duration = 60L),
+                ControlPoint(intensity = 0.0f, sharpness = 0.0f, duration = 200L),
+                ControlPoint(intensity = 0.3f, sharpness = 1.0f, duration = 60L),
+            ),
+        )!!
+
+        assertTrue(
+            "the 200 ms silence must read as a long gap, got offs ${offs(timings)}",
+            offs(timings).maxOrNull()!! >= 150L,
+        )
+    }
+
+    @Test
+    fun pwmBuilderRejectsNothingToPlay() {
+        assertNull(generator.buildPwmTimings(emptyList()))
+        assertNull(
+            generator.buildPwmTimings(
+                listOf(ControlPoint(intensity = 0.0f, sharpness = 0.0f, duration = 100L)),
+            ),
+        )
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## What & why

On **timing-only Android actuators** — no amplitude control, no composition primitives (a bare on/off motor, e.g. a weak ERM like the moto g05) — Pulsar collapsed every signal to a single on/off run. Continuous presets and realtime finger motion came out as **one monotonous buzz** with no intensity or frequency variation.

This ports the web `PatternComposer`'s **PWM model** to the Android SDK: on such hardware, both missing axes are simulated purely with timings — **pulse width tracks intensity**, **gap width tracks frequency** (higher frequency = shorter gap = denser train). Floors are tuned to the felt threshold measured on the reference ERM (~35 ms; a 20 ms pulse isn't felt).

Scope: **Android SDK only** (`Android/Pulsar`). No behavior change for devices with amplitude/envelope/primitive support.

## Changes

- **`PwmHapticsGenerator`** (new, pure `data class`): the duty-cycle model (`resolveShotWidth` / `resolvePauseWidth`) plus the timing builders — `buildPwmTimings` (continuous line → PWM train, follows the intensity/frequency curve, silence → gap) and `buildImpulseTimings` (discrete → one felt pulse per impulse, no line building). Pure, so unit-testable without a device.
- **`VibrationEffectsGenerator`**: the timing-only branch now emits a PWM duty-cycle waveform instead of collapsing to on/off. Amplitude gate tightened `>= LIMITED_SUPPORT` → `>= STANDARD_SUPPORT` so `forceHapticsSupportLevel(LIMITED_SUPPORT)` reaches the PWM path for testing on capable phones. Exposes `resolvesToTimingWaveform()`.
- **`HapticBuilder`**: the impulse-only fallback maps each impulse straight to one felt pulse (`convertToImpulseTimingWaveform`) on timing-only devices; keeps the existing linear→amplitude path for amplitude-capable-but-no-primitive devices.
- **Realtime**: `RealtimePrimitiveComposer` (what a weak device is already assigned) now holds a `pwmFallback = if (engine.hasPrimitiveSupport()) null else RealtimePwmComposer(engine)` and delegates all `RealtimeComposable` methods to it when the motor can't play primitives — i.e. **PWM only kicks in when there's no better option**; it is *not* a selectable strategy. `RealtimePwmComposer` is Handler-driven: `set()` only updates the target amp/freq while a self-scheduled loop fires one pulse per period, so dragging a finger reshapes the train without restarting it mid-pulse (a repeating waveform re-issued every frame would never reach the off gap and would read as a continuous buzz).

Presets, preset composer, and realtime all reach PWM on weak hardware.

## Testing

- New pure JUnit suite `PwmHapticsGeneratorTest` (14 tests): intensity→width, frequency→gap, felt-floor, continuous run becomes a pulse train (not one buzz), silence→gap, one-pulse-per-impulse with preserved rhythm.
- `./gradlew :Pulsar:testDebugUnitTest` is green except one **pre-existing** failure on `main` unrelated to this change: `ImpulseCompositionHapticBuilderTest.keepsEveryImpulseADistinctFullPowerPulse` (peak builder yields a 34 ms pulse, 1 ms under the 35 ms floor — a rounding regression from an earlier 40→35 constant change).

### Reviewer notes
- Physical perception can't be unit-tested; the timing math is covered by the pure builders, and the composer wiring is thin. Realtime PWM was drag-verified on the moto g05.
- **Coupling caveat** inherent to on/off-only hardware: intensity maps to duty cycle and frequency to the gap, so raising frequency (shorter gap) also nudges perceived strength up slightly.