### PR TITLE
fix(android): felt long-press ticks on PWM-only realtime composers

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeWithDiscretePrimitivesComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimeEnvelopeWithDiscretePrimitivesComposer.kt
@@ -13,6 +13,10 @@ class RealtimeEnvelopeWithDiscretePrimitivesComposer(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
+        if (!engine.hasPrimitiveSupport()) {
+            super.playDiscrete(amplitude, frequency)
+            return
+        }
         val effect = createCompositionEffect(amplitude, frequency)
         engine.vibrate(effect)
     }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -68,11 +68,6 @@ open class RealtimePrimitiveComposer(
         }
 
         if (pwmFallback != null) {
-            // PWM / timing-only actuators have no per-pulse width to separate taps, so a stream of
-            // playDiscrete calls (e.g. a long-press) blurs into a dense buzz. Gate on the same
-            // frequency-derived cadence the realtime loop uses: drop calls arriving sooner than the
-            // interval so a held press reads as distinct ticks, matching drag (set()). Devices with
-            // real primitive support keep firing every impulse immediately.
             val now = SystemClock.uptimeMillis()
             if (now - lastDiscreteAtMs < intervalForFrequency(frequency)) {
                 return

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveComposer.kt
@@ -3,6 +3,7 @@ package com.swmansion.pulsar.composers
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.os.VibrationEffect
 import androidx.annotation.RequiresApi
 import com.swmansion.pulsar.haptics.HapticEngineWrapper
@@ -14,8 +15,8 @@ open class RealtimePrimitiveComposer(
     private val engine: HapticEngineWrapper,
     compatibilityMode: CompatibilityMode,
 ) : RealtimeComposable {
-    private var minIntervalMs = 10L
-    private var maxIntervalMs = 100L
+    protected var minIntervalMs = 10L
+    protected var maxIntervalMs = 100L
 
     private val pwmFallback: RealtimePwmComposer? =
         if (engine.hasPrimitiveSupport()) null else RealtimePwmComposer(engine)
@@ -31,6 +32,7 @@ open class RealtimePrimitiveComposer(
     @Volatile private var currentAmplitude = 0.0f
     @Volatile private var currentFrequency = 0.0f
     @Volatile private var currentIntervalMs: Long = 50L
+    @Volatile private var lastDiscreteAtMs: Long = 0L
 
     private val handler = Handler(Looper.getMainLooper())
     private val loopRunnable = Runnable { loop() }
@@ -53,7 +55,7 @@ open class RealtimePrimitiveComposer(
 
         currentAmplitude = amplitude.coerceIn(0f, 1f)
         currentFrequency = frequency.coerceIn(0f, 1f)
-        currentIntervalMs = (minIntervalMs + (1 - frequency) * (maxIntervalMs - minIntervalMs)).toLong()
+        currentIntervalMs = intervalForFrequency(frequency)
 
         if (!isPlaying.get()) {
             start(currentAmplitude, currentFrequency)
@@ -61,16 +63,33 @@ open class RealtimePrimitiveComposer(
     }
 
     override fun playDiscrete(amplitude: Float, frequency: Float) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
         if (pwmFallback != null) {
+            // PWM / timing-only actuators have no per-pulse width to separate taps, so a stream of
+            // playDiscrete calls (e.g. a long-press) blurs into a dense buzz. Gate on the same
+            // frequency-derived cadence the realtime loop uses: drop calls arriving sooner than the
+            // interval so a held press reads as distinct ticks, matching drag (set()). Devices with
+            // real primitive support keep firing every impulse immediately.
+            val now = SystemClock.uptimeMillis()
+            if (now - lastDiscreteAtMs < intervalForFrequency(frequency)) {
+                return
+            }
+            lastDiscreteAtMs = now
+
             pwmFallback.playDiscrete(amplitude, frequency)
             return
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return
-        }
         val effect = createCompositionEffect(amplitude, frequency)
         engine.vibrate(effect)
+    }
+
+    private fun intervalForFrequency(frequency: Float): Long {
+        val clamped = frequency.coerceIn(0f, 1f)
+        return (minIntervalMs + (1 - clamped) * (maxIntervalMs - minIntervalMs)).toLong()
     }
 
     override fun stop() {

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveTickComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveTickComposer.kt
@@ -11,9 +11,6 @@ class RealtimePrimitiveTickComposer(
 ) : RealtimePrimitiveComposer(engine, compatibilityMode) {
 
     init {
-        // A stream of ticks needs clear air between each one, otherwise the individual clicks blur
-        // into a continuous buzz (the shared primitive defaults drop to ~10ms at high frequency).
-        // Widen the cadence so ticks stay distinct across the whole frequency range.
         minIntervalMs = maxOf(minIntervalMs, 60L)
         maxIntervalMs = maxOf(maxIntervalMs, 300L)
     }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveTickComposer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/composers/RealtimePrimitiveTickComposer.kt
@@ -10,6 +10,14 @@ class RealtimePrimitiveTickComposer(
     compatibilityMode: CompatibilityMode,
 ) : RealtimePrimitiveComposer(engine, compatibilityMode) {
 
+    init {
+        // A stream of ticks needs clear air between each one, otherwise the individual clicks blur
+        // into a continuous buzz (the shared primitive defaults drop to ~10ms at high frequency).
+        // Widen the cadence so ticks stay distinct across the whole frequency range.
+        minIntervalMs = maxOf(minIntervalMs, 60L)
+        maxIntervalMs = maxOf(maxIntervalMs, 300L)
+    }
+
     @RequiresApi(android.os.Build.VERSION_CODES.TIRAMISU)
     override fun selectPrimitive(value: Float): Int {
         return VibrationEffect.Composition.PRIMITIVE_CLICK


### PR DESCRIPTION
## What & why

Fixes three realtime-composer haptics issues on Android actuators that support **only PWM / timing-only signal haptics** (no primitives — e.g. moto g05). Everything is in the native SDK (`Android/Pulsar`); the app playground is unchanged.

### 1. Envelope+Discrete long-press was silent
`RealtimeEnvelopeWithDiscretePrimitivesComposer.playDiscrete` fired a `VibrationEffect.Composition` primitive unconditionally. On a device with no primitive support that silently no-ops, so a long-press produced nothing. It now falls back to the inherited envelope path (`convertToVibrationEffect` → PWM waveform, one felt pulse) when `!engine.hasPrimitiveSupport()`. Primitive-capable devices are unaffected.

### 2. Primitive Tick ticks were too dense
The shared `RealtimePrimitiveComposer` interval is `min + (1-freq)·(max-min)`; with the defaults it dropped to ~10ms at high frequency, so successive clicks blurred into a continuous buzz. `RealtimePrimitiveTickComposer` now widens its cadence to **60–300ms** (via `maxOf`, so the LIMITED tier's 60/200 floor isn't narrowed). `Primitive Complex` keeps the original spacing.

### 3. PWM-only long-press blurred a `playDiscrete` stream
The playground long-press fires `composer.playDiscrete` on a fixed 80ms interval. A PWM pulse/primitive click has no width to separate the taps, so on PWM-only devices the stream read as a dense buzz rather than distinct ticks (unlike dragging, which uses the native `set()` loop's frequency-aware cadence).

`RealtimePrimitiveComposer.playDiscrete` now gates on `SystemClock.uptimeMillis()` **inside the `pwmFallback` branch only**: it drops calls arriving sooner than the strategy's frequency-derived interval (the same formula the realtime loop uses, extracted into a shared helper). A held press down-samples to a distinct tick train matching drag. **Devices with real primitive support keep firing every impulse immediately** — no behavior change and no coalescing there.

## Reviewer notes
- Scope is intentionally limited to no-primitive devices; the `playDiscrete` gate does not affect primitive-capable hardware.
- Spacing during long-press is quantized to the caller's ~80ms call rate (≈80ms at high frequency, ≈320ms at low) — qualitatively matches the drag cadence.
- Validated on a moto g05 (no primitives, no amplitude control); its "Primitive Tick" path runs through `pwmFallback`, which is why the gate is exercised there.
- No existing unit tests cover these realtime composers; `:Pulsar:compileDebugKotlin` passes.