### PR TITLE
ci+docs: guard the Flutter CocoaPods path and document the iOS module rename

### DIFF
--- a/.github/workflows/_build-ios-flutter-cocoapods.yml
+++ b/.github/workflows/_build-ios-flutter-cocoapods.yml
@@ -1,0 +1,76 @@
+name: build-ios-flutter-cocoapods
+
+# Reusable: build the Flutter PulsarApp on iOS with Swift Package Manager
+# DISABLED, i.e. through CocoaPods. This is the configuration from #140, where
+# the plugin's podspec was misnamed and `flutter pub get` concluded the plugin
+# was SPM-only and failed outright — the CocoaPods path was previously untested.
+# It also guards the case-insensitive module-name collision fixed in #171: with
+# the local native pod (`s.module_name = 'Pulsar'`) and the example app's
+# `use_frameworks!`, `pod install` must not report conflicting framework names.
+#
+# Built against the local iOS/Pulsar sources (USE_LOCAL_PULSAR_IOS=1), matching
+# the rest of test-build-apps.yml, so it does not depend on a published pod.
+#
+# Called from test-build-apps.yml.
+
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        description: 'debug | release'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      USE_LOCAL_PULSAR_IOS: '1'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Disable Swift Package Manager
+        # The CocoaPods path is what #140 was about; force it on this runner
+        # regardless of the Flutter channel default.
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Verify Pulsar invocation in app sources
+        run: |
+          if ! grep -qrE "package:pulsar_haptics" flutter/PulsarApp/lib; then
+            echo "::error::No pulsar_haptics import found in flutter/PulsarApp/lib." >&2
+            exit 1
+          fi
+
+      - name: Flutter pub get
+        # The #140 failure mode: with SPM off, a misnamed podspec makes this step
+        # end with "Plugin pulsar_haptics is only Swift Package Manager compatible".
+        working-directory: flutter/PulsarApp
+        run: flutter pub get
+
+      - name: Pod install
+        # Explicit so a module-name collision surfaces here with a clear message
+        # (e.g. "target has frameworks with conflicting names") rather than deep
+        # inside the Flutter build.
+        working-directory: flutter/PulsarApp/ios
+        run: pod install
+
+      - name: Build Flutter iOS PulsarApp via CocoaPods (no codesign)
+        working-directory: flutter/PulsarApp
+        run: |
+          if [[ "${{ inputs.build_type }}" == "release" ]]; then
+            flutter build ios --release --no-codesign
+          else
+            flutter build ios --debug --no-codesign --simulator
+          fi

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -189,3 +189,17 @@ jobs:
     uses: ./.github/workflows/_build-ios-flutter.yml
     with:
       build_type: ${{ matrix.build_type }}
+
+  # Same framework x platform, but through CocoaPods (Swift Package Manager
+  # disabled) — the integration path from #140 that _build-ios-flutter.yml
+  # (which goes through SPM) does not exercise.
+  ios-flutter-cocoapods:
+    needs: setup
+    if: ${{ inputs.platform_ios && inputs.framework_flutter }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ${{ fromJSON(needs.setup.outputs.build_types) }}
+    uses: ./.github/workflows/_build-ios-flutter-cocoapods.yml
+    with:
+      build_type: ${{ matrix.build_type }}

--- a/iOS/Pulsar/CHANGELOG.md
+++ b/iOS/Pulsar/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to the Pulsar iOS SDK are documented here.
+
+## 1.3.0
+
+### Changed
+
+- **CocoaPods: the pod now exposes its module as `Pulsar`.** Previously the
+  `Pulsar-haptics` pod had no explicit `module_name`, so CocoaPods derived
+  `Pulsar_haptics` from the pod name — inconsistent with Swift Package Manager,
+  which has always exposed the module as `Pulsar`, and with the documentation,
+  which has always shown `import Pulsar`. The podspec now sets
+  `s.module_name = 'Pulsar'` so both integration paths agree.
+
+  **Migration (CocoaPods only):** if your code imported the derived module name,
+  change `import Pulsar_haptics` to `import Pulsar`. This is a compile-time change
+  only — the API is unchanged. Swift Package Manager users are unaffected (the
+  module was already `Pulsar`), as is anyone who followed the documented
+  `import Pulsar`.
+
+  This also removes a case-insensitive module-name collision with the Flutter
+  plugin pod `pulsar_haptics`, which had prevented Flutter apps that use
+  `use_frameworks!` (dynamic frameworks, common with Firebase and other Swift
+  pods) from adopting the plugin.

--- a/iOS/Pulsar/README.md
+++ b/iOS/Pulsar/README.md
@@ -58,6 +58,11 @@ Then run:
 pod install
 ```
 
+> **Upgrading from 1.2.x via CocoaPods?** The pod now exposes its module as
+> `Pulsar` (matching Swift Package Manager). If you were importing the previously
+> derived module name, change `import Pulsar_haptics` to `import Pulsar`. See the
+> [CHANGELOG](./CHANGELOG.md).
+
 ### Preset example
 
 ```swift


### PR DESCRIPTION
Faza 5 + 6, closing out the CocoaPods module rename (#171).

## Faza 5 — CI guard for the Flutter CocoaPods path

`_build-ios-flutter.yml` builds the Flutter example **through Swift Package Manager** (it patches `Package.swift` to a local path dep). So the **CocoaPods** integration path — the one that broke in #140 (misnamed podspec → `flutter pub get` fails with "only Swift Package Manager compatible") and that the module-name collision from #171 affects — has had **no CI coverage**. This is exactly why #140 shipped.

New reusable workflow `_build-ios-flutter-cocoapods.yml`, wired into `test-build-apps.yml` as `ios-flutter-cocoapods` next to the SPM job (same `platform_ios && framework_flutter` gate). It:

1. `flutter config --no-enable-swift-package-manager` — forces the CocoaPods path.
2. `flutter pub get` — the #140 failure point.
3. `pod install` — so a module-name collision surfaces here with a clear message rather than deep in the build.
4. `flutter build ios --no-codesign` — end-to-end.

Runs against the local `iOS/Pulsar` sources (`USE_LOCAL_PULSAR_IOS=1`), matching the rest of `test-build-apps.yml`, so it needs no published pod. With the example app's `use_frameworks!` (#174) it also guards the collision fix.

I ran these exact steps locally against current `main` (Flutter 3.41.6, CocoaPods 1.16.2): `flutter pub get` (SPM off) succeeds, and `pod install` with the local `module_name = 'Pulsar'` pod installs cleanly — so the guard reflects real behavior, not a hypothetical.

## Faza 6 — migration note

- `iOS/Pulsar/CHANGELOG.md` (new) with a 1.3.0 entry documenting the CocoaPods module rename: `import Pulsar_haptics → import Pulsar`, compile-time only, SPM users unaffected.
- Short upgrade callout in the iOS README's CocoaPods section pointing at it.

## Dependencies / notes

- Independent of #174 and #177; can merge in any order. The guard passes both before #174 (static linkage) and after (`use_frameworks!`).
- `dispatch`-only workflow (like the rest of `test-build-apps.yml`), so it runs when you trigger it with iOS + Flutter selected — it does not add per-PR load.
