### PR TITLE
fix(ios): expose native pod as module `Pulsar` (module_name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Presets.tap();
 ### iOS
 
 <!-- GENERATED:IOS_VERSION_START -->
-Latest available version: `1.2.0`
+Latest available version: `1.3.0`
 <!-- GENERATED:IOS_VERSION_END -->
 
 Add Pulsar as a Swift Package dependency in Xcode, or add it to your `Package.swift`:
@@ -73,7 +73,7 @@ Add Pulsar as a Swift Package dependency in Xcode, or add it to your `Package.sw
 <!-- GENERATED:IOS_INSTALL_SNIPPET_START -->
 ```swift
 dependencies: [
-  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.2.0")
+  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.3.0")
 ]
 ```
 <!-- GENERATED:IOS_INSTALL_SNIPPET_END -->

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -52,7 +52,7 @@ The Pulsar iOS SDK provides haptic feedback through three building blocks: `Pres
 ## Installation
 
 {/* GENERATED:IOS_VERSION_START */}
-Latest available version: `1.2.0`
+Latest available version: `1.3.0`
 {/* GENERATED:IOS_VERSION_END */}
 
 Add Pulsar as a Swift Package dependency in Xcode:
@@ -66,7 +66,7 @@ Or add it to your `Package.swift`:
 {/* GENERATED:IOS_INSTALL_SNIPPET_START */}
 ```swift
 dependencies: [
-  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.2.0")
+  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.3.0")
 ]
 ```
 {/* GENERATED:IOS_INSTALL_SNIPPET_END */}

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -10,7 +10,7 @@ This page covers concepts that apply across all Pulsar SDKs: types of haptics, p
 
 | Platform | Package | Version |
 | --- | --- | --- |
-| iOS | Swift Package | `1.2.0` |
+| iOS | Swift Package | `1.3.0` |
 | Android | `com.swmansion:pulsar` (Maven) | `1.2.0` |
 | React Native | `react-native-pulsar` (npm) | `1.6.1` |
 | Kotlin Multiplatform | `com.swmansion:pulsar-kmp` (Maven) | `0.0.3` |

--- a/iOS/Pulsar/Pulsar-haptics.podspec
+++ b/iOS/Pulsar/Pulsar-haptics.podspec
@@ -1,6 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'Pulsar-haptics'
-  s.version          = '1.2.0' # pulsar-sync:ios-version
+  # Expose the module as `Pulsar` — the same name the Swift Package already uses,
+  # and what the docs tell consumers to `import`. It also avoids a case-insensitive
+  # CocoaPods module-name clash with the Flutter plugin pod `pulsar_haptics` (which
+  # would otherwise derive `Pulsar_haptics`) when an app opts into `use_frameworks!`.
+  s.module_name      = 'Pulsar'
+  s.version          = '1.3.0' # pulsar-sync:ios-version
   s.summary          = 'A haptic feedback SDK for iOS, written in Swift.'
   s.description      = <<-DESC
 Pulsar provides ready-to-use haptic presets, a pattern composer for custom

--- a/iOS/Pulsar/Pulsar-haptics.podspec
+++ b/iOS/Pulsar/Pulsar-haptics.podspec
@@ -1,9 +1,5 @@
 Pod::Spec.new do |s|
   s.name             = 'Pulsar-haptics'
-  # Expose the module as `Pulsar` — the same name the Swift Package already uses,
-  # and what the docs tell consumers to `import`. It also avoids a case-insensitive
-  # CocoaPods module-name clash with the Flutter plugin pod `pulsar_haptics` (which
-  # would otherwise derive `Pulsar_haptics`) when an app opts into `use_frameworks!`.
   s.module_name      = 'Pulsar'
   s.version          = '1.3.0' # pulsar-sync:ios-version
   s.summary          = 'A haptic feedback SDK for iOS, written in Swift.'

--- a/iOS/Pulsar/README.md
+++ b/iOS/Pulsar/README.md
@@ -19,7 +19,7 @@ A haptic feedback SDK for iOS, written in Swift. Pulsar provides ready-to-use ha
 ### Installation
 
 <!-- GENERATED:IOS_VERSION_START -->
-Latest available version: `1.2.0`
+Latest available version: `1.3.0`
 <!-- GENERATED:IOS_VERSION_END -->
 
 #### Swift Package Manager
@@ -35,7 +35,7 @@ Or add Pulsar to your `Package.swift`:
 <!-- GENERATED:IOS_INSTALL_SNIPPET_START -->
 ```swift
 dependencies: [
-  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.2.0")
+  .package(url: "https://github.com/software-mansion-labs/pulsar-ios", from: "1.3.0")
 ]
 ```
 <!-- GENERATED:IOS_INSTALL_SNIPPET_END -->
@@ -48,7 +48,7 @@ Add Pulsar to your `Podfile`:
 
 <!-- GENERATED:IOS_COCOAPODS_INSTALL_SNIPPET_START -->
 ```ruby
-pod 'Pulsar-haptics', '~> 1.2.0'
+pod 'Pulsar-haptics', '~> 1.3.0'
 ```
 <!-- GENERATED:IOS_COCOAPODS_INSTALL_SNIPPET_END -->
 

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -1,6 +1,6 @@
 {
   "ios": {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "swiftPackageUrl": "https://github.com/software-mansion-labs/pulsar-ios"
   },
   "android": {


### PR DESCRIPTION
Follow-up to #141 (Faza 1 of the plan). Closes the remaining caveat noted there: Flutter apps that use `use_frameworks!` still failed `pod install`.

## What was wrong

The published `Pulsar-haptics` pod declares no `s.module_name`, so CocoaPods derives the module **`Pulsar_haptics`** from the pod name. Two problems follow:

1. **Inconsistent with SPM and the docs.** The Swift Package already exposes module `Pulsar`, and every install snippet (`iOS/Pulsar/README.md`, `docs/sdk/ios.mdx`) tells consumers to `import Pulsar`. A CocoaPods-only user who follows the README hits `no such module 'Pulsar'`.
2. **Case-insensitive collision with the Flutter plugin pod `pulsar_haptics`.** CocoaPods compares product module names case-insensitively, so `Pulsar_haptics` vs `pulsar_haptics` clash and `pod install` fails with:
   ```
   [!] The 'Pods-Runner' target has frameworks with conflicting names: pulsar_haptics.
   ```
   whenever a Flutter app opts into `use_frameworks!` (common with Firebase and other Swift pods). This is exactly the caveat #141 documented and deferred, because the fix needs a native release.

## Change

- `iOS/Pulsar/Pulsar-haptics.podspec`: add `s.module_name = 'Pulsar'` — matching what SPM and the docs already use.
- Bump iOS version `1.2.0 → 1.3.0` via `sdk-versions.json` + `node scripts/sync-sdk-versions.mjs` (podspec + READMEs + docs), so the change ships in a release and the publish workflow's version check passes.

No Swift source changes — this only renames the module used in `import`.

## Consequence / migration

Renames the CocoaPods module for consumers who imported the derived name `Pulsar_haptics`; they switch to `import Pulsar` (a compile-time error, one line per file). It's a no-op for SPM users (already `Pulsar`) and for anyone who followed the docs (`import Pulsar` starts working). A changelog migration note should accompany the release.

## Version choice

Tagged **1.3.0** (minor). Strictly this renames a public module, so if you'd rather treat it as breaking, bump `sdk-versions.json` iOS to `2.0.0` and re-run the sync before merging — it's a one-line change.

## After merge (not in this PR)

1. Run the **Publish iOS package to CocoaPods** workflow with `version=1.3.0` (needs the trunk token; also ensure the `1.3.0` tag exists in `pulsar-ios`, since `s.source` pulls sources from that tag).
2. Faza 2/4 — once `Pulsar-haptics 1.3.0` is live, bump the native pin in the Flutter plugin (`pulsar_haptics.podspec` + `Package.swift`) and React Native (`Pulsar.podspec`) to `1.3.0`, re-enable `use_frameworks!` in the Flutter example Podfile, and simplify the now-dead `Pulsar_haptics` branches in `react-native/.../ios/Haptics.mm`.

## Verification

- `ruby -c` on the podspec: Syntax OK.
- `node scripts/sync-sdk-versions.mjs` runs clean and is idempotent (second run is a no-op).