### PR TITLE
fix(android): keep impulse fallback pulse at the weak-actuator floor

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/PeakLineBuilder.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/PeakLineBuilder.kt
@@ -40,13 +40,13 @@ class PeakLineBuilder(private val minTransitionDuration: Long = 15L) {
     }
 
     private fun peakTiming(time: Long): List<Long> {
-        val slopeDuration = (minTransitionDuration * 0.75).toLong()
-        val peakDuration = (minTransitionDuration * 0.25).toLong()
+        val halfPeakDuration = (minTransitionDuration * 0.25 / 2).toLong()
+        val slopeDuration = minTransitionDuration - 2 * halfPeakDuration
         return listOf(
-            time - slopeDuration - peakDuration / 2,
-            time - peakDuration / 2,
-            time + peakDuration / 2,
-            time + peakDuration / 2 + 1L,
+            time - slopeDuration - halfPeakDuration,
+            time - halfPeakDuration,
+            time + halfPeakDuration,
+            time + halfPeakDuration + 1L,
         )
     }
 }


### PR DESCRIPTION
## What

Fixes an integer-rounding regression in `PeakLineBuilder.peakTiming` that made the impulse-only fallback pulse **34 ms** wide instead of the required **35 ms** — one ms under the weak-actuator floor.

## Why it matters

This path is the amplitude-capable-but-no-primitive fallback. Each impulse is fattened into a `slope-up + flat-peak` pulse. The *felt* pulse is the continuous ON run the motor sees — `slopeDuration + peakDuration` — and it must be `>= WEAK_ACTUATOR_MIN_CONTROL_POINT_DURATION_MS` (35 ms) or a sluggish ERM/LRA (e.g. moto g05) never spins up and the tap is silent.

`peakTiming` split the 35 ms budget 75/25 and floored each half **independently**:

```
floor(0.75 × 35) = 26   (slope)
floor(0.25 × 35) =  8   (peak)
26 + 8           = 34   ← 1 ms short
```

`0.75 + 0.25 = 1.0` in math, but `floor(26.25) + floor(8.75) = 34` — the double-floor throws away the fractional 1 ms. It was latent at the old value of 40 (`30 + 10 = 40`) and surfaced when `WEAK_ACTUATOR_MIN_CONTROL_POINT_DURATION_MS` dropped `40 → 35`.

## The fix

Derive the slope from the already-halved peak instead of flooring both pieces separately:

```kotlin
val halfPeakDuration = (minTransitionDuration * 0.25 / 2).toLong()
val slopeDuration = minTransitionDuration - 2 * halfPeakDuration
```

The emitted ON run is then `(min − 2×half) + 2×half = min` **exactly**, for any value and regardless of how the division rounds — so the pulse can never fall under the floor again. At 35 ms: `half = 4`, `slope = 27`, pulse = `27 + 8 = 35`. The pulse shape is preserved; the leading edge just moves 1 ms earlier.

## Testing

`./gradlew :Pulsar:testDebugUnitTest` — all green, including:
- `ImpulseCompositionHapticBuilderTest.keepsEveryImpulseADistinctFullPowerPulse` (previously failing)
- `quantizedPathWouldFlattenTheImpulsesIntoASmear` (exercises the 15 ms path — unaffected)

## Note for reviewers

Genuinely timing-only devices no longer use this path — they go through `VibrationEffectsGenerator.convertToImpulseTimingWaveform`. This fix targets the amplitude-capable-but-no-primitive fallback only.