### PR TITLE
chore(docs): point studio demo videos to Supabase-hosted mp4

### DIFF
--- a/docs/src/components/landing/StudioSection/StudioSection.tsx
+++ b/docs/src/components/landing/StudioSection/StudioSection.tsx
@@ -26,7 +26,7 @@ function StudioPreview() {
       <div className={styles.previewBody}>
         <video
           className={styles.video}
-          src={`${BASE_PATH}/assets/pulsar-demo.mp4`}
+          src="https://xhxogbcwlfdzhbojhtwe.supabase.co/storage/v1/object/public/pulsar_docs/Pulsar%20Studio.mp4"
           poster={`${BASE_PATH}/assets/pulsar-demo-poster.jpg`}
           controls
           autoPlay

--- a/docs/src/components/studio/StudioDemo/StudioDemo.tsx
+++ b/docs/src/components/studio/StudioDemo/StudioDemo.tsx
@@ -52,7 +52,7 @@ export function StudioDemo() {
               <video
                 ref={videoRef}
                 className={styles.video}
-                src={`${BASE_PATH}/assets/pulsar-demo.mp4`}
+                src="https://xhxogbcwlfdzhbojhtwe.supabase.co/storage/v1/object/public/pulsar_docs/Pulsar%20Studio.mp4"
                 poster={`${BASE_PATH}/assets/pulsar-demo-poster.jpg`}
                 controls
                 loop


### PR DESCRIPTION
## What

Updates the studio demo video `src` on both landing pages to the new Supabase-hosted mp4:

- `docs/src/components/landing/StudioSection/StudioSection.tsx` — landing page
- `docs/src/components/studio/StudioDemo/StudioDemo.tsx` — studio page

New URL: `https://xhxogbcwlfdzhbojhtwe.supabase.co/storage/v1/object/public/pulsar_docs/Pulsar%20Studio.mp4`

## Why

Serve the demo video from Supabase storage instead of bundling the local asset.

## Notes

- The `poster` images still reference the local `${BASE_PATH}/assets/` path and are unchanged.