### PR TITLE
docs: temporarily redirect 'Edit in Studio' to waitlist

### DIFF
--- a/docs/src/content/docs/components/studioLink.ts
+++ b/docs/src/content/docs/components/studioLink.ts
@@ -13,7 +13,10 @@ import type { PatternData } from './Preset/types';
 
 /** The full URL that opens this preset for editing in Studio. */
 export function buildStudioEditUrl(data: PatternData): string {
-  return `${STUDIO_URL}/open?preset=${encodeURIComponent(data.name)}`;
+  // TEMPORARY: Studio's `/open?preset=<name>` deep link isn't live yet, so route
+  // users to the Studio waitlist instead. Restore the line below once Studio ships.
+  // return `${STUDIO_URL}/open?preset=${encodeURIComponent(data.name)}`;
+  return 'https://docs.swmansion.com/pulsar/studio/#waitlist';
 }
 
 /** Open the preset in Studio in a new tab. */


### PR DESCRIPTION
## What

Temporarily route the **"Edit in Pulsar Studio"** button on docs preset cards to the Studio waitlist:

`https://docs.swmansion.com/pulsar/studio/#waitlist`

## Why

Studio's `/open?preset=<name>` deep link isn't live yet. Clicking "Edit in Pulsar Studio" on a preset currently sends users to a non-existent page (e.g. `https://pulsar.swmansion.com/studio/open?preset=Afterglow`), which 404s. Until Studio ships, the waitlist is a better landing spot.

## How

Single change in `docs/src/content/docs/components/studioLink.ts` — `buildStudioEditUrl()` now returns the waitlist URL. The original deep-link line is preserved as a comment, so restoring the real behavior once Studio ships is a one-line revert.

## Notes for reviewer

- `STUDIO_URL` and the `data` param become unused, but the docs package uses Astro's `strict` tsconfig (not `strictest`) and has no ESLint, so this doesn't break the type-check/build. They're intentionally left in place to keep the revert trivial.
- Verified locally against the running docs site: clicking the edit button on a preset opens `https://docs.swmansion.com/pulsar/studio/#waitlist`.