### PR TITLE
test: unit tests + CI for native iOS & Android SDKs (with fixes)

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -1,0 +1,46 @@
+name: Test Android SDK
+
+# Runs the Android Pulsar library's JVM unit tests on any change to the SDK
+# sources (Android/Pulsar/**). These are plain JUnit tests that exercise the
+# pure haptics logic (line builders, quantizer, PWM, impulse composition) and
+# run on the JVM without an emulator.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Android/Pulsar/**'
+      - '.github/workflows/test-android-sdk.yml'
+  pull_request:
+    paths:
+      - 'Android/Pulsar/**'
+      - '.github/workflows/test-android-sdk.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run Pulsar library unit tests
+        working-directory: Android/PulsarApp
+        run: ./gradlew :Pulsar:testDebugUnitTest
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-unit-test-report
+          path: Android/Pulsar/build/reports/tests/testDebugUnitTest
+          if-no-files-found: ignore

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -1,0 +1,65 @@
+name: Test iOS SDK
+
+# Runs the iOS Pulsar Swift Package test suite on any change to the SDK
+# sources (iOS/Pulsar/**). The package imports UIKit, so it cannot be built
+# for the macOS host — the tests must run against an iOS Simulator via
+# xcodebuild. On the simulator CHHapticEngine reports haptics unsupported, so
+# the suite covers construction, data transforms, line/curve geometry, preset
+# resolution/caching and audio buffer rendering (not real haptic playback).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'iOS/Pulsar/**'
+      - '.github/workflows/test-ios-sdk.yml'
+  pull_request:
+    paths:
+      - 'iOS/Pulsar/**'
+      - '.github/workflows/test-ios-sdk.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Resolve an available iPhone simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available \
+            | grep -E "iPhone [0-9]+" \
+            | grep -oE "[0-9A-F]{8}-[0-9A-F-]{27}" \
+            | head -1)
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found on the runner." >&2
+            xcrun simctl list devices available >&2
+            exit 1
+          fi
+          echo "Using simulator $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      - name: Run Pulsar package tests
+        working-directory: iOS/Pulsar
+        run: |
+          xcodebuild test \
+            -scheme Pulsar \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -skipPackagePluginValidation \
+            -resultBundlePath TestResults.xcresult
+
+      - name: Upload test result bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-results
+          path: iOS/Pulsar/TestResults.xcresult
+          if-no-files-found: ignore

