### PR TITLE
fix(react-native): pin native pod to 1.3.0 and simplify the Swift-header shim

### DIFF
--- a/react-native/react-native-pulsar/Pulsar.podspec
+++ b/react-native/react-native-pulsar/Pulsar.podspec
@@ -2,7 +2,7 @@ require "json"
 require "fileutils"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4" # pulsar-sync:rn-pulsar-ios
+pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.3.0" # pulsar-sync:rn-pulsar-ios
 
 # By default depend on the published `Pulsar-haptics` CocoaPod.
 # Set USE_LOCAL_PULSAR_IOS=1 to build against the in-repo `iOS/Pulsar` sources instead.
@@ -51,10 +51,10 @@ Pod::Spec.new do |s|
     s.frameworks = "AVFoundation", "CoreHaptics", "UIKit"
   else
     s.dependency "Pulsar-haptics", pulsar_ios_pod_version
-    # The published `Pulsar-haptics` pod compiles its Swift into the `Pulsar_haptics`
-    # module, whose generated ObjC interface (`Pulsar_haptics-Swift.h`) is not on this
-    # pod's header search path by default. Expose it so the ObjC++ bridge can `#import`
-    # it (C++ modules are disabled, so `@import` is not an option here).
+    # The published `Pulsar-haptics` pod (>= 1.3.0) compiles its Swift into the `Pulsar`
+    # module, whose generated ObjC interface (`Pulsar-Swift.h`) is not on this pod's header
+    # search path by default. Expose it so the ObjC++ bridge can `#import` it (C++ modules
+    # are disabled, so `@import` is not an option here).
     pod_target_xcconfig["HEADER_SEARCH_PATHS"] = '"${PODS_CONFIGURATION_BUILD_DIR}/Pulsar-haptics/Swift Compatibility Header"'
   end
 

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -1,15 +1,13 @@
 #import "Haptics.h"
 #import <UIKit/UIKit.h>
+// The Pulsar Swift SDK is exposed as the `Pulsar` module in every mode:
+//  - USE_LOCAL_PULSAR_IOS=1: the sources are compiled straight into this pod's `Pulsar` module.
+//  - Published pod (Pulsar-haptics >= 1.3.0): the pod sets `s.module_name = 'Pulsar'`.
+// With frameworks the generated interface is reachable as <Pulsar/Pulsar-Swift.h>; with the
+// default static libs it is reachable as "Pulsar-Swift.h" via the HEADER_SEARCH_PATHS added
+// in Pulsar.podspec.
 #if __has_include(<Pulsar/Pulsar-Swift.h>)
-// Local sources mode (USE_LOCAL_PULSAR_IOS=1): Swift is compiled into the `Pulsar` module.
 #import <Pulsar/Pulsar-Swift.h>
-#elif __has_include(<Pulsar_haptics/Pulsar_haptics-Swift.h>)
-// Published pod mode with frameworks: angle-bracket header is reachable.
-#import <Pulsar_haptics/Pulsar_haptics-Swift.h>
-#elif __has_include("Pulsar_haptics-Swift.h")
-// Published pod mode (default, static libs): the `Pulsar_haptics` Swift interface header
-// is reachable via the HEADER_SEARCH_PATHS added in Pulsar.podspec.
-#import "Pulsar_haptics-Swift.h"
 #else
 #import "Pulsar-Swift.h"
 #endif

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -11,7 +11,7 @@
     "version": "1.6.1",
     "packageName": "react-native-pulsar",
     "pulsarCore": {
-      "iosPodVersion": "1.1.4",
+      "iosPodVersion": "1.3.0",
       "androidMavenVersion": "1.1.2"
     }
   },


### PR DESCRIPTION
Faza 4, following #171 (native `s.module_name = 'Pulsar'`, shipped in Pulsar-haptics 1.3.0).

## Change

- Bump the RN bridge's native iOS pin `1.1.4 → 1.3.0` (`sdk-versions.json` + `node scripts/sync-sdk-versions.mjs`, marker `pulsar-sync:rn-pulsar-ios` in `Pulsar.podspec`), so the RN SDK builds against the module-renamed native pod, in step with the other SDKs.
- Simplify the `Haptics.mm` `__has_include` cascade: the native module is now `Pulsar` in every mode (local-sources mode already compiled into `Pulsar`; the published pod sets `s.module_name = 'Pulsar'`), so the two `Pulsar_haptics` branches are dead. Drop them, leaving `<Pulsar/Pulsar-Swift.h>` (frameworks) + the `"Pulsar-Swift.h"` fallback (static, via the podspec `HEADER_SEARCH_PATHS`). Refresh the stale comments here and in `Pulsar.podspec`.

## No module-name clash (verified, not assumed)

The RN bridge pod is itself named `Pulsar`, so pinning to a native pod whose module is now also `Pulsar` looked risky. It isn't:

- **`pod install` — no "conflicting names".** The CocoaPods framework product name derives from the **pod** name (`Pulsar-haptics`), not `module_name`, so `Pulsar` (bridge) and `Pulsar-haptics` (native) don't collide. Confirmed in both static **and** `USE_FRAMEWORKS=dynamic` linkage.
- **Compile — no clang module redefinition.** The bridge imports the native Swift interface **textually** (`#import "Pulsar-Swift.h"`; C++ modules are disabled, so `@import` isn't used), so the native `Pulsar` Swift module is never imported as a module into the bridge's own `Pulsar` module.

## Verification

Built the `Pulsar` pod scheme in the RN example (`react-native/PulsarApp`) against a local `Pulsar-haptics 1.3.0` (module `Pulsar`), static linkage: `Haptics.mm` compiles for arm64 + x86_64, **BUILD SUCCEEDED**. (Isolated against local `iOS/Pulsar` sources because the published 1.3.0's CocoaPods CDN version index was still propagating; the local podspec carries the same `module_name`/version.)

Note RN CI (`_build-ios-rn.yml`) only builds in `USE_LOCAL_PULSAR_IOS=1` mode, which compiles the native Swift into the `Pulsar` pod and never exercises the separate-native-pod path — so this published-mode build closes a gap CI doesn't cover.

## Not included

No RN package release (`reactNative.version` stays `1.6.1`); this only changes the native dependency pin, for you to fold into the next RN publish.
