### PR TITLE
docs: document synchronized sound-haptics API

### DIFF
--- a/docs/src/content/docs/sdk/android.mdx
+++ b/docs/src/content/docs/sdk/android.mdx
@@ -598,6 +598,20 @@ Parses a `PatternData` object and prepares it for playback.
 fun parsePattern(hapticsData: PatternData)
 ```
 
+#### `parsePatternWithSound(hapticsData, sound)`
+
+:::caution[Unreleased API]
+Synchronized sound is not part of the latest release (`1.3.0`). It is available on [`main`](https://github.com/software-mansion/pulsar) and will ship in a future release — until then, depend on the repository directly to use it.
+:::
+
+Parses a pattern together with a short sound played in sync with the haptics.
+
+```kotlin
+fun parsePatternWithSound(hapticsData: PatternData, sound: SoundData)
+```
+
+On devices that support audio-coupled haptics, provide an **`.ogg`** whose baked haptic channels drive the vibrator for perfect, single-stream sync. Any other file — `.wav`/`.mp3`, or a bare name (which defaults to `.wav`) — plays the audio while the pattern's own generated `VibrationEffect` fires in parallel. See [`SoundData`](#sounddata) for `uri`, `volume`, `offset`, `hapticChannels`, and the `startMs`/`durationMs` trim window.
+
 #### `play()`
 
 Plays the previously parsed pattern.
@@ -833,6 +847,29 @@ data class PatternData(
   val discretePattern: List<ConfigPoint>
 )
 ```
