### PR TITLE
chore(ios): make sync.sh self-contained (clone + PR)

### DIFF
--- a/iOS/Pulsar/.gitignore
+++ b/iOS/Pulsar/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.tmp
 /Packages
 xcuserdata/
 DerivedData/

--- a/iOS/Pulsar/sync.sh
+++ b/iOS/Pulsar/sync.sh
@@ -6,6 +6,10 @@
 # The mirror repo is cloned into ./.tmp on first run and reused (fetched)
 # afterwards, so no pre-existing local checkout is required anywhere on the
 # machine. Changes are pushed to a fresh branch and a PR is opened with `gh`.
+#
+# With --release the script additionally merges the freshly opened PR, then
+# tags and publishes a GitHub release using the iOS version declared in
+# ../../sdk-versions.json (.ios.version).
 
 set -euo pipefail
 
@@ -13,17 +17,75 @@ REPO_URL="https://github.com/software-mansion-labs/pulsar-ios"
 REPO_SLUG="software-mansion-labs/pulsar-ios"
 BASE_BRANCH="main"
 
+RELEASE=false
+
+usage() {
+  cat <<'EOF'
+Usage: ./sync.sh [options]
+
+Syncs the iOS Pulsar sources to the public mirror repo by opening a PR.
+
+Options:
+  --release   After opening the PR, merge it, then create a tag and a GitHub
+              release using the iOS version from ../../sdk-versions.json.
+  --help      Show this help message.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --release)
+      RELEASE=true
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Always operate relative to this script's location, regardless of the caller's cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$SCRIPT_DIR"
 TMP_DIR="$SCRIPT_DIR/.tmp"
 CLONE_DIR="$TMP_DIR/pulsar-ios"
+SDK_VERSIONS_FILE="$SCRIPT_DIR/../../sdk-versions.json"
 
-# `gh` is required to open the pull request.
+# `gh` is required to open the pull request (and to release).
 if ! command -v gh >/dev/null 2>&1; then
   echo "Error: GitHub CLI (gh) is required but not installed." >&2
   echo "Install it from https://cli.github.com/ and run 'gh auth login'." >&2
   exit 1
+fi
+
+# When releasing, resolve and validate the version up front so we fail before
+# touching the remote if something is off.
+if [ "$RELEASE" = true ]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required for --release but not installed." >&2
+    exit 1
+  fi
+  if [ ! -f "$SDK_VERSIONS_FILE" ]; then
+    echo "Error: cannot find sdk-versions.json at $SDK_VERSIONS_FILE" >&2
+    exit 1
+  fi
+  VERSION="$(jq -r '.ios.version' "$SDK_VERSIONS_FILE")"
+  if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+    echo "Error: could not read .ios.version from $SDK_VERSIONS_FILE" >&2
+    exit 1
+  fi
+  # Refuse to clobber an existing tag/release.
+  if git ls-remote --tags "$REPO_URL" "refs/tags/$VERSION" | grep -q "refs/tags/$VERSION"; then
+    echo "Error: tag $VERSION already exists on $REPO_SLUG." >&2
+    echo "Bump .ios.version in sdk-versions.json before releasing." >&2
+    exit 1
+  fi
+  echo "Releasing iOS Pulsar version $VERSION"
 fi
 
 # 1. Ensure the mirror repo is available locally inside ./.tmp
@@ -63,17 +125,41 @@ if git diff --cached --quiet; then
   # Leave the base branch checked out and drop the empty sync branch.
   git checkout "$BASE_BRANCH"
   git branch -D "$BRANCH"
+  if [ "$RELEASE" = true ]; then
+    echo "Nothing to release: sources are already up to date." >&2
+    exit 1
+  fi
   exit 0
 fi
 
 git commit -m "Sync iOS Pulsar files"
 git push -u origin "$BRANCH"
 
-gh pr create \
+PR_URL="$(gh pr create \
   --repo "$REPO_SLUG" \
   --base "$BASE_BRANCH" \
   --head "$BRANCH" \
   --title "Sync iOS Pulsar files" \
-  --body "Automated sync of iOS Pulsar sources from the pulsar monorepo."
+  --body "Automated sync of iOS Pulsar sources from the pulsar monorepo.")"
 
-echo "Opened a pull request on $REPO_SLUG from branch $BRANCH"
+echo "Opened a pull request: $PR_URL"
+
+if [ "$RELEASE" != true ]; then
+  exit 0
+fi
+
+# 5. Release: merge the PR, then tag and publish a GitHub release.
+echo "Merging $PR_URL..."
+gh pr merge "$PR_URL" --repo "$REPO_SLUG" --merge --delete-branch
+
+# Make sure the release targets the merged commit on the base branch.
+git fetch origin "$BASE_BRANCH"
+
+echo "Creating release $VERSION on $REPO_SLUG..."
+gh release create "$VERSION" \
+  --repo "$REPO_SLUG" \
+  --target "$BASE_BRANCH" \
+  --title "$VERSION" \
+  --generate-notes
+
+echo "Released $VERSION: $(gh release view "$VERSION" --repo "$REPO_SLUG" --json url --jq .url)"