--- a/Android/Pulsar/build.gradle.kts
+++ b/Android/Pulsar/build.gradle.kts
@@ -41,6 +41,12 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    testOptions {
+        unitTests {
+            // Robolectric needs the Android resources/manifest available to unit tests.
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -49,6 +55,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     testImplementation(libs.junit)
+    testImplementation("org.robolectric:robolectric:4.14.1")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     implementation(libs.kotlinx.serialization.json)

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/ControlLineBuilder.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/haptics/ControlLineBuilder.kt
@@ -73,8 +73,8 @@ class ControlLineBuilder(val configLine: ConfigLineBuilder) {
 
             points.add(
                 ControlPoint(
-                    intensity = amplitudeArea / duration,
-                    sharpness = frequencyArea / duration,
+                    intensity = (amplitudeArea / duration).coerceIn(0f, 1f),
+                    sharpness = (frequencyArea / duration).coerceIn(0f, 1f),
                     duration = duration,
                 )
             )
@@ -91,7 +91,13 @@ class ControlLineBuilder(val configLine: ConfigLineBuilder) {
             if (i > 0) {
                 duration = point.time - configLine.points[i - 1].time
             }
-            points.add(ControlPoint(point.amplitude, point.frequency, duration))
+            points.add(
+                ControlPoint(
+                    point.amplitude.coerceIn(0f, 1f),
+                    point.frequency.coerceIn(0f, 1f),
+                    duration,
+                )
+            )
         }
         return points
     }

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/RobolectricPulsarTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/RobolectricPulsarTest.kt
@@ -1,0 +1,67 @@
+package com.swmansion.pulsar
+
+import android.os.Vibrator
+import com.swmansion.pulsar.types.CompatibilityMode
+import com.swmansion.pulsar.types.RealtimeComposerStrategy
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric smoke coverage of the top-level [Pulsar] façade — construction of the whole object
+ * graph (engine, audio simulator, composers) and its delegating public API. None of this is
+ * reachable from plain-JVM tests because the constructor needs a real [android.content.Context] and
+ * [Vibrator].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RobolectricPulsarTest {
+
+    private fun pulsar(): Pulsar {
+        val app = RuntimeEnvironment.getApplication()
+        shadowOf(app.getSystemService(Vibrator::class.java)).setHasVibrator(true)
+        return Pulsar(app)
+    }
+
+    @Test
+    fun constructsAndReportsACompatibilityMode() {
+        assertNotNull(pulsar().hapticSupport())
+    }
+
+    @Test
+    fun exposesAPatternComposer() {
+        assertNotNull(pulsar().getPatternComposer())
+    }
+
+    @Test
+    fun cachesTheRealtimeComposer() {
+        val p = pulsar()
+        val a = p.getRealtimeComposer()
+        val b = p.getRealtimeComposer()
+        assertSame(a, b)
+    }
+
+    @Test
+    fun rebuildsTheRealtimeComposerWhenAStrategyIsForced() {
+        val composer = pulsar().getRealtimeComposer(RealtimeComposerStrategy.PRIMITIVE_TICK)
+        assertNotNull(composer)
+    }
+
+    @Test
+    fun delegatingCallsAreSafe() {
+        val p = pulsar()
+        // None of these should throw when driven against the Robolectric device.
+        p.enableHaptics(false)
+        p.enableHaptics(true)
+        p.enableSound(false)
+        p.forceHapticsSupportLevel(CompatibilityMode.LIMITED_SUPPORT)
+        p.enableImpulseCompositionMode(false)
+        p.enableImpulseCompositionMode(true)
+        p.stopHaptics()
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ConfigLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ConfigLineBuilderTest.kt
@@ -1,0 +1,59 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ValuePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [ConfigLineBuilder] fuses the independent amplitude and frequency lines onto a single, shared,
+ * strictly-increasing timeline — sampling both lines at every timestamp either line mentions.
+ */
+class ConfigLineBuilderTest {
+
+    private fun valueLine(vararg points: Pair<Long, Float>) = ValueLineBuilder().apply {
+        points.forEach { pushPoint(ValuePoint(it.first, it.second)) }
+    }
+
+    @Test
+    fun unionsAndSortsTimestampsFromBothLines() {
+        val amplitude = valueLine(0L to 0f, 100L to 1f)
+        val frequency = valueLine(0L to 0.5f, 50L to 0.5f, 100L to 0.5f)
+
+        val config = ConfigLineBuilder(amplitude, frequency)
+
+        assertEquals(listOf(0L, 50L, 100L), config.points.map { it.time })
+    }
+
+    @Test
+    fun samplesEachLineAtEveryTimestamp() {
+        val amplitude = valueLine(0L to 0f, 100L to 1f)
+        val frequency = valueLine(0L to 0.5f, 50L to 0.5f, 100L to 0.5f)
+
+        val config = ConfigLineBuilder(amplitude, frequency)
+        val mid = config.points.first { it.time == 50L }
+
+        assertEquals("amplitude interpolated at the frequency-only timestamp", 0.5f, mid.amplitude, 1e-6f)
+        assertEquals("frequency sampled exactly", 0.5f, mid.frequency, 1e-6f)
+    }
+
+    @Test
+    fun deduplicatesSharedTimestamps() {
+        val amplitude = valueLine(0L to 0f, 50L to 0.5f, 100L to 1f)
+        val frequency = valueLine(0L to 0.3f, 50L to 0.3f, 100L to 0.3f)
+
+        val config = ConfigLineBuilder(amplitude, frequency)
+
+        assertEquals(3, config.points.size)
+        // Strictly increasing — the invariant getLinearPoints relies on for positive durations.
+        val times = config.points.map { it.time }
+        assertEquals(times.sorted(), times)
+        assertTrue(times.zipWithNext().all { (a, b) -> b > a })
+    }
+
+    @Test
+    fun emptyLinesProduceNoPoints() {
+        val config = ConfigLineBuilder(ValueLineBuilder(), ValueLineBuilder())
+        assertTrue(config.points.isEmpty())
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ControlLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ControlLineBuilderTest.kt
@@ -86,6 +86,22 @@ class ControlLineBuilderTest {
     }
 
     @Test
+    fun quantizerAreaAveragesARisingRampIntoIncreasingBuckets() {
+        // Exercises the trapezoidal averaging (averageValuesInSegment): a 0→1 ramp must yield
+        // monotonically increasing bucket intensities, each near the bucket's midpoint value.
+        val line = controlLine(
+            amplitude = listOf(0L to 0f, 1000L to 1f),
+            frequency = listOf(0L to 0f, 1000L to 1f),
+        )
+
+        val intensities = line.getStepsPoints().map { it.intensity }
+
+        assertEquals("ramp buckets must be sorted ascending", intensities.sortedBy { it }, intensities)
+        assertTrue("ramp should start faint", intensities.first() < 0.1f)
+        assertTrue("ramp should end near full", intensities.last() > 0.9f)
+    }
+
+    @Test
     fun emptyConfigProducesNoStepPoints() {
         val line = ControlLineBuilder(ConfigLineBuilder(ValueLineBuilder(), ValueLineBuilder()))
         assertTrue(line.getStepsPoints().isEmpty())

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ControlLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ControlLineBuilderTest.kt
@@ -1,0 +1,122 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ValuePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [ControlLineBuilder] turns the fused config line into the [com.swmansion.pulsar.types.ControlPoint]
+ * stream the effect generators consume, in two flavours:
+ *  - [ControlLineBuilder.getLinearPoints] — one control point per config point, duration = the gap
+ *    to the previous point.
+ *  - [ControlLineBuilder.getStepsPoints] — a fixed ~13 Hz quantizer that area-averages amplitude and
+ *    frequency into evenly-spaced buckets (the path that sluggish LRAs can actually follow).
+ */
+class ControlLineBuilderTest {
+
+    private fun valueLine(vararg points: Pair<Long, Float>) = ValueLineBuilder().apply {
+        points.forEach { pushPoint(ValuePoint(it.first, it.second)) }
+    }
+
+    private fun controlLine(
+        amplitude: List<Pair<Long, Float>>,
+        frequency: List<Pair<Long, Float>>,
+    ): ControlLineBuilder {
+        val amp = ValueLineBuilder().apply { amplitude.forEach { pushPoint(ValuePoint(it.first, it.second)) } }
+        val freq = ValueLineBuilder().apply { frequency.forEach { pushPoint(ValuePoint(it.first, it.second)) } }
+        return ControlLineBuilder(ConfigLineBuilder(amp, freq))
+    }
+
+    // region getLinearPoints
+
+    @Test
+    fun linearPointsUseGapsToThePreviousPointAsDuration() {
+        val line = controlLine(
+            amplitude = listOf(0L to 0f, 50L to 0.5f, 100L to 1f),
+            frequency = listOf(0L to 0.3f, 100L to 0.3f),
+        )
+
+        val points = line.getLinearPoints()
+
+        assertEquals(3, points.size)
+        assertEquals(listOf(1L, 50L, 50L), points.map { it.duration })
+        assertEquals(listOf(0f, 0.5f, 1f), points.map { it.intensity })
+        points.forEach { assertEquals(0.3f, it.sharpness, 1e-6f) }
+    }
+
+    @Test
+    fun firstLinearPointDurationIsFlooredToOne() {
+        // First config point at time 0 → maxOf(1, 0) == 1, never 0.
+        val line = controlLine(
+            amplitude = listOf(0L to 0.4f, 10L to 0.4f),
+            frequency = listOf(0L to 0.4f, 10L to 0.4f),
+        )
+        assertEquals(1L, line.getLinearPoints().first().duration)
+    }
+
+    @Test
+    fun emptyConfigProducesNoLinearPoints() {
+        val line = ControlLineBuilder(ConfigLineBuilder(ValueLineBuilder(), ValueLineBuilder()))
+        assertTrue(line.getLinearPoints().isEmpty())
+    }
+
+    // endregion
+
+    // region getStepsPoints
+
+    @Test
+    fun quantizesIntoFixedWidthBucketsThatCoverTheWholeTimeline() {
+        // Constant 0.5 line over 1000ms. 13 buckets of 76ms + a 12ms remainder = 1000ms.
+        val line = controlLine(
+            amplitude = listOf(0L to 0.5f, 1000L to 0.5f),
+            frequency = listOf(0L to 0.5f, 1000L to 0.5f),
+        )
+
+        val points = line.getStepsPoints()
+
+        assertEquals(1000L, points.sumOf { it.duration })
+        assertEquals(76L, points.first().duration)
+        assertEquals(12L, points.last().duration)
+        // A flat input must stay flat after averaging.
+        points.forEach {
+            assertEquals(0.5f, it.intensity, 1e-4f)
+            assertEquals(0.5f, it.sharpness, 1e-4f)
+        }
+    }
+
+    @Test
+    fun emptyConfigProducesNoStepPoints() {
+        val line = ControlLineBuilder(ConfigLineBuilder(ValueLineBuilder(), ValueLineBuilder()))
+        assertTrue(line.getStepsPoints().isEmpty())
+    }
+
+    @Test
+    fun clampsOutOfRangeAmplitudeAndFrequencyToUnitRange() {
+        // Regression: preset data outside [0,1] must be clamped before the effect generator, which
+        // otherwise scales intensity past a motor's 0..255 range.
+        val line = controlLine(
+            amplitude = listOf(0L to 2.0f, 100L to 2.0f),
+            frequency = listOf(0L to -0.5f, 100L to -0.5f),
+        )
+
+        (line.getLinearPoints() + line.getStepsPoints()).forEach {
+            assertTrue("intensity out of range: ${it.intensity}", it.intensity in 0f..1f)
+            assertTrue("sharpness out of range: ${it.sharpness}", it.sharpness in 0f..1f)
+        }
+        // The over-range amplitude clamps to the ceiling, the negative frequency to the floor.
+        assertEquals(1f, line.getLinearPoints().first().intensity, 0f)
+        assertEquals(0f, line.getLinearPoints().first().sharpness, 0f)
+    }
+
+    @Test
+    fun everyStepDurationIsAtLeastOne() {
+        val line = controlLine(
+            amplitude = listOf(0L to 0.2f, 200L to 0.9f),
+            frequency = listOf(0L to 0.1f, 200L to 0.1f),
+        )
+        assertTrue(line.getStepsPoints().all { it.duration >= 1L })
+    }
+
+    // endregion
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/HapticBuilderControlLineTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/HapticBuilderControlLineTest.kt
@@ -1,0 +1,59 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.PatternData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end coverage of the pure companion [HapticBuilder.buildControlLine], which wires the whole
+ * line-builder pipeline (value → peak → config → control) for a preset without needing a device.
+ * This is the seam the existing impulse-fallback tests already lean on; here we exercise the
+ * continuous and mixed shapes.
+ */
+class HapticBuilderControlLineTest {
+
+    /** A triangular continuous envelope: silent → full at 500ms → silent at 1000ms. */
+    private val continuousPreset = PatternData(
+        rawContinuousPattern = listOf(
+            listOf(listOf(0f, 0f), listOf(500f, 1f), listOf(1000f, 0f)),
+            listOf(listOf(0f, 0.5f), listOf(1000f, 0.5f)),
+        ),
+        rawDiscretePattern = listOf(),
+    )
+
+    @Test
+    fun continuousEnvelopeSurvivesAsLinearPoints() {
+        val line = HapticBuilder.buildControlLine(continuousPreset, 15L)
+        val points = line.getLinearPoints()
+
+        assertEquals(listOf(0f, 1f, 0f), points.map { it.intensity })
+        assertEquals(listOf(1L, 500L, 500L), points.map { it.duration })
+        points.forEach { assertEquals(0.5f, it.sharpness, 1e-6f) }
+    }
+
+    @Test
+    fun continuousEnvelopeQuantizesToBucketsCoveringTheTimeline() {
+        val steps = HapticBuilder.buildControlLine(continuousPreset, 15L).getStepsPoints()
+
+        assertEquals("buckets must tile the full 1000ms", 1000L, steps.sumOf { it.duration })
+        assertTrue("the ramp peak must survive quantization", steps.maxOf { it.intensity } > 0.8f)
+    }
+
+    @Test
+    fun mixedPresetMergesDiscretePeaksIntoTheContinuousLine() {
+        val mixed = PatternData(
+            rawContinuousPattern = listOf(
+                listOf(listOf(0f, 0.2f), listOf(400f, 0.2f)),
+                listOf(listOf(0f, 0.5f), listOf(400f, 0.5f)),
+            ),
+            rawDiscretePattern = listOf(listOf(200f, 1f, 0.3f)),
+        )
+
+        val points = HapticBuilder.buildControlLine(mixed, 15L).getLinearPoints()
+
+        // The flat 0.2 baseline is present, and the impulse injects a full-power peak on top.
+        assertTrue("baseline floor present", points.any { it.intensity in 0.15f..0.25f })
+        assertTrue("impulse peak present", points.any { it.intensity > 0.9f })
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ImpulseCompositionHapticBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ImpulseCompositionHapticBuilderTest.kt
@@ -77,6 +77,32 @@ class ImpulseCompositionHapticBuilderTest {
     }
 
     @Test
+    fun aPresetWithNoDiscreteEventsIsNotImpulsesOnly() {
+        val continuousOnly = PatternData(
+            rawContinuousPattern = listOf(
+                listOf(listOf(0.0f, 0.8f), listOf(100.0f, 0.0f)),
+                listOf(listOf(0.0f, 0.5f), listOf(100.0f, 0.5f)),
+            ),
+            rawDiscretePattern = listOf(),
+        )
+        assertFalse(ImpulseCompositionHapticBuilder.isImpulsesOnly(continuousOnly))
+    }
+
+    @Test
+    fun anAllZeroContinuousAmplitudeStillCountsAsImpulsesOnly() {
+        // A flat, silent continuous channel accompanying real impulses does not disqualify the
+        // impulse-only fast path — only a *non-zero* continuous amplitude does.
+        val impulsesWithSilentEnvelope = PatternData(
+            rawContinuousPattern = listOf(
+                listOf(listOf(0.0f, 0.0f), listOf(200.0f, 0.0f)),
+                listOf(listOf(0.0f, 0.5f), listOf(200.0f, 0.5f)),
+            ),
+            rawDiscretePattern = listOf(listOf(0.0f, 1.0f, 0.3f)),
+        )
+        assertTrue(ImpulseCompositionHapticBuilder.isImpulsesOnly(impulsesWithSilentEnvelope))
+    }
+
+    @Test
     fun keepsEveryImpulseADistinctFullPowerPulse() {
         val points = impulseFallbackPoints(stomp)
 

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PeakLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PeakLineBuilderTest.kt
@@ -1,0 +1,93 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.ValuePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [PeakLineBuilder] expands each discrete impulse into a 4-point "peak" on the continuous line:
+ * rise from the baseline to the impulse value, a short plateau, then an near-instant fall back to
+ * the baseline. The peak width is driven by `minTransitionDuration` (the per-device minimum a motor
+ * can follow).
+ */
+class PeakLineBuilderTest {
+
+    private fun baseline(vararg points: Pair<Long, Float>) = ValueLineBuilder().apply {
+        points.forEach { pushPoint(ValuePoint(it.first, it.second)) }
+    }
+
+    @Test
+    fun expandsAnImpulseIntoFourTimedPoints() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val impulse = listOf(ConfigPoint(time = 100L, amplitude = 1f, frequency = 0.3f))
+
+        val line = builder.convertToContinuousPatternOfAmplitude(impulse, baseline())
+
+        // half = (15 * 0.25 / 2) = 1; slope = 15 - 2 = 13 → offsets [-14, -1, +1, +2].
+        assertEquals(listOf(86L, 99L, 101L, 102L), line.points.map { it.time })
+        assertEquals(listOf(0f, 1f, 1f, 0f), line.points.map { it.value })
+    }
+
+    @Test
+    fun plateauCarriesAmplitudeForTheAmplitudeVariant() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val impulse = listOf(ConfigPoint(time = 100L, amplitude = 0.7f, frequency = 0.3f))
+
+        val line = builder.convertToContinuousPatternOfAmplitude(impulse, baseline())
+        // The two middle (plateau) points carry the amplitude.
+        assertEquals(0.7f, line.points[1].value, 1e-6f)
+        assertEquals(0.7f, line.points[2].value, 1e-6f)
+    }
+
+    @Test
+    fun plateauCarriesFrequencyForTheFrequencyVariant() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val impulse = listOf(ConfigPoint(time = 100L, amplitude = 0.7f, frequency = 0.3f))
+
+        val line = builder.convertToContinuousPatternOfFrequency(impulse, baseline())
+        assertEquals(0.3f, line.points[1].value, 1e-6f)
+        assertEquals(0.3f, line.points[2].value, 1e-6f)
+    }
+
+    @Test
+    fun risesFromAndReturnsToTheBaselineValue() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val flatBaseline = baseline(0L to 0.2f, 300L to 0.2f)
+        val impulse = listOf(ConfigPoint(time = 100L, amplitude = 1f, frequency = 0.3f))
+
+        val line = builder.convertToContinuousPatternOfAmplitude(impulse, flatBaseline)
+        assertEquals("rise starts at the baseline", 0.2f, line.points.first().value, 1e-6f)
+        assertEquals("fall returns to the baseline", 0.2f, line.points.last().value, 1e-6f)
+    }
+
+    @Test
+    fun widerTransitionDurationMakesAWiderPeak() {
+        val impulse = listOf(ConfigPoint(time = 200L, amplitude = 1f, frequency = 0.3f))
+        val narrow = PeakLineBuilder(15L).convertToContinuousPatternOfAmplitude(impulse, baseline())
+        val wide = PeakLineBuilder(35L).convertToContinuousPatternOfAmplitude(impulse, baseline())
+
+        val narrowSpan = narrow.points.last().time - narrow.points.first().time
+        val wideSpan = wide.points.last().time - wide.points.first().time
+        assertTrue("a larger minTransitionDuration must widen the peak", wideSpan > narrowSpan)
+    }
+
+    @Test
+    fun emitsFourPointsPerImpulse() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val impulses = listOf(
+            ConfigPoint(time = 0L, amplitude = 1f, frequency = 0.3f),
+            ConfigPoint(time = 500L, amplitude = 1f, frequency = 0.3f),
+        )
+        val line = builder.convertToContinuousPatternOfAmplitude(impulses, baseline())
+        assertEquals(8, line.points.size)
+    }
+
+    @Test
+    fun emptyPatternProducesEmptyLine() {
+        val builder = PeakLineBuilder(minTransitionDuration = 15L)
+        val line = builder.convertToContinuousPatternOfAmplitude(emptyList(), baseline())
+        assertTrue(line.points.isEmpty())
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PwmHapticsGeneratorEdgeTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/PwmHapticsGeneratorEdgeTest.kt
@@ -1,0 +1,87 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.ControlPoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Boundary / clamping coverage for [PwmHapticsGenerator] that complements the behavioural
+ * `PwmHapticsGeneratorTest`: out-of-range inputs, degenerate actuator floors, and the null
+ * "nothing to play" contract.
+ */
+class PwmHapticsGeneratorEdgeTest {
+
+    private val generator = PwmHapticsGenerator.forActuator(
+        HapticEngineWrapper.WEAK_ACTUATOR_MIN_CONTROL_POINT_DURATION_MS, // 35ms
+    )
+
+    // region clamping
+
+    @Test
+    fun shotWidthClampsIntensityToRange() {
+        assertEquals(generator.minPulseMs, generator.resolveShotWidth(-0.5f, capMs = 500L))
+        assertEquals(
+            generator.resolveShotWidth(1.0f, capMs = 500L),
+            generator.resolveShotWidth(2.0f, capMs = 500L),
+        )
+    }
+
+    @Test
+    fun pauseWidthClampsFrequencyToRange() {
+        assertEquals(generator.maxPauseMs, generator.resolvePauseWidth(-1f))
+        assertEquals(generator.minPauseMs, generator.resolvePauseWidth(5f))
+    }
+
+    @Test
+    fun capBelowFloorCollapsesToTheFloor() {
+        // A segment too short to host even the minimum pulse still yields the floor, never 0.
+        assertEquals(generator.minPulseMs, generator.resolveShotWidth(1.0f, capMs = 20L))
+    }
+
+    // endregion
+
+    // region forActuator floors
+
+    @Test
+    fun forActuatorNeverAllowsAZeroOrNegativeFloor() {
+        assertEquals(1L, PwmHapticsGenerator.forActuator(0L).minPulseMs)
+        assertEquals(1L, PwmHapticsGenerator.forActuator(-5L).minPulseMs)
+    }
+
+    @Test
+    fun forActuatorKeepsMaxAtLeastAsLargeAsMin() {
+        val slow = PwmHapticsGenerator.forActuator(500L)
+        assertEquals(500L, slow.minPulseMs)
+        assertTrue(slow.maxPulseMs >= slow.minPulseMs)
+    }
+
+    // endregion
+
+    // region null "nothing to play" contract + output shape
+
+    @Test
+    fun pwmReturnsNullForEmptyAllSilentOrZeroDuration() {
+        assertNull(generator.buildPwmTimings(emptyList()))
+        assertNull(generator.buildPwmTimings(listOf(ControlPoint(0f, 0f, 100L))))
+        assertNull(generator.buildPwmTimings(listOf(ControlPoint(0.5f, 0.5f, 0L))))
+    }
+
+    @Test
+    fun impulseTimingsSortAndClampNegativeTimes() {
+        val impulses = listOf(
+            ConfigPoint(time = 100L, amplitude = 1f, frequency = 0.3f),
+            ConfigPoint(time = -50L, amplitude = 1f, frequency = 0.3f),
+        )
+
+        val timings = generator.buildImpulseTimings(impulses)!!
+
+        assertEquals("waveform must be [off, on, …] pairs", 0, timings.size % 2)
+        assertTrue("no negative timings", timings.all { it >= 0L })
+        assertEquals("leading gap clamps the negative start to 0", 0L, timings.first())
+    }
+
+    // endregion
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/RobolectricCompatibilityModeTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/RobolectricCompatibilityModeTest.kt
@@ -1,0 +1,63 @@
+package com.swmansion.pulsar.haptics
+
+import android.os.Vibrator
+import com.swmansion.pulsar.types.CompatibilityMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric coverage of `HapticEngineWrapper.getRealCompatibilityMode()` — the real device
+ * capability probe (Vibrator amplitude control + SDK level) that plain JVM tests can't reach.
+ * These pin the "system-specific" tiering the whole SDK branches on.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RobolectricCompatibilityModeTest {
+
+    private fun engineWithAmplitudeControl(hasAmplitude: Boolean): HapticEngineWrapper {
+        val app = RuntimeEnvironment.getApplication()
+        val vibrator = app.getSystemService(Vibrator::class.java)
+        shadowOf(vibrator).setHasVibrator(true)
+        shadowOf(vibrator).setHasAmplitudeControl(hasAmplitude)
+        return HapticEngineWrapper(app)
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun amplitudeControlMapsToStandardSupport() {
+        val engine = engineWithAmplitudeControl(hasAmplitude = true)
+        assertEquals(CompatibilityMode.STANDARD_SUPPORT, engine.getRealCompatibilityMode())
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun noAmplitudeControlMapsToLimitedSupport() {
+        val engine = engineWithAmplitudeControl(hasAmplitude = false)
+        assertEquals(CompatibilityMode.LIMITED_SUPPORT, engine.getRealCompatibilityMode())
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun preRDeviceWithAmplitudeControlIsStandardSupport() {
+        val engine = engineWithAmplitudeControl(hasAmplitude = true)
+        assertEquals(CompatibilityMode.STANDARD_SUPPORT, engine.getRealCompatibilityMode())
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun preRDeviceWithoutAmplitudeControlIsLimitedSupport() {
+        val engine = engineWithAmplitudeControl(hasAmplitude = false)
+        assertEquals(CompatibilityMode.LIMITED_SUPPORT, engine.getRealCompatibilityMode())
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun amplitudeSupportReflectsTheVibrator() {
+        assertEquals(true, engineWithAmplitudeControl(hasAmplitude = true).isAmplitudeSupported())
+        assertEquals(false, engineWithAmplitudeControl(hasAmplitude = false).isAmplitudeSupported())
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/RobolectricVibrationEffectTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/RobolectricVibrationEffectTest.kt
@@ -1,0 +1,111 @@
+package com.swmansion.pulsar.haptics
+
+import android.os.Vibrator
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.PatternData
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric coverage of the real `VibrationEffect` generation pipeline
+ * (`HapticBuilder` → `VibrationEffectsGenerator` → `PwmHapticsGenerator` → framework
+ * `VibrationEffect.createWaveform`). These paths build genuine `android.os.VibrationEffect`
+ * objects, so they can only run against the framework — not the plain-JVM suites.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RobolectricVibrationEffectTest {
+
+    private fun engine(hasAmplitude: Boolean = false): HapticEngineWrapper {
+        val app = RuntimeEnvironment.getApplication()
+        val vibrator = app.getSystemService(Vibrator::class.java)
+        shadowOf(vibrator).setHasVibrator(true)
+        shadowOf(vibrator).setHasAmplitudeControl(hasAmplitude)
+        return HapticEngineWrapper(app)
+    }
+
+    private val continuousPreset = PatternData(
+        rawContinuousPattern = listOf(
+            listOf(listOf(0f, 0f), listOf(500f, 1f), listOf(1000f, 0f)),
+            listOf(listOf(0f, 0.5f), listOf(1000f, 0.5f)),
+        ),
+        rawDiscretePattern = listOf(),
+    )
+
+    private val impulsePreset = PatternData(
+        rawDiscretePattern = listOf(
+            listOf(0f, 1f, 0.3f),
+            listOf(75f, 1f, 0.3f),
+            listOf(150f, 1f, 0.3f),
+        ),
+    )
+
+    @Test
+    fun continuousPresetProducesAPwmWaveformWithoutAmplitudeControl() {
+        val effect = engine(hasAmplitude = false).getHapticBuilder().createVibrationEffect(continuousPreset)
+        assertNotNull("PWM waveform should be produced on a timing-only actuator", effect)
+    }
+
+    @Test
+    fun continuousPresetProducesAnAmplitudeWaveformWithAmplitudeControl() {
+        val effect = engine(hasAmplitude = true).getHapticBuilder().createVibrationEffect(continuousPreset)
+        assertNotNull("amplitude waveform should be produced when the actuator supports it", effect)
+    }
+
+    @Test
+    fun outOfRangeAmplitudeDoesNotThrowAtTheVibrationEffectBoundary() {
+        // Regression for the [0,1] clamp: an amplitude of 2.0 would become 510 (> the motor's 255
+        // ceiling) and VibrationEffect.createWaveform would throw. The clamp keeps it at 255.
+        val outOfRange = PatternData(
+            rawContinuousPattern = listOf(
+                listOf(listOf(0f, 2.0f), listOf(500f, 2.0f)),
+                listOf(listOf(0f, 0.5f), listOf(500f, 0.5f)),
+            ),
+            rawDiscretePattern = listOf(),
+        )
+        val effect = engine(hasAmplitude = true).getHapticBuilder().createVibrationEffect(outOfRange)
+        assertNotNull("clamped amplitude must stay within the framework's accepted range", effect)
+    }
+
+    @Test
+    fun impulseOnlyPresetProducesAnEffectViaCompositionOrFallback() {
+        // Whether the composition path succeeds or falls back to a timing waveform, a felt effect
+        // must come out.
+        val effect = engine(hasAmplitude = false).getHapticBuilder().createVibrationEffect(impulsePreset)
+        assertNotNull(effect)
+    }
+
+    @Test
+    fun impulseTimingWaveformIsBuiltFromDiscretePoints() {
+        val generator = VibrationEffectsGenerator(engine(hasAmplitude = false))
+        val effect = generator.convertToImpulseTimingWaveform(
+            listOf(
+                ConfigPoint(time = 0L, amplitude = 1f, frequency = 0.3f),
+                ConfigPoint(time = 75L, amplitude = 1f, frequency = 0.3f),
+            ),
+        )
+        assertNotNull(effect)
+    }
+
+    @Test
+    fun impulseTimingWaveformIsNullForNoImpulses() {
+        val generator = VibrationEffectsGenerator(engine(hasAmplitude = false))
+        assertNull(generator.convertToImpulseTimingWaveform(emptyList()))
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun compositionEffectIsNullBelowApi30() {
+        // Pre-R has no composition primitives, so the impulse-composition path bows out (the caller
+        // then falls back). This is the documented contract of createCompositionEffect.
+        val effect = ImpulseCompositionHapticBuilder()
+            .createCompositionEffect(impulsePreset, engine(hasAmplitude = false))
+        assertNull(effect)
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ValueLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ValueLineBuilderTest.kt
@@ -70,6 +70,16 @@ class ValueLineBuilderTest {
     }
 
     @Test
+    fun interpolatesAcrossTheCorrectSegmentWithThreePoints() {
+        // Two segments: 0→0.4 over [0,100], then 0.4→1.0 over [100,200]. Interpolation must pick
+        // the right segment either side of the knot at 100.
+        val builder = line(0L to 0f, 100L to 0.4f, 200L to 1f)
+        assertEquals(0.2f, builder.valueForX(50L), 1e-6f)   // first segment midpoint
+        assertEquals(0.4f, builder.valueForX(100L), 1e-6f)  // exact knot
+        assertEquals(0.7f, builder.valueForX(150L), 1e-6f)  // second segment midpoint
+    }
+
+    @Test
     fun singlePointLineReturnsItsValueEverywhere() {
         // A one-point line is treated as a constant — the size==1 short-circuit runs before the
         // out-of-range zeroing, so even far-away x's return the point's value.
@@ -98,6 +108,27 @@ class ValueLineBuilderTest {
         // Endpoints outside the window survive.
         assertEquals(0.2f, baseline.valueForX(0L), 1e-6f)
         assertEquals(0.2f, baseline.valueForX(100L), 1e-6f)
+    }
+
+    @Test
+    fun mergeLineHandlesMultipleConsecutiveGroups() {
+        val baseline = line(
+            0L to 0.2f, 25L to 0.2f, 50L to 0.2f, 75L to 0.2f, 100L to 0.2f,
+            125L to 0.2f, 150L to 0.2f, 175L to 0.2f, 200L to 0.2f,
+        )
+        // Two 4-point peak groups: [25,40,60,75] and [125,140,160,175].
+        val peaks = line(
+            25L to 0.2f, 40L to 1f, 60L to 1f, 75L to 0.2f,
+            125L to 0.2f, 140L to 1f, 160L to 1f, 175L to 0.2f,
+        )
+
+        baseline.mergeLine(peaks)
+
+        assertEquals("first peak", 1f, baseline.valueForX(50L), 1e-6f)
+        assertEquals("second peak", 1f, baseline.valueForX(150L), 1e-6f)
+        assertEquals("baseline between the peaks survives", 0.2f, baseline.valueForX(100L), 1e-6f)
+        assertEquals("baseline before the first peak survives", 0.2f, baseline.valueForX(0L), 1e-6f)
+        assertEquals("baseline after the last peak survives", 0.2f, baseline.valueForX(200L), 1e-6f)
     }
 
     @Test

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ValueLineBuilderTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/haptics/ValueLineBuilderTest.kt
@@ -1,0 +1,115 @@
+package com.swmansion.pulsar.haptics
+
+import com.swmansion.pulsar.types.ValuePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * [ValueLineBuilder] is the pure geometry primitive every preset flows through: it keeps a
+ * time-sorted list of [ValuePoint]s and linearly interpolates between them. These tests pin the
+ * insertion ordering and the (deliberately asymmetric) out-of-range behaviour of `valueForX`.
+ */
+class ValueLineBuilderTest {
+
+    private fun line(vararg points: Pair<Long, Float>) = ValueLineBuilder().apply {
+        points.forEach { pushPoint(ValuePoint(it.first, it.second)) }
+    }
+
+    // region pushPoint — sorted insertion
+
+    @Test
+    fun keepsPointsSortedRegardlessOfInsertionOrder() {
+        val builder = line(0L to 0f, 100L to 1f, 50L to 0.5f, 25L to 0.25f)
+        assertEquals(listOf(0L, 25L, 50L, 100L), builder.points.map { it.time })
+    }
+
+    @Test
+    fun appendsWhenTimeIsAtOrAfterTheLast() {
+        val builder = line(0L to 0f, 100L to 1f, 100L to 0.7f)
+        assertEquals(listOf(0L, 100L, 100L), builder.points.map { it.time })
+        // Equal-to-last goes on the end, so the newest value is last.
+        assertEquals(0.7f, builder.points.last().value, 0f)
+    }
+
+    @Test
+    fun initialListSeedsThePoints() {
+        val builder = ValueLineBuilder(listOf(ValuePoint(0L, 0.1f), ValuePoint(10L, 0.2f)))
+        assertEquals(2, builder.points.size)
+        assertEquals(0.2f, builder.valueForX(10L), 0f)
+    }
+
+    // endregion
+
+    // region valueForX — interpolation and boundaries
+
+    @Test
+    fun emptyLineIsSilent() {
+        assertEquals(0f, ValueLineBuilder().valueForX(42L), 0f)
+    }
+
+    @Test
+    fun exactTimestampReturnsItsOwnValue() {
+        val builder = line(0L to 0f, 100L to 1f)
+        assertEquals(0f, builder.valueForX(0L), 0f)
+        assertEquals(1f, builder.valueForX(100L), 0f)
+    }
+
+    @Test
+    fun interpolatesLinearlyBetweenPoints() {
+        val builder = line(0L to 0f, 100L to 1f)
+        assertEquals(0.5f, builder.valueForX(50L), 1e-6f)
+        assertEquals(0.25f, builder.valueForX(25L), 1e-6f)
+    }
+
+    @Test
+    fun outsideTheRangeReadsAsSilenceForMultiPointLines() {
+        val builder = line(10L to 0.4f, 100L to 1f)
+        assertEquals("before the first point", 0f, builder.valueForX(5L), 0f)
+        assertEquals("after the last point", 0f, builder.valueForX(200L), 0f)
+    }
+
+    @Test
+    fun singlePointLineReturnsItsValueEverywhere() {
+        // A one-point line is treated as a constant — the size==1 short-circuit runs before the
+        // out-of-range zeroing, so even far-away x's return the point's value.
+        val builder = line(100L to 0.6f)
+        assertEquals(0.6f, builder.valueForX(100L), 0f)
+        assertEquals(0.6f, builder.valueForX(0L), 0f)
+        assertEquals(0.6f, builder.valueForX(9999L), 0f)
+    }
+
+    // endregion
+
+    // region mergeLine
+
+    @Test
+    fun mergeLineReplacesTheOverlappedBaselineWindow() {
+        // A flat baseline every 25ms.
+        val baseline = line(0L to 0.2f, 25L to 0.2f, 50L to 0.2f, 75L to 0.2f, 100L to 0.2f)
+        // One 4-point peak group covering [25, 75].
+        val peak = line(25L to 0.2f, 40L to 1f, 60L to 1f, 75L to 0.2f)
+
+        baseline.mergeLine(peak)
+
+        // Baseline points strictly inside [25,75] are dropped and replaced by the peak's points.
+        val peakValue = baseline.valueForX(50L)
+        assertEquals("merged window should carry the peak's plateau", 1f, peakValue, 1e-6f)
+        // Endpoints outside the window survive.
+        assertEquals(0.2f, baseline.valueForX(0L), 1e-6f)
+        assertEquals(0.2f, baseline.valueForX(100L), 1e-6f)
+    }
+
+    @Test
+    fun mergeLineAssumesGroupsOfFour() {
+        // mergeLine walks in steps of 4 and reads points[i+3]; a non-multiple-of-4 line is a
+        // programming error and throws rather than silently mis-grouping.
+        val baseline = line(0L to 0f, 100L to 0f)
+        val notAGroupOfFour = line(10L to 1f, 20L to 1f, 30L to 1f)
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            baseline.mergeLine(notAGroupOfFour)
+        }
+    }
+
+    // endregion
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/types/CompatibilityModeTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/types/CompatibilityModeTest.kt
@@ -1,0 +1,31 @@
+package com.swmansion.pulsar.types
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The SDK selects rendering strategies with ordinal comparisons like
+ * `hapticSupport() >= CompatibilityMode.STANDARD_SUPPORT` (see `Pulsar.kt`). That only behaves as
+ * intended while the enum stays ordered weakest → strongest, so pin the ordering here — reordering
+ * the constants would silently break capability gating.
+ */
+class CompatibilityModeTest {
+
+    @Test
+    fun isOrderedFromWeakestToStrongest() {
+        val expected = listOf(
+            CompatibilityMode.NO_SUPPORT,
+            CompatibilityMode.LIMITED_SUPPORT,
+            CompatibilityMode.STANDARD_SUPPORT,
+            CompatibilityMode.ADVANCED_SUPPORT,
+        )
+        assertTrue(expected.zipWithNext().all { (weaker, stronger) -> weaker < stronger })
+    }
+
+    @Test
+    fun standardSupportGateIncludesAdvancedButNotLimited() {
+        assertTrue(CompatibilityMode.ADVANCED_SUPPORT >= CompatibilityMode.STANDARD_SUPPORT)
+        assertTrue(CompatibilityMode.STANDARD_SUPPORT >= CompatibilityMode.STANDARD_SUPPORT)
+        assertTrue(CompatibilityMode.LIMITED_SUPPORT < CompatibilityMode.STANDARD_SUPPORT)
+    }
+}

--- a/Android/Pulsar/src/test/java/com/swmansion/pulsar/types/PatternDataTest.kt
+++ b/Android/Pulsar/src/test/java/com/swmansion/pulsar/types/PatternDataTest.kt
@@ -1,0 +1,68 @@
+package com.swmansion.pulsar.types
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [PatternData]'s secondary constructor is the boundary where the cross-platform "raw" pattern
+ * format (nested float arrays coming from JS / preset literals) is parsed into typed points. These
+ * tests pin that parsing and document that it is strict about shape.
+ */
+class PatternDataTest {
+
+    @Test
+    fun parsesRawContinuousAndDiscretePatterns() {
+        val data = PatternData(
+            rawContinuousPattern = listOf(
+                listOf(listOf(0f, 0.2f), listOf(100f, 0.8f)),
+                listOf(listOf(0f, 0.5f), listOf(100f, 0.5f)),
+            ),
+            rawDiscretePattern = listOf(listOf(10f, 1f, 0.3f)),
+        )
+
+        assertEquals(listOf(0L, 100L), data.continuousPattern.amplitude.map { it.time })
+        assertEquals(listOf(0.2f, 0.8f), data.continuousPattern.amplitude.map { it.value })
+        assertEquals(listOf(0.5f, 0.5f), data.continuousPattern.frequency.map { it.value })
+
+        assertEquals(1, data.discretePattern.size)
+        val impulse = data.discretePattern.single()
+        assertEquals(10L, impulse.time)
+        assertEquals(1f, impulse.amplitude, 0f)
+        assertEquals(0.3f, impulse.frequency, 0f)
+    }
+
+    @Test
+    fun defaultsToEmptyPattern() {
+        val data = PatternData()
+        assertTrue(data.continuousPattern.amplitude.isEmpty())
+        assertTrue(data.continuousPattern.frequency.isEmpty())
+        assertTrue(data.discretePattern.isEmpty())
+    }
+
+    @Test
+    fun floatTimesAreTruncatedToLongMillis() {
+        val data = PatternData(
+            rawContinuousPattern = listOf(listOf(listOf(12.9f, 0.5f)), listOf()),
+            rawDiscretePattern = listOf(),
+        )
+        assertEquals(12L, data.continuousPattern.amplitude.single().time)
+    }
+
+    @Test
+    fun rejectsContinuousPatternMissingTheFrequencyChannel() {
+        // The raw form must always carry both amplitude[0] and frequency[1] channels.
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            PatternData(rawContinuousPattern = listOf(listOf(listOf(0f, 0.5f))))
+        }
+    }
+
+    @Test
+    fun rejectsDiscretePointMissingFrequency() {
+        // Each discrete triple must be [time, amplitude, frequency].
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            PatternData(rawDiscretePattern = listOf(listOf(0f, 0.5f)))
+        }
+    }
+}

--- a/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Audio/AudioSimulator.swift
@@ -210,7 +210,7 @@ public final class AudioSimulator: NSObject, @unchecked Sendable {
 
 	private func generateContinuousAudioConfig(from data: PatternData) -> [ContinuousAudioConfig] {
 		let amplitudePoints: [ValuePoint] = data.continuousPattern.amplitude.count > 0 ? data.continuousPattern.amplitude : []
-		let frequencyPoints: [ValuePoint] = data.continuousPattern.frequency.count > 1 ? data.continuousPattern.frequency : []
+		let frequencyPoints: [ValuePoint] = data.continuousPattern.frequency.count > 0 ? data.continuousPattern.frequency : []
 
 		func normalizeFrequency(_ x: Float) -> Double {
 			return 80.0 + (230.0 - 80.0) * Double(x)

--- a/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/RealtimeComposer.swift
@@ -61,8 +61,8 @@ public class RealtimeComposer: NSObject {
     guard engine.isHapticsEnabled else { return }
     guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
 
-    let intensityParam = CHHapticEventParameter(parameterID: .hapticIntensity, value: amplitude)
-    let sharpnessParam = CHHapticEventParameter(parameterID: .hapticSharpness, value: frequency)
+    let intensityParam = CHHapticEventParameter(parameterID: .hapticIntensity, value: min(max(amplitude, 0), 1))
+    let sharpnessParam = CHHapticEventParameter(parameterID: .hapticSharpness, value: min(max(frequency, 0), 1))
     let event = CHHapticEvent(eventType: .hapticTransient, parameters: [intensityParam, sharpnessParam], relativeTime: 0)
 
     do {

--- a/iOS/Pulsar/Sources/Pulsar/Lines/ContinuousLine.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Lines/ContinuousLine.swift
@@ -7,5 +7,6 @@ public struct ContinuousLine {
   
   public mutating func reset() {
     intensityCurveLine.reset()
+    sharpnessCurveLine.reset()
   }
 }

--- a/iOS/Pulsar/Sources/Pulsar/Lines/CurveLineModifier.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Lines/CurveLineModifier.swift
@@ -10,14 +10,15 @@ public class CurveLineModifier {
   ///   - time: Time in milliseconds (ms)
   ///   - value: Normalized value (0.0 - 1.0)
   public func addPoint(time: Double, value: Float) {
+    let clampedValue = min(max(value, 0), 1)
     let timeInSeconds = time / 1000.0
     if points.isEmpty && timeInSeconds > 0 {
       points.append(
-        CHHapticParameterCurve.ControlPoint(relativeTime: 0, value: value)
+        CHHapticParameterCurve.ControlPoint(relativeTime: 0, value: clampedValue)
       )
     }
     points.append(
-      CHHapticParameterCurve.ControlPoint(relativeTime: timeInSeconds, value: value)
+      CHHapticParameterCurve.ControlPoint(relativeTime: timeInSeconds, value: clampedValue)
     )
     if timeInSeconds > maxTime {
       maxTime = timeInSeconds

--- a/iOS/Pulsar/Sources/Pulsar/Lines/DiscreteLine.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Lines/DiscreteLine.swift
@@ -17,8 +17,8 @@ public struct DiscreteLine {
     let event = CHHapticEvent(
       eventType: .hapticTransient,
       parameters: [
-        CHHapticEventParameter(parameterID: .hapticIntensity, value: intensity),
-        CHHapticEventParameter(parameterID: .hapticSharpness, value: sharpness)
+        CHHapticEventParameter(parameterID: .hapticIntensity, value: min(max(intensity, 0), 1)),
+        CHHapticEventParameter(parameterID: .hapticSharpness, value: min(max(sharpness, 0), 1))
       ],
       relativeTime: timestamp / 1000.0,
     )

--- a/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
@@ -44,11 +44,15 @@ import Foundation
     self.discretePattern = discretePattern
   }
   public init(line: [[[Double]]], bar: [[Double]]) {
+    let amplitudeRaw = line.count > 0 ? line[0] : []
+    let frequencyRaw = line.count > 1 ? line[1] : []
     self.continuousPattern = ContinuousPattern(
-      amplitude: line[0].map { ValuePoint(time: Double($0[0]), value: Float($0[1])) },
-      frequency: line[1].map { ValuePoint(time: Double($0[0]), value: Float($0[1])) }
+      amplitude: amplitudeRaw.compactMap { $0.count >= 2 ? ValuePoint(time: $0[0], value: Float($0[1])) : nil },
+      frequency: frequencyRaw.compactMap { $0.count >= 2 ? ValuePoint(time: $0[0], value: Float($0[1])) : nil }
     )
-    self.discretePattern = bar.map { DiscretePoint(time: Double($0[0]), amplitude: Float($0[1]), frequency: Float($0[2])) }
+    self.discretePattern = bar.compactMap {
+      $0.count >= 3 ? DiscretePoint(time: $0[0], amplitude: Float($0[1]), frequency: Float($0[2])) : nil
+    }
   }
 }
 

--- a/iOS/Pulsar/Tests/PulsarTests/ComposerAndAudioTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/ComposerAndAudioTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import Pulsar
+
+/// `RealtimeComposer` never actually starts on the simulator (no haptics hardware), so it should
+/// stay inactive and swallow every call without crashing.
+@MainActor
+@Suite struct RealtimeComposerTests {
+
+    @Test func staysInactiveWhenHardwareIsUnsupported() {
+        let composer = Pulsar().getRealtimeComposer()
+        #expect(composer.isActive == false)
+        composer.set(amplitude: 0.5, frequency: 0.5)
+        #expect(composer.isActive == false)
+    }
+
+    @Test func setToleratesOutOfRangeValues() {
+        // set() clamps amplitude/frequency internally; out-of-range input must not crash.
+        let composer = Pulsar().getRealtimeComposer()
+        composer.set(amplitude: 2.0, frequency: -1.0)
+        composer.set(amplitude: -5.0, frequency: 9.0)
+        #expect(composer.isActive == false)
+    }
+
+    @Test func playDiscreteAndStopAreSafeNoOps() {
+        let composer = Pulsar().getRealtimeComposer()
+        composer.playDiscrete()
+        composer.playDiscrete(amplitude: 1.0, frequency: 0.5)
+        composer.stop()
+        #expect(composer.isActive == false)
+    }
+}
+
+/// `AudioSimulator` renders PCM buffers purely (no session needed for `parsePattern`). On the
+/// simulator sound is force-enabled, so rendering yields a real buffer.
+@Suite struct AudioSimulatorTests {
+
+    private let pattern = PatternData(
+        line: [
+            [[0, 0.0], [100, 1.0], [200, 0.0]],
+            [[0, 0.5], [200, 0.5]],
+        ],
+        bar: [[0, 1.0, 0.3]]
+    )
+
+    @Test func rendersANonEmptyBufferWhenSoundIsOn() {
+        let simulator = AudioSimulator()
+        let buffer = simulator.parsePattern(from: pattern)
+        #expect(buffer != nil)
+        #expect((buffer?.frameLength ?? 0) > 0)
+    }
+
+    @Test func rendersNilWhenSoundIsDisabled() {
+        let simulator = AudioSimulator()
+        simulator.enableSound(false)
+        #expect(simulator.parsePattern(from: pattern) == nil)
+    }
+
+    @Test func rendersContinuousAudioWithASingleFrequencyPoint() {
+        // Regression: a continuous pattern with exactly one frequency point used to be dropped
+        // (count > 1 guard). It must now still render a non-empty buffer.
+        let singleFreq = PatternData(
+            line: [
+                [[0, 0.5], [200, 0.5]],
+                [[0, 0.5]],
+            ],
+            bar: []
+        )
+        let buffer = AudioSimulator().parsePattern(from: singleFreq)
+        #expect(buffer != nil)
+        #expect((buffer?.frameLength ?? 0) > 0)
+    }
+}

--- a/iOS/Pulsar/Tests/PulsarTests/LineTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/LineTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+import CoreHaptics
+@testable import Pulsar
+
+/// The curve/discrete "line" builders convert millisecond-based pattern points into CoreHaptics
+/// control points and events. Constructing those CoreHaptics value types needs no engine, so this
+/// pure geometry is fully exercisable on the simulator.
+@Suite struct LineTests {
+
+    // MARK: - CurveLineModifier
+
+    @Test func addingAPointAtTimeZeroDoesNotPrependASyntheticPoint() {
+        let curve = IntensityCurveLineModifier()
+        curve.addPoint(time: 0, value: 0.5)
+        #expect(curve.points.count == 1)
+        #expect(curve.points[0].relativeTime == 0)
+        #expect(curve.points[0].value == 0.5)
+    }
+
+    @Test func firstPointAfterTimeZeroGetsASyntheticAnchorAtZero() {
+        // A curve that starts late is anchored at t=0 with the same value so playback begins there.
+        let curve = IntensityCurveLineModifier()
+        curve.addPoint(time: 100, value: 0.5)
+
+        #expect(curve.points.count == 2)
+        #expect(curve.points[0].relativeTime == 0)
+        #expect(curve.points[0].value == 0.5)
+        #expect(abs(curve.points[1].relativeTime - 0.1) < 1e-9)
+    }
+
+    @Test func durationTracksTheMaximumTimeNotTheLastInserted() {
+        let curve = IntensityCurveLineModifier()
+        curve.addPoint(time: 100, value: 0.5)
+        curve.addPoint(time: 50, value: 0.9) // inserted out of order
+        #expect(abs(curve.getDuration() - 0.1) < 1e-9)
+    }
+
+    @Test func resetEmptiesTheCurve() {
+        let curve = IntensityCurveLineModifier()
+        curve.addPoint(time: 100, value: 0.5)
+        #expect(!curve.isEmpty)
+        curve.reset()
+        #expect(curve.isEmpty)
+        #expect(curve.getDuration() == 0)
+    }
+
+    @Test func addPointClampsOutOfRangeValuesToUnitRange() {
+        // Regression: out-of-range curve values are clamped to [0, 1] before reaching CoreHaptics.
+        let curve = IntensityCurveLineModifier()
+        curve.addPoint(time: 0, value: 2.0)
+        curve.addPoint(time: 10, value: -1.0)
+        #expect(curve.points.allSatisfy { $0.value >= 0 && $0.value <= 1 })
+        #expect(curve.points.first?.value == 1.0)
+        #expect(curve.points.contains { $0.value == 0.0 })
+    }
+
+    @Test func resetClearsBothIntensityAndSharpnessCurves() {
+        // Regression for the sharpness-accumulation bug: ContinuousLine.reset() must clear both
+        // curves, otherwise sharpness control points pile up across repeated parsePattern calls.
+        var line = ContinuousLine()
+        line.intensityCurveLine.addPoint(time: 0, value: 0.5)
+        line.sharpnessCurveLine.addPoint(time: 0, value: 0.5)
+        #expect(!line.intensityCurveLine.isEmpty)
+        #expect(!line.sharpnessCurveLine.isEmpty)
+
+        line.reset()
+
+        #expect(line.intensityCurveLine.isEmpty)
+        #expect(line.sharpnessCurveLine.isEmpty)
+    }
+
+    @Test func intensityAndSharpnessCurvesUseDistinctParameterIDs() {
+        let intensity = IntensityCurveLineModifier()
+        intensity.addPoint(time: 0, value: 0.5)
+        let sharpness = SharpnessCurveLineModifier()
+        sharpness.addPoint(time: 0, value: 0.5)
+
+        #expect(intensity.getCurve.parameterID == .hapticIntensityControl)
+        #expect(sharpness.getCurve.parameterID == .hapticSharpnessControl)
+    }
+
+    // MARK: - DiscreteLine
+
+    @Test func addEventConvertsMillisecondsToRelativeSeconds() {
+        var line = DiscreteLine()
+        line.addEvent(timestamp: 150, intensity: 0.8, sharpness: 0.4)
+        #expect(line.getEvents.count == 1)
+        #expect(abs(line.getEvents[0].relativeTime - 0.15) < 1e-9)
+    }
+
+    @Test func addEventDefaultsToFullIntensityAndSharpness() {
+        var line = DiscreteLine()
+        line.addEvent(timestamp: 0)
+        #expect(line.getEvents.count == 1)
+        // Defaults are intensity 1 / sharpness 1 — assert the event exists at t=0.
+        #expect(line.getEvents[0].relativeTime == 0)
+    }
+
+    @Test func resetClearsEvents() {
+        var line = DiscreteLine()
+        line.addEvent(timestamp: 10)
+        line.addEvent(timestamp: 20)
+        #expect(line.getEvents.count == 2)
+        line.reset()
+        #expect(line.getEvents.isEmpty)
+    }
+}

--- a/iOS/Pulsar/Tests/PulsarTests/PresetsWrapperTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/PresetsWrapperTests.swift
@@ -48,4 +48,54 @@ import Foundation
         let sameInstance = ObjectIdentifier(a) == ObjectIdentifier(b)
         #expect(!sameInstance)
     }
+
+    @Test func cacheIsEnabledByDefault() {
+        #expect(makeWrapper().isCacheEnabled() == true)
+    }
+
+    @Test func preloadingWarmsTheCacheWithTheSameInstance() throws {
+        let presets = makeWrapper()
+        presets.preloadPresetByName("Heartbeat")
+        let a = try #require(presets.getByName("Heartbeat"))
+        let b = try #require(presets.getByName("Heartbeat"))
+        let sameInstance = ObjectIdentifier(a) == ObjectIdentifier(b)
+        #expect(sameInstance)
+    }
+
+    @Test func resetCacheDropsTheCachedInstance() throws {
+        let presets = makeWrapper()
+        let before = try #require(presets.getByName("Heartbeat"))
+        presets.resetCache()
+        let after = try #require(presets.getByName("Heartbeat"))
+        // A fresh instance proves the cache was actually cleared.
+        let sameInstance = ObjectIdentifier(before) == ObjectIdentifier(after)
+        #expect(!sameInstance)
+    }
+
+    @Test func resolvesSystemPresetsByName() {
+        // System presets build a UIFeedbackGenerator in init (main-thread precondition) — safe here
+        // because the suite is @MainActor. Only constructs; does not play.
+        let presets = makeWrapper()
+        #expect(presets.getByName("SystemImpactHeavy") != nil)
+        #expect(presets.getByName("SystemNotificationError") != nil)
+        #expect(presets.getByName("SystemSelection") != nil)
+    }
+
+    /// Broad guard that the codegen name→class mapper and the public getters stay consistent:
+    /// every one of these documented names must resolve. A curated cross-section (system +
+    /// generated across categories) rather than all ~160, to keep the run fast.
+    @Test func resolvesARepresentativeSetOfPresetNames() {
+        let names = [
+            "SystemImpactLight", "SystemImpactMedium", "SystemImpactHeavy",
+            "SystemImpactSoft", "SystemImpactRigid",
+            "SystemNotificationSuccess", "SystemNotificationWarning", "SystemNotificationError",
+            "SystemSelection",
+            "Heartbeat", "DogBark", "Buzz", "Pulse", "Hammer", "Explosion",
+            "Rain", "Typewriter", "Metronome", "Zipper", "Wave",
+        ]
+        let presets = makeWrapper()
+        for name in names {
+            #expect(presets.getByName(name) != nil, "preset \(name) failed to resolve")
+        }
+    }
 }

--- a/iOS/Pulsar/Tests/PulsarTests/PresetsWrapperTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/PresetsWrapperTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import Pulsar
+
+/// Name resolution and caching in `PresetsWrapper`. Resolving a (non-system) preset only
+/// constructs it — it does not play — so this is safe on the simulator. `@MainActor` because
+/// constructing a preset walks through the engine's lifecycle bootstrap.
+@MainActor
+@Suite struct PresetsWrapperTests {
+
+    private func makeWrapper() -> PresetsWrapper {
+        PresetsWrapper(haptics: Pulsar())
+    }
+
+    @Test func resolvesAKnownPresetByName() {
+        let presets = makeWrapper()
+        #expect(presets.getByName("Heartbeat") != nil)
+    }
+
+    @Test func nameLookupIsCaseInsensitive() {
+        let presets = makeWrapper()
+        #expect(presets.getByName("heartbeat") != nil)
+        #expect(presets.getByName("HEARTBEAT") != nil)
+        #expect(presets.getByName("HeArTbEaT") != nil)
+    }
+
+    @Test func unknownNameResolvesToNil() {
+        let presets = makeWrapper()
+        #expect(presets.getByName("definitely-not-a-preset") == nil)
+    }
+
+    @Test func cachingReturnsTheSameInstanceForTheSameName() throws {
+        let presets = makeWrapper()
+        let a = try #require(presets.getByName("Heartbeat"))
+        let b = try #require(presets.getByName("heartbeat")) // same preset, different casing
+        // Compute identity outside the macro to keep the comparison off the autoclosure path.
+        let sameInstance = ObjectIdentifier(a) == ObjectIdentifier(b)
+        #expect(sameInstance)
+    }
+
+    @Test func disablingTheCacheReturnsFreshInstances() throws {
+        let presets = makeWrapper()
+        presets.enableCache(state: false)
+        #expect(presets.isCacheEnabled() == false)
+
+        let a = try #require(presets.getByName("Heartbeat"))
+        let b = try #require(presets.getByName("Heartbeat"))
+        let sameInstance = ObjectIdentifier(a) == ObjectIdentifier(b)
+        #expect(!sameInstance)
+    }
+}

--- a/iOS/Pulsar/Tests/PulsarTests/PulsarAPITests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/PulsarAPITests.swift
@@ -1,0 +1,98 @@
+import Testing
+import Foundation
+@testable import Pulsar
+
+/// Top-level façade + engine-wrapper behaviour. Runs on the iOS Simulator, where
+/// `CHHapticEngine.capabilitiesForHardware().supportsHaptics` is false — so haptics are
+/// unsupported and the engine never actually starts. That lets us verify the state machine and
+/// object graph without real hardware.
+///
+/// Marked `@MainActor` because the engine seeds its app-lifecycle cache from `UIApplication`, which
+/// must be read on the main thread.
+@MainActor
+@Suite struct PulsarAPITests {
+
+    @Test func hapticsAreUnsupportedAndUnplayableOnTheSimulator() {
+        let pulsar = Pulsar()
+        #expect(pulsar.isHapticsSupported() == false)
+        #expect(pulsar.canPlayHaptics() == false)
+    }
+
+    @Test func hapticsAreEnabledByDefaultAndToggle() {
+        let pulsar = Pulsar()
+        #expect(pulsar.isHapticsEnabled == true)
+
+        pulsar.enableHaptics(state: false)
+        #expect(pulsar.isHapticsEnabled == false)
+
+        pulsar.enableHaptics(state: true)
+        #expect(pulsar.isHapticsEnabled == true)
+    }
+
+    @Test func getPresetsReturnsACachedInstance() {
+        let pulsar = Pulsar()
+        let a = pulsar.getPresets()
+        let b = pulsar.getPresets()
+        #expect(a === b)
+    }
+
+    @Test func getRealtimeComposerReturnsACachedInstance() {
+        let pulsar = Pulsar()
+        let a = pulsar.getRealtimeComposer()
+        let b = pulsar.getRealtimeComposer()
+        #expect(a === b)
+    }
+
+    @Test func getPatternComposerReturnsAFreshInstanceEachCall() {
+        // Documents current behaviour: unlike presets/realtime, the pattern composer is not cached.
+        let pulsar = Pulsar()
+        let a = pulsar.getPatternComposer()
+        let b = pulsar.getPatternComposer()
+        #expect(a !== b)
+    }
+
+    @Test func lifecycleAndCacheCallsAreSafeWhenUnsupported() {
+        let pulsar = Pulsar()
+        // None of these should throw or crash on the simulator.
+        pulsar.enableCache(state: true)
+        pulsar.enableSound(state: false)
+        pulsar.preloadPresets(presetNames: ["Heartbeat"])
+        pulsar.clearCache()
+        pulsar.stopHaptics()
+        pulsar.shutDownEngine()
+    }
+}
+
+/// Direct coverage of `HapticEngineWrapper`'s state and null-safety on the simulator.
+@MainActor
+@Suite struct HapticEngineWrapperTests {
+
+    @Test func startsEnabledAndUnsupportedOnSimulator() {
+        let engine = HapticEngineWrapper()
+        #expect(engine.isHapticsEnabled == true)
+        #expect(engine.isHapticsSupported() == false)
+        #expect(engine.canPlayHaptics() == false)
+    }
+
+    @Test func enableHapticsTogglesState() {
+        let engine = HapticEngineWrapper()
+        engine.enableHaptics(false)
+        #expect(engine.isHapticsEnabled == false)
+        engine.enableHaptics(true)
+        #expect(engine.isHapticsEnabled == true)
+    }
+
+    @Test func cannotBuildPlayersWhenHapticsAreUnsupported() {
+        let engine = HapticEngineWrapper()
+        #expect(engine.createPlayer(pattern: nil) == nil)
+        #expect(engine.getRealtimePlayer() == nil)
+    }
+
+    @Test func stoppingOrRemovingAnUnknownPlayerIsANoOp() {
+        let engine = HapticEngineWrapper()
+        engine.stopPlayer(id: 999)
+        engine.removePlayer(id: 999)
+        engine.stopHaptics()
+        engine.shutDownEngine()
+    }
+}

--- a/iOS/Pulsar/Tests/PulsarTests/TypesTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/TypesTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import Pulsar
+
+/// Construction, parsing and Codable behaviour of the public pattern data types. These are the
+/// cross-platform wire types every preset and composer is built from.
+@Suite struct TypesTests {
+
+    @Test func valuePointStoresTimeAndValue() {
+        let point = ValuePoint(time: 120, value: 0.35)
+        #expect(point.time == 120)
+        #expect(point.value == 0.35)
+    }
+
+    @Test func discretePointStoresAllChannels() {
+        let point = DiscretePoint(time: 75, amplitude: 0.9, frequency: 0.4)
+        #expect(point.time == 75)
+        #expect(point.amplitude == 0.9)
+        #expect(point.frequency == 0.4)
+    }
+
+    @Test func patternDataFromNestedArraysMapsEveryChannel() {
+        let data = PatternData(
+            line: [
+                [[0, 0.0], [100, 1.0]],
+                [[0, 0.5], [100, 0.5]],
+            ],
+            bar: [[10, 1.0, 0.3]]
+        )
+
+        #expect(data.continuousPattern.amplitude.map { $0.time } == [0, 100])
+        #expect(data.continuousPattern.amplitude.map { $0.value } == [0.0, 1.0])
+        #expect(data.continuousPattern.frequency.map { $0.value } == [0.5, 0.5])
+
+        #expect(data.discretePattern.count == 1)
+        let impulse = data.discretePattern[0]
+        #expect(impulse.time == 10)
+        #expect(impulse.amplitude == 1.0)
+        #expect(impulse.frequency == 0.3)
+    }
+
+    @Test func patternDataFromArraysToleratesMalformedInput() {
+        // Regression: the array initializer must not trap on missing channels / short points.
+        let empty = PatternData(line: [], bar: [])
+        #expect(empty.continuousPattern.amplitude.isEmpty)
+        #expect(empty.continuousPattern.frequency.isEmpty)
+        #expect(empty.discretePattern.isEmpty)
+
+        let partial = PatternData(
+            line: [[[0, 0.5], [10]]], // second amplitude point is too short → skipped; no frequency channel
+            bar: [[0, 0.5]]           // discrete point missing frequency → skipped
+        )
+        #expect(partial.continuousPattern.amplitude.count == 1)
+        #expect(partial.continuousPattern.frequency.isEmpty)
+        #expect(partial.discretePattern.isEmpty)
+    }
+
+    @Test func patternDataIsCodableRoundTrippable() throws {
+        let original = PatternData(
+            continuousPattern: ContinuousPattern(
+                amplitude: [ValuePoint(time: 0, value: 0.2), ValuePoint(time: 100, value: 0.8)],
+                frequency: [ValuePoint(time: 0, value: 0.5)]
+            ),
+            discretePattern: [DiscretePoint(time: 50, amplitude: 1.0, frequency: 0.3)]
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PatternData.self, from: encoded)
+
+        #expect(decoded.continuousPattern.amplitude.count == 2)
+        #expect(decoded.continuousPattern.amplitude[1].value == 0.8)
+        #expect(decoded.continuousPattern.frequency.count == 1)
+        #expect(decoded.discretePattern.count == 1)
+        #expect(decoded.discretePattern[0].amplitude == 1.0)
+        #expect(decoded.discretePattern[0].frequency == 0.3)
+    }
+
+    @Test func waveformTypeRawValuesAreStable() {
+        #expect(WaveformType.sine.rawValue == "sine")
+        #expect(WaveformType.square.rawValue == "square")
+        #expect(WaveformType.triangle.rawValue == "triangle")
+        #expect(WaveformType.sawtooth.rawValue == "sawtooth")
+        #expect(WaveformType(rawValue: "triangle") == .triangle)
+        #expect(WaveformType(rawValue: "nope") == nil)
+    }
+}


### PR DESCRIPTION
## What

Adds unit-test coverage for the native **iOS** and **Android** Pulsar SDKs, wires up CI to run them on SDK changes, and fixes a handful of bugs uncovered while writing the tests.

### Tests
- **Android — 90 tests** (`./gradlew :Pulsar:testDebugUnitTest`):
  - Pure-JVM JUnit over the haptics logic: `ValueLineBuilder`, `PeakLineBuilder`, `ConfigLineBuilder`, `ControlLineBuilder`, `HapticBuilder.buildControlLine`, `PwmHapticsGenerator`, `ImpulseCompositionHapticBuilder.isImpulsesOnly`, `PatternData` parsing, `CompatibilityMode` ordering — incl. clamping, quantizer bucketing, PWM/impulse timing edge cases.
  - **Robolectric** for the framework layer that a JVM test can't reach: real `VibrationEffect` generation across device tiers (PWM vs amplitude waveform, impulse composition/fallback), `getRealCompatibilityMode()` capability→tier mapping across SDK levels, and top-level `Pulsar` façade construction/delegation.
- **iOS — 43 tests** (`xcodebuild test` on an iOS Simulator): pattern types + `Codable`, curve/discrete line geometry, `Pulsar`/`HapticEngineWrapper` state machine, `RealtimeComposer` clamping, `PresetsWrapper` resolution + caching (incl. system presets), `AudioSimulator` buffer rendering.

### CI
- `.github/workflows/test-android-sdk.yml` (ubuntu) and `test-ios-sdk.yml` (macOS), each path-filtered to its SDK (`Android/Pulsar/**` / `iOS/Pulsar/**`), on push-to-main + PR + manual dispatch.

### Bug fixes (found via the tests, each with a regression test)
- **iOS `ContinuousLine.reset()`** now also resets the sharpness curve — previously sharpness control points accumulated across repeated `parsePattern` calls on the same composer.
- **iOS `AudioSimulator`** continuous-frequency guard `count > 1` → `count > 0` (a single frequency point silently dropped continuous audio).
- **iOS `PatternData(line:bar:)`** now tolerates malformed/partial input instead of trapping on out-of-bounds indexing.
- **Clamping to [0,1]** on previously-unclamped input paths: iOS `CurveLineModifier`/`DiscreteLine`/`RealtimeComposer.playDiscrete` and Android `ControlLineBuilder` output (an out-of-range amplitude could otherwise exceed the motor's 0–255 range and make `createWaveform` throw).

## Why
The native SDKs had essentially no unit tests (placeholder only) and no CI to run them. This locks in the public/testable interface and the device-tier behavior, and guards the fixes above.

## Notes for reviewers
- Why iOS runs on a simulator: the package imports UIKit, so it can't build for the macOS host; on the simulator `CHHapticEngine` reports haptics unsupported, so tests cover construction/data/geometry/rendering, not real playback.
- Robolectric is declared inline as `testImplementation("org.robolectric:robolectric:4.14.1")` in `Android/Pulsar/build.gradle.kts` (not in the shared `PulsarApp` catalog), and being test-scoped it is **not** part of the published library POM — consumers don't get it.
- Robolectric 4.14.1 caps below API 36 (BAKLAVA), so the envelope / `VibratorFrequencyProfile` (`ADVANCED_SUPPORT`) paths remain device/instrumented-only; `@Config(sdk=[..])` targets ≤34.
- Two latent Android issues on framework-only paths were left untouched (out of scope, not unit-testable here): `VibrationEffectsGenerator`'s `frequencyProfile!!` NPE risk and `RealtimePrimitiveComposer`'s unclamped tick interval.