+
+### SoundData
+
+:::caution[Unreleased API]
+Not part of the latest release (`1.3.0`) — available on [`main`](https://github.com/software-mansion/pulsar) only.
+:::
+
+A short sound to play in sync with a haptic pattern via [`parsePatternWithSound`](#parsepatternwithsoundhapticsdata-sound).
+
+```kotlin
+data class SoundData(
+  val uri: String,             // File path, file:// uri, or res/raw resource name
+  val volume: Float = 1f,      // Playback volume (0-1)
+  val offset: Long = 0L,       // Audio delay relative to haptics, in ms (fallback path)
+  val hapticChannels: Boolean = true,
+  val startMs: Long = 0L,      // Where playback begins in the source file, in ms
+  val durationMs: Long = 0L    // How much to play from startMs, in ms (0 = to the end)
+)
+```
+
+The format comes from `uri`'s extension; when none is given the default is `.wav`, so a bare name like `"beep"` loads `res/raw/beep.wav`. Only an explicit `.ogg` with baked haptic channels uses the audio-coupled path (on supported devices); everything else plays the audio while the pattern's own haptics fire in parallel. Set `hapticChannels = false` to force that fallback for an `.ogg` that does not carry haptic channels.
+
+`startMs` and `durationMs` trim the clip: `startMs` is where playback begins in the source file and `durationMs` is how much of it to play (`0` plays to the end). The audio is sliced to that window before playing rather than seeked at runtime, so one bundled file can back several trimmed sounds without losing sync.
 
 ### ContinuousPattern
 

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -431,6 +431,20 @@ Parses a `PatternData` object and prepares it for playback.
 Future<void> parsePattern(PatternData data);
 ```
 
+#### `parsePatternWithSound(pattern, sound)`
+
+:::caution[Unreleased API]
+Synchronized sound is not part of the latest release (`0.1.0`). It is available on [`main`](https://github.com/software-mansion/pulsar) and will ship in a future release — until then, use a `git` dependency on the repository to try it.
+:::
+
+Parses a pattern together with a short sound played in sync with the haptics.
+
+```dart
+Future<void> parsePatternWithSound(PatternData data, Sound sound);
+```
+
+Provide the sound via a [`Sound`](#sound). On Android an explicit `.ogg` with baked haptic channels enables audio-coupled sync on supported devices; any other format — or a bare name, which defaults to `.wav` — plays the audio while the pattern's own haptics fire in parallel. On iOS the sound is registered as a Core Haptics audio event on the pattern's timeline. A Flutter asset is not a native file path — bundle the file natively (iOS app bundle / Android `res/raw`) and pass its name, or copy it from `rootBundle` to a temp file and pass that absolute path.
+
 #### `playPattern(pattern)`
 
 Convenience method that parses and immediately plays a pattern.
@@ -780,6 +794,36 @@ class PatternData {
 ```
 
 The `PatternData.fromArrays` factory accepts the raw triplet form (`List<List<double>>`) for parity with serialized pattern definitions.
+
+### Sound
+
+:::caution[Unreleased API]
+Not part of the latest release (`0.1.0`) — available on [`main`](https://github.com/software-mansion/pulsar) only.
+:::
+
+A short sound to play in sync with a haptic pattern via [`parsePatternWithSound`](#parsepatternwithsoundpattern-sound).
+
+```dart
+class Sound {
+  const Sound({
+    required this.uri,
+    this.volume = 1.0,
+    this.offset = 0,
+    this.start = 0,
+    this.duration = 0,
+  });
+
+  final String uri;      // File path, file:// uri, or bundled resource name
+  final double volume;   // Playback volume (0-1)
+  final int offset;      // Audio delay relative to haptics, in ms
+  final int start;       // Where playback begins in the source file, in ms
+  final int duration;    // How much to play from start, in ms (0 = to the end)
+}
+```
+
+The format comes from `uri`'s extension; when none is given the default is `.wav`, so a bare name like `'beep'` resolves `beep.wav` on both platforms (iOS app bundle / Android `res/raw`).
+
+`start` and `duration` trim the clip: `start` is where playback begins in the source file and `duration` is how much of it to play (`0` plays to the end). The native side slices the audio to that window before playing rather than seeking at runtime, so one bundled file can back several trimmed sounds without losing sync.
 
 ### ContinuousPattern
 

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -496,6 +496,29 @@ Parses a `PatternData` object and prepares it for playback.
 func parsePattern(hapticsData: PatternData)
 ```
 
+#### `parsePatternWithSound(hapticsData:uri:volume:offset:start:duration:)`
+
+:::caution[Unreleased API]
+Synchronized sound is not part of the latest release (`1.4.0`). It is available on [`main`](https://github.com/software-mansion/pulsar) and will ship in a future release — until then, point your SPM or CocoaPods dependency at the repository to use it.
+:::
+
+Parses a pattern together with a short sound played in sync with the haptics. The sound is registered as a Core Haptics audio event on the **same timeline** as the pattern, so audio and haptics stay sample-accurate. `volume` (0–1) and `offset` (milliseconds, shifting the audio relative to the haptics) are optional.
+
+```swift
+func parsePatternWithSound(
+  hapticsData: PatternData,
+  uri: String,
+  volume: Float = 1,
+  offset: Double = 0,
+  start: Double = 0,
+  duration: Double = 0
+)
+```
+
+`uri` must resolve to a **local** file — an absolute path, a `file://` URL, or the name of a resource bundled in the app. When no extension is given it defaults to `.wav`, so a bare name like `"beep"` resolves `beep.wav` from the app bundle (add the file to your target's **Copy Bundle Resources**). Requires a real device — Core Haptics is unavailable on the simulator — and a missing or unregisterable file degrades gracefully to haptics-only.
+
+`start` and `duration` (both in milliseconds) trim the clip: `start` is where playback begins in the source file, `duration` is how much of it to play (`0` plays to the end). Core Haptics registers an audio resource by URL only, so when either is set the file is sliced to a temporary `.caf` first — the temp file is cleaned up on the next parse and on dispose.
+
 #### `playPattern(hapticsData:)`
 
 Parses and immediately plays a pattern. Equivalent to calling `parsePattern` followed by `play`.

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -420,6 +420,20 @@ Parses a `PatternData` object and prepares it for playback.
 fun parsePattern(pattern: PatternData)
 ```
 
+#### `parsePatternWithSound(pattern, sound)`
+
+:::caution[Unreleased API]
+Synchronized sound is not part of the latest release (`0.1.0`). It is available on [`main`](https://github.com/software-mansion/pulsar) and will ship in a future release — until then, depend on the repository directly to use it.
+:::
+
+Parses a pattern together with a short sound played in sync with the haptics.
+
+```kotlin
+fun parsePatternWithSound(pattern: PatternData, sound: SoundData)
+```
+
+On Android, an explicit `.ogg` with baked haptic channels enables audio-coupled sync on supported devices; any other file — or a bare name, which defaults to `.wav` — plays the audio while the pattern's own haptics fire in parallel. On iOS the sound is registered as a Core Haptics audio event on the pattern's timeline. See [`SoundData`](#sounddata).
+
 #### `playPattern(pattern)`
 
 Convenience method that parses and immediately plays a pattern.
@@ -724,6 +738,28 @@ data class PatternData(
 ```
 
 A secondary constructor accepts the raw triplet form (`List<List<List<Float>>>` for continuous, `List<List<Float>>` for discrete) for parity with serialized pattern definitions.
+
+### SoundData
+
+:::caution[Unreleased API]
+Not part of the latest release (`0.1.0`) — available on [`main`](https://github.com/software-mansion/pulsar) only.
+:::
+
+A short sound to play in sync with a haptic pattern via [`parsePatternWithSound`](#parsepatternwithsoundpattern-sound).
+
+```kotlin
+data class SoundData(
+  val uri: String,          // File path, file:// uri, or bundled resource name
+  val volume: Float = 1f,   // Playback volume (0-1)
+  val offset: Long = 0L,    // Audio delay relative to haptics, in ms
+  val startMs: Long = 0L,   // Where playback begins in the source file, in ms
+  val durationMs: Long = 0L // How much to play from startMs, in ms (0 = to the end)
+)
+```
+
+The format comes from `uri`'s extension; when none is given the default is `.wav`, so a bare name like `"beep"` resolves `beep.wav` on both platforms (iOS app bundle / Android `res/raw`).
+
+`startMs` and `durationMs` trim the clip: `startMs` is where playback begins in the source file and `durationMs` is how much of it to play (`0` plays to the end). The audio is sliced to that window before playing rather than seeked at runtime, so one bundled file can back several trimmed sounds without losing sync.
 
 ### ContinuousPattern
 

--- a/docs/src/content/docs/sdk/react-native.mdx
+++ b/docs/src/content/docs/sdk/react-native.mdx
@@ -508,6 +508,27 @@ function MyComponent() {
 }
 ```
 
+### Synchronized sound
+
+:::caution[Unreleased API]
+Synchronized sound is not part of the latest release (`1.7.0`). It is available on [`main`](https://github.com/software-mansion/pulsar) and will ship in a future release — until then, depend on the repository directly to use it.
+:::
+
+Add a `sound` field to the pattern to play a short audio file in sync with the haptics. On iOS the file is registered as a Core Haptics audio event on the pattern's timeline (sample-accurate); on Android an explicit `.ogg` with baked haptic channels drives the vibrator directly on supported devices, and any other file falls back to playing the audio while the pattern's haptics fire in parallel.
+
+```tsx
+const pattern = {
+  discretePattern: [{ time: 0, amplitude: 1, frequency: 0.5 }],
+  continuousPattern: { amplitude: [], frequency: [] },
+  sound: { uri: require('./beep.wav') },
+};
+
+const composer = usePatternComposer(pattern);
+composer.play();
+```
+
+`sound.uri` accepts a `require('./beep.wav')` (resolved automatically via `Image.resolveAssetSource`) or a string — a bundled resource name, an absolute path, or a `file://` uri. When no extension is given it defaults to `.wav`, so a bare `'beep'` resolves `beep.wav` on both platforms. Because a `require()` resolves to a **remote** Metro URL in dev but a local file in release, test `require()` sounds on a release build or device. See the [`Sound`](#sound) type for `volume`, `offset`, and the `start`/`duration` trim window.
+
 ---
 
 ## useRealtimeComposer
@@ -718,10 +739,33 @@ type Pattern = {
       value: number; // Frequency value (0-1)
     }>;
   };
+  sound?: Sound; // Optional audio played in sync with the haptics
 };
 ```
 
-Use `discretePattern` for distinct taps and impacts. Use `continuousPattern` envelopes to shape a sustained haptic over time.
+Use `discretePattern` for distinct taps and impacts. Use `continuousPattern` envelopes to shape a sustained haptic over time. Add an optional `sound` to play an audio file in sync — see [Synchronized sound](#synchronized-sound).
+
+### Sound
+
+:::caution[Unreleased API]
+Not part of the latest release (`1.7.0`) — available on [`main`](https://github.com/software-mansion/pulsar) only.
+:::
+
+A short sound played in sync with a haptic pattern.
+
+```ts
+type Sound = {
+  uri: number | string; // require('./beep.wav') or a resource name / path / file:// uri
+  volume?: number; // Playback volume (0-1), defaults to 1
+  offset?: number; // Audio delay relative to haptics, in ms, defaults to 0
+  start?: number; // Where playback begins in the source file, in ms, defaults to 0
+  duration?: number; // How much to play from `start`, in ms, defaults to 0 (to the end)
+};
+```
+
+When `uri` has no extension it defaults to `.wav`, so a bare `'beep'` resolves `beep.wav` (iOS app bundle / Android `res/raw`). On Android, an explicit `.ogg` with baked haptic channels enables audio-coupled sync; every other format uses the audio + generated-haptics fallback.
+
+`start` and `duration` trim the clip: `start` is where playback begins in the source file and `duration` is how much of it to play (0 plays to the end). The native side slices the audio to that window before playing rather than seeking at runtime, so a single bundled file can back several trimmed sounds without losing sample-accurate sync.
 
 ### HapticSupport
 


### PR DESCRIPTION
## What

Documents the new **synchronized sound + haptics** API across all five SDK pages (React Native, iOS, Android, Flutter, KMP).

## Why

The feature ([#162](https://github.com/software-mansion/pulsar/pull/162)) added `parsePatternWithSound` / a `sound` field to the Pattern Composer, but the SDK docs didn't cover it. This adds reference docs so developers can discover and use it.

## Changes

Per platform page (`docs/src/content/docs/sdk/*.mdx`):
- **React Native** — a "Synchronized sound" subsection under `usePatternComposer`, the `sound?` field on the `Pattern` type, and a new `Sound` type (covering `require()` support and the dev-vs-release Metro URL caveat).
- **iOS** — `parsePatternWithSound(hapticsData:uri:volume:offset:)` method reference (Core Haptics audio event, bundle a local file, device-only).
- **Android** — `parsePatternWithSound(hapticsData, sound)` method + `SoundData` type (explicit `.ogg` for the audio-coupled path, otherwise the audio + generated-haptics fallback).
- **Flutter** — `parsePatternWithSound(pattern, sound)` method + `Sound` type.
- **KMP** — `parsePatternWithSound(pattern, sound)` method + `SoundData` type.

All pages document the shared rule: **the format comes from the uri's extension, defaulting to `.wav`**, so a bare name like `beep` resolves `beep.wav` on both platforms.

## Base branch

Stacked on `feat/audio-haptics-sync` so the diff is docs-only. Retarget to `main` once the feature branch merges (or merge the feature first).

## Verification

`npx astro build` in `docs/` completes successfully — all five SDK pages build with no errors.