--- a/iOS/Pulsar/sync.sh
+++ b/iOS/Pulsar/sync.sh
@@ -1,7 +1,79 @@
-cd ../../../pulsar-ios
-cp -r ../pulsar/iOS/Pulsar/* ./
-rm sync.sh
-git add .
+#!/bin/bash
+#
+# Syncs this iOS Pulsar directory to the public mirror repository
+# (github.com/software-mansion-labs/pulsar-ios) by opening a pull request.
+#
+# The mirror repo is cloned into ./.tmp on first run and reused (fetched)
+# afterwards, so no pre-existing local checkout is required anywhere on the
+# machine. Changes are pushed to a fresh branch and a PR is opened with `gh`.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/software-mansion-labs/pulsar-ios"
+REPO_SLUG="software-mansion-labs/pulsar-ios"
+BASE_BRANCH="main"
+
+# Always operate relative to this script's location, regardless of the caller's cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR"
+TMP_DIR="$SCRIPT_DIR/.tmp"
+CLONE_DIR="$TMP_DIR/pulsar-ios"
+
+# `gh` is required to open the pull request.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required but not installed." >&2
+  echo "Install it from https://cli.github.com/ and run 'gh auth login'." >&2
+  exit 1
+fi
+
+# 1. Ensure the mirror repo is available locally inside ./.tmp
+if [ -d "$CLONE_DIR/.git" ]; then
+  echo "Reusing existing clone in .tmp, fetching latest..."
+  git -C "$CLONE_DIR" fetch origin
+  git -C "$CLONE_DIR" checkout "$BASE_BRANCH"
+  git -C "$CLONE_DIR" reset --hard "origin/$BASE_BRANCH"
+else
+  echo "Cloning $REPO_URL into .tmp..."
+  rm -rf "$CLONE_DIR"
+  mkdir -p "$TMP_DIR"
+  git clone "$REPO_URL" "$CLONE_DIR"
+fi
+
+# 2. Create a fresh sync branch off the base branch.
+BRANCH="sync/ios-$(date +%Y%m%d-%H%M%S)"
+git -C "$CLONE_DIR" checkout -b "$BRANCH"
+
+# 3. Mirror the iOS sources into the clone (excluding local-only artifacts).
+echo "Copying iOS Pulsar files into the mirror repo..."
+rsync -a --delete \
+  --exclude='.git/' \
+  --exclude='.tmp/' \
+  --exclude='.build/' \
+  --exclude='.swiftpm/' \
+  --exclude='DerivedData/' \
+  --exclude='.DS_Store' \
+  --exclude='sync.sh' \
+  "$SRC_DIR/" "$CLONE_DIR/"
+
+# 4. Commit, push the branch, and open a PR if anything changed.
+cd "$CLONE_DIR"
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to sync."
+  # Leave the base branch checked out and drop the empty sync branch.
+  git checkout "$BASE_BRANCH"
+  git branch -D "$BRANCH"
+  exit 0
+fi
+
 git commit -m "Sync iOS Pulsar files"
-git push origin main
-cd ../pulsar/iOS/Pulsar/
+git push -u origin "$BRANCH"
+
+gh pr create \
+  --repo "$REPO_SLUG" \
+  --base "$BASE_BRANCH" \
+  --head "$BRANCH" \
+  --title "Sync iOS Pulsar files" \
+  --body "Automated sync of iOS Pulsar sources from the pulsar monorepo."
+
+echo "Opened a pull request on $REPO_SLUG from branch $BRANCH"


### PR DESCRIPTION
## What

Rewrites `iOS/Pulsar/sync.sh` so it no longer depends on a pre-existing `pulsar-ios` checkout sitting somewhere on the machine (previously `cd ../../../pulsar-ios`).

The script now:
1. Clones the public mirror `github.com/software-mansion-labs/pulsar-ios` into `iOS/Pulsar/.tmp/` on first run, and reuses + fetches it on subsequent runs.
2. Creates a fresh `sync/ios-<timestamp>` branch off `main`.
3. Mirrors the iOS sources with `rsync --delete`, excluding local-only artifacts (`.git/`, `.tmp/`, `.build/`, `.swiftpm/`, `DerivedData/`, `.DS_Store`, and `sync.sh` itself).
4. Commits, pushes the branch, and opens a PR with `gh pr create` — only when there are actual changes (otherwise it cleans up the empty branch and exits).

Also adds `/.tmp` to `iOS/Pulsar/.gitignore` so the clone dir doesn't show up in the monorepo status.

## Why

The old script hard-coded a sibling `pulsar-ios` directory and pushed straight to `main`, so it only worked on a machine with that exact layout and gave no review step. This makes syncing reproducible from any checkout and routes changes through a PR.

## Notes for reviewers

- Requires the GitHub CLI (`gh`); the script checks for it up front and errors with install instructions if missing.
- `set -euo pipefail` and `SCRIPT_DIR`-relative paths make it safe to run from any cwd.
- Behaviour change: syncing now opens a PR against the mirror's `main` instead of pushing directly to it.