### PR TITLE
test(ios): swizzled CoreHaptics mock suite for engine-interaction coverage

### DIFF
--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -47,6 +47,8 @@ jobs:
           echo "Using simulator $UDID"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
+      # Main suites — real behavior on the simulator. Excludes the CoreHaptics mock suite,
+      # which swizzles CoreHaptics process-wide and must not race the real-behavior assertions.
       - name: Run Pulsar package tests
         working-directory: iOS/Pulsar
         run: |
@@ -54,12 +56,27 @@ jobs:
             -scheme Pulsar \
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
             -skipPackagePluginValidation \
+            -skip-testing:PulsarTests/CoreHapticsMockTests \
             -resultBundlePath TestResults.xcresult
 
-      - name: Upload test result bundle
+      # CoreHaptics mock suite — swizzles CHHapticEngine to verify the wrapper's interaction with
+      # CoreHaptics. Run in isolation so the global swizzle can't affect the suites above.
+      - name: Run CoreHaptics mock suite (isolated)
+        working-directory: iOS/Pulsar
+        run: |
+          xcodebuild test \
+            -scheme Pulsar \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -skipPackagePluginValidation \
+            -only-testing:PulsarTests/CoreHapticsMockTests \
+            -resultBundlePath MockTestResults.xcresult
+
+      - name: Upload test result bundles
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ios-test-results
-          path: iOS/Pulsar/TestResults.xcresult
+          path: |
+            iOS/Pulsar/TestResults.xcresult
+            iOS/Pulsar/MockTestResults.xcresult
           if-no-files-found: ignore

--- a/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMock.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMock.swift
@@ -1,0 +1,126 @@
+import Foundation
+import CoreHaptics
+import ObjectiveC
+
+/// A swizzled stand-in for CoreHaptics so the engine wrapper's *interaction* with CHHapticEngine
+/// can be verified on the simulator (where the real engine can't initialize). The mock lets
+/// `CHHapticEngine()` "succeed", makes `capabilitiesForHardware().supportsHaptics` report true, and
+/// returns fake players that record every start/stop/sendParameters call.
+///
+/// Swizzling is process-global, so `install()`/`uninstall()` save and restore the original IMPs and
+/// the mock suite runs serialized and in isolation from the real-behavior suites.
+final class HapticMockRecorder {
+    // Test-only global state; access is serialized (mock suite is @Suite(.serialized), main thread).
+    nonisolated(unsafe) static let shared = HapticMockRecorder()
+
+    var enginesCreated = 0
+    var startCalls = 0
+    var playersCreated = 0
+    var advancedPlayersCreated = 0
+    var playerStarts = 0
+    var playerStops = 0
+    var sentParameters: [(intensity: Float, sharpness: Float)] = []
+
+    func reset() {
+        enginesCreated = 0
+        startCalls = 0
+        playersCreated = 0
+        advancedPlayersCreated = 0
+        playerStarts = 0
+        playerStops = 0
+        sentParameters.removeAll()
+    }
+}
+
+/// Fake `CHHapticPatternPlayer` — records start/stop.
+final class MockPatternPlayer: NSObject {
+    @objc func start(atTime time: TimeInterval) throws { HapticMockRecorder.shared.playerStarts += 1 }
+    @objc func stop(atTime time: TimeInterval) throws { HapticMockRecorder.shared.playerStops += 1 }
+    @objc var isMuted: Bool = false
+}
+
+/// Fake `CHHapticAdvancedPatternPlayer` — also records the dynamic parameters the realtime path sends.
+final class MockAdvancedPlayer: NSObject {
+    @objc func start(atTime time: TimeInterval) throws { HapticMockRecorder.shared.playerStarts += 1 }
+    @objc func stop(atTime time: TimeInterval) throws { HapticMockRecorder.shared.playerStops += 1 }
+    @objc var isMuted: Bool = false
+
+    @objc func sendParameters(_ parameters: [CHHapticDynamicParameter], atTime time: TimeInterval) throws {
+        var intensity: Float = .nan
+        var sharpness: Float = .nan
+        for p in parameters {
+            if p.parameterID == .hapticIntensityControl { intensity = p.value }
+            if p.parameterID == .hapticSharpnessControl { sharpness = p.value }
+        }
+        HapticMockRecorder.shared.sentParameters.append((intensity, sharpness))
+    }
+}
+
+enum CoreHapticsMock {
+    nonisolated(unsafe) private static var saved: [(AnyClass, Selector, IMP)] = []
+    nonisolated(unsafe) private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        HapticMockRecorder.shared.reset()
+
+        let engine: AnyClass = CHHapticEngine.self
+
+        // capabilitiesForHardware().supportsHaptics -> true
+        let cap = CHHapticEngine.capabilitiesForHardware() as AnyObject
+        if let capCls: AnyClass = object_getClass(cap) {
+            let supports: @convention(block) (AnyObject) -> Bool = { _ in true }
+            swizzle(capCls, NSSelectorFromString("supportsHaptics"), supports)
+        }
+
+        // -initAndReturnError:  -> return self as a shell engine
+        let initBlock: @convention(block) (AnyObject, UnsafeMutableRawPointer?) -> AnyObject? = { obj, _ in
+            HapticMockRecorder.shared.enginesCreated += 1
+            return obj
+        }
+        swizzle(engine, NSSelectorFromString("initAndReturnError:"), initBlock)
+
+        // -startAndReturnError: -> YES
+        let startBlock: @convention(block) (AnyObject, UnsafeMutableRawPointer?) -> Bool = { _, _ in
+            HapticMockRecorder.shared.startCalls += 1
+            return true
+        }
+        swizzle(engine, NSSelectorFromString("startAndReturnError:"), startBlock)
+
+        // -stopWithCompletionHandler: -> no-op
+        let stopBlock: @convention(block) (AnyObject, AnyObject?) -> Void = { _, _ in }
+        swizzle(engine, NSSelectorFromString("stopWithCompletionHandler:"), stopBlock)
+
+        // -createPlayerWithPattern:error: -> fake pattern player
+        let playerBlock: @convention(block) (AnyObject, AnyObject?, UnsafeMutableRawPointer?) -> AnyObject? = { _, _, _ in
+            HapticMockRecorder.shared.playersCreated += 1
+            return MockPatternPlayer()
+        }
+        swizzle(engine, NSSelectorFromString("createPlayerWithPattern:error:"), playerBlock)
+
+        // -createAdvancedPlayerWithPattern:error: -> fake advanced player
+        let advancedBlock: @convention(block) (AnyObject, AnyObject?, UnsafeMutableRawPointer?) -> AnyObject? = { _, _, _ in
+            HapticMockRecorder.shared.advancedPlayersCreated += 1
+            return MockAdvancedPlayer()
+        }
+        swizzle(engine, NSSelectorFromString("createAdvancedPlayerWithPattern:error:"), advancedBlock)
+    }
+
+    static func uninstall() {
+        for (cls, sel, imp) in saved.reversed() {
+            if let m = class_getInstanceMethod(cls, sel) {
+                method_setImplementation(m, imp)
+            }
+        }
+        saved.removeAll()
+        installed = false
+    }
+
+    private static func swizzle(_ cls: AnyClass, _ sel: Selector, _ block: Any) {
+        guard let m = class_getInstanceMethod(cls, sel) else { return }
+        let newImp = imp_implementationWithBlock(block)
+        let old = method_setImplementation(m, newImp)
+        saved.append((cls, sel, old))
+    }
+}

--- a/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMockTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMockTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+import CoreHaptics
+import UIKit
+@testable import Pulsar
+
+/// Verifies the engine wrapper *drives* CoreHaptics correctly, using the swizzled `CoreHapticsMock`
+/// so the real (simulator-unavailable) engine is stood in for. Serialized + isolated because the
+/// swizzle is process-global — run these via a separate `-only-testing` invocation.
+@MainActor
+@Suite(.serialized)
+struct CoreHapticsMockTests {
+
+    private func makePattern() -> CHHapticPattern? {
+        let event = CHHapticEvent(
+            eventType: .hapticTransient,
+            parameters: [CHHapticEventParameter(parameterID: .hapticIntensity, value: 1)],
+            relativeTime: 0
+        )
+        return try? CHHapticPattern(events: [event], parameters: [])
+    }
+
+    /// Builds a wrapper, runs its one-time lifecycle bootstrap, then forces the app-active state so
+    /// `canPlayHaptics()` is deterministic regardless of the test host's UIApplication state.
+    private func activeEngine(resetAfterWarmup: Bool = true) -> HapticEngineWrapper {
+        let engine = HapticEngineWrapper()
+        _ = engine.createPlayer(pattern: nil)          // trigger bootstrap/seed
+        engine.updatePlaybackAvailability(for: .active) // force active
+        if resetAfterWarmup { HapticMockRecorder.shared.reset() }
+        return engine
+    }
+
+    @Test func mockedEngineConstructsStartsAndCreatesPlayers() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine(resetAfterWarmup: false)
+        let id = engine.createPlayer(pattern: makePattern())
+
+        #expect(id != nil)
+        #expect(HapticMockRecorder.shared.enginesCreated >= 1)
+        #expect(HapticMockRecorder.shared.startCalls >= 1)
+    }
+
+    @Test func createPlayerReturnsDistinctIdsAndBuildsAPlayerEachTime() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        let a = engine.createPlayer(pattern: makePattern())
+        let b = engine.createPlayer(pattern: makePattern())
+
+        #expect(a != nil && b != nil)
+        #expect(a != b)
+        #expect(HapticMockRecorder.shared.playersCreated == 2)
+    }
+
+    @Test func registryEvictsTheOldestPlayerBeyondTheLimit() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        // playerLimit is 20; the 21st creation must evict (and stop) the oldest.
+        for _ in 0..<21 { _ = engine.createPlayer(pattern: makePattern()) }
+
+        #expect(HapticMockRecorder.shared.playersCreated == 21)
+        #expect(HapticMockRecorder.shared.playerStops >= 1)
+    }
+
+    @Test func stopHapticsStopsEveryRegisteredPlayer() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        for _ in 0..<3 { _ = engine.createPlayer(pattern: makePattern()) }
+        engine.stopHaptics()
+
+        #expect(HapticMockRecorder.shared.playerStops >= 3)
+    }
+
+    @Test func realtimeComposerActivatesAndSendsClampedParameters() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        let composer = RealtimeComposer(engine: engine)
+        composer.set(amplitude: 2.0, frequency: -1.0) // out of range
+
+        #expect(composer.isActive)
+        #expect(HapticMockRecorder.shared.advancedPlayersCreated >= 1)
+        #expect(HapticMockRecorder.shared.playerStarts >= 1)
+
+        let last = HapticMockRecorder.shared.sentParameters.last
+        #expect(last?.intensity == 1.0)   // clamped up-bound
+        #expect(last?.sharpness == 0.0)   // clamped low-bound
+    }
+
+    @Test func stopDeactivatesTheRealtimeComposer() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        let composer = RealtimeComposer(engine: engine)
+        composer.set(amplitude: 0.5, frequency: 0.5)
+        #expect(composer.isActive)
+
+        composer.stop()
+        #expect(!composer.isActive)
+        #expect(HapticMockRecorder.shared.playerStops >= 1)
+    }
+}


### PR DESCRIPTION
## What

Adds an iOS test suite that verifies the **engine wrapper's interaction with CoreHaptics** by swizzling `CHHapticEngine`, plus the CI wiring to run it safely.

On the iOS Simulator a real `CHHapticEngine` cannot initialize (`CHHapticError -4815` — no haptics server), so every playback path (`createPlayer`, the player registry, `RealtimeComposer`) was previously a no-op in tests. This suite stands in a fake engine + recording players via a process-global swizzle, so we can assert the wrapper drives CoreHaptics correctly — independent of real playback.

### New tests (`CoreHapticsMockTests`, 6)
- engine construct + start, and `createPlayer` returning distinct ids / building a player each call
- **20-player FIFO registry eviction** — the 21st creation stops the oldest
- `stopHaptics()` stopping every registered player
- `RealtimeComposer` activating, creating an advanced player, starting it, and **sending clamped dynamic parameters** (2.0 → 1.0, −1.0 → 0.0) end-to-end
- `stop()` deactivating the composer and stopping the player

### Mechanism (`CoreHapticsMock.swift`)
Swizzles `capabilitiesForHardware().supportsHaptics`, `-initAndReturnError:`, `-startAndReturnError:`, `-stopWithCompletionHandler:`, `-createPlayerWithPattern:error:`, and `-createAdvancedPlayerWithPattern:error:`, saving and restoring the original IMPs. A `HapticMockRecorder` captures the calls; fake `MockPatternPlayer`/`MockAdvancedPlayer` record start/stop/sendParameters.

## Why / reviewer notes
- The swizzle is **process-global**, so the suite is `@Suite(.serialized)` and CI runs it as a **separate `-only-testing` invocation**, while the main run excludes it via `-skip-testing:PulsarTests/CoreHapticsMockTests`. This guarantees it never races the real-behavior suites (e.g. the "haptics unsupported on the simulator" assertions).
- All of this is test-target only — no SDK/source changes, nothing published to consumers.
- `nonisolated(unsafe)` on the recorder's statics is the Swift-6 escape hatch for the (serialized, main-thread) test-only global state.

Follow-up to #155.
