### PR TITLE
fix(ios): rename the CocoaPod to `PulsarHaptics` so use_frameworks! works everywhere

### DIFF
--- a/.github/workflows/publish-ios-cocoapods.yml
+++ b/.github/workflows/publish-ios-cocoapods.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           EXPECTED_VERSION="${{ steps.release.outputs.version }}"
           SDK_VERSION="$(ruby -rjson -e 'puts JSON.parse(File.read("sdk-versions.json")).fetch("ios").fetch("version")')"
-          PODSPEC_VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/Pulsar-haptics.podspec | head -n 1)"
+          PODSPEC_VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
 
           if [[ "$SDK_VERSION" != "$EXPECTED_VERSION" ]]; then
             echo "sdk-versions.json iOS version ($SDK_VERSION) does not match requested version ($EXPECTED_VERSION)." >&2
@@ -56,7 +56,7 @@ jobs:
           fi
 
           if [[ "$PODSPEC_VERSION" != "$EXPECTED_VERSION" ]]; then
-            echo "Pulsar-haptics.podspec version ($PODSPEC_VERSION) does not match requested version ($EXPECTED_VERSION)." >&2
+            echo "PulsarHaptics.podspec version ($PODSPEC_VERSION) does not match requested version ($EXPECTED_VERSION)." >&2
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ pulsar/
 
 The iOS and Android SDKs are standalone native libraries. The React Native (Turbo Module) and Flutter (method-channel plugin) SDKs each ship a thin bridge and consume the published native artifacts rather than vendoring a copy of the native sources:
 
-- **iOS:** the bridge podspec (`react-native/react-native-pulsar/Pulsar.podspec`, `flutter/pulsar/ios/pulsar_haptics.podspec`) depends on the published `Pulsar-haptics` CocoaPod by default. For local development in the example app, set `USE_LOCAL_PULSAR_IOS=1` before `pod install` to use `iOS/Pulsar/` instead.
+- **iOS:** the bridge podspec (`react-native/react-native-pulsar/Pulsar.podspec`, `flutter/pulsar/ios/pulsar_haptics.podspec`) depends on the published `PulsarHaptics` CocoaPod by default. For local development in the example app, set `USE_LOCAL_PULSAR_IOS=1` before `pod install` to use `iOS/Pulsar/` instead.
 - **Android:** the bridge Gradle module (`react-native/react-native-pulsar/android/build.gradle`, `flutter/pulsar/android/build.gradle.kts`) depends on the published `com.swmansion:pulsar` Maven artifact by default. For local development, set `USE_LOCAL_PULSAR_ANDROID=1` to compile against `Android/Pulsar/src/main/java/` instead.
 
 The Kotlin Multiplatform SDK (`kmp/Pulsar/library`) follows the same convention on Android:
 
 - **Android:** `kmp/Pulsar/library/build.gradle.kts` depends on the published `com.swmansion:pulsar` Maven artifact by default. Set `USE_LOCAL_PULSAR_ANDROID=1` (property or env var) to compile `androidMain` against `Android/Pulsar/src/main/java/` instead.
-- **iOS:** `iosMain` still vendors a Kotlin/Native implementation under `iosimpl/`. The Swift `Pulsar-haptics` SDK exposes `@objc` symbols so it can be consumed from Kotlin/Native via cinterop, but the KMP library is not yet wired to it (doing so would require downstream iOS apps to supply the pod at link time).
+- **iOS:** `iosMain` still vendors a Kotlin/Native implementation under `iosimpl/`. The Swift `PulsarHaptics` SDK exposes `@objc` symbols so it can be consumed from Kotlin/Native via cinterop, but the KMP library is not yet wired to it (doing so would require downstream iOS apps to supply the pod at link time).
 
 The native pod/artifact version can be overridden with `PULSAR_IOS_POD_VERSION` / `PULSAR_ANDROID_MAVEN_VERSION`.
 

--- a/flutter/PulsarApp/ios/Podfile
+++ b/flutter/PulsarApp/ios/Podfile
@@ -31,10 +31,10 @@ target 'Runner' do
   use_frameworks!
 
   if ENV['USE_LOCAL_PULSAR_IOS'] == '1'
-    Pod::UI.puts 'Using local Pulsar-haptics pod from iOS/Pulsar'.green
-    pod 'Pulsar-haptics', :path => '../../../iOS/Pulsar'
+    Pod::UI.puts 'Using local PulsarHaptics pod from iOS/Pulsar'.green
+    pod 'PulsarHaptics', :path => '../../../iOS/Pulsar'
   else
-    Pod::UI.puts 'Using published Pulsar-haptics pod from CocoaPods'.green
+    Pod::UI.puts 'Using published PulsarHaptics pod from CocoaPods'.green
   end
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
-#if canImport(Pulsar_haptics)
-import Pulsar_haptics
+#if canImport(PulsarHaptics)
+import PulsarHaptics
 #elseif canImport(Pulsar)
 import Pulsar
 #endif

--- a/flutter/pulsar/ios/pulsar_haptics.podspec
+++ b/flutter/pulsar/ios/pulsar_haptics.podspec
@@ -21,10 +21,10 @@ Dart-friendly API that bridges to native CoreHaptics on iOS.
   s.author           = { 'Software Mansion' => 'projects@swmansion.com' }
   s.source           = { :path => '.' }
   # Only the Flutter bridge lives here; the haptics implementation comes from the
-  # published Pulsar-haptics CocoaPod (or a local override, see the example Podfile).
+  # published PulsarHaptics CocoaPod (or a local override, see the example Podfile).
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Pulsar-haptics', pulsar_ios_pod_version
+  s.dependency 'PulsarHaptics', pulsar_ios_pod_version
   s.platform = :ios, '13.0'
   s.frameworks = 'CoreHaptics', 'AudioToolbox', 'AVFoundation'
 

--- a/iOS/Pulsar/CHANGELOG.md
+++ b/iOS/Pulsar/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the Pulsar iOS SDK are documented here.
+
+## Unreleased
+
+### Changed (CocoaPods only — breaking)
+
+- **The CocoaPod is renamed `Pulsar-haptics` → `PulsarHaptics`**, and its module is
+  now `PulsarHaptics` (the pod no longer overrides `module_name`). Pod name and
+  module name now agree, which is what makes the pod build under **all** CocoaPods
+  linkage modes — including `use_frameworks!` (`:linkage => :static` and
+  `:dynamic`), where the previous `Pulsar-haptics` pod with a `module_name = 'Pulsar'`
+  override failed to compile (`'Pulsar-Swift.h' file not found`).
+
+  **Migration (CocoaPods):**
+  - `pod 'Pulsar-haptics'` → `pod 'PulsarHaptics'`
+  - `import Pulsar_haptics` (or `import Pulsar`) → `import PulsarHaptics`
+
+  This is a compile-time change only; the public API is unchanged (`Pulsar()`,
+  `getPresets()`, …). **Swift Package Manager is unaffected** — it still exposes the
+  module as `Pulsar`, so SPM users keep `import Pulsar`.

--- a/iOS/Pulsar/PulsarHaptics.podspec
+++ b/iOS/Pulsar/PulsarHaptics.podspec
@@ -1,6 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = 'Pulsar-haptics'
-  s.module_name      = 'Pulsar'
+  s.name             = 'PulsarHaptics'
   s.version          = '1.3.0' # pulsar-sync:ios-version
   s.summary          = 'A haptic feedback SDK for iOS, written in Swift.'
   s.description      = <<-DESC

--- a/iOS/Pulsar/README.md
+++ b/iOS/Pulsar/README.md
@@ -48,7 +48,7 @@ Add Pulsar to your `Podfile`:
 
 <!-- GENERATED:IOS_COCOAPODS_INSTALL_SNIPPET_START -->
 ```ruby
-pod 'Pulsar-haptics', '~> 1.3.0'
+pod 'PulsarHaptics', '~> 1.3.0'
 ```
 <!-- GENERATED:IOS_COCOAPODS_INSTALL_SNIPPET_END -->
 

--- a/iOS/Pulsar/publish-cocoapods.sh
+++ b/iOS/Pulsar/publish-cocoapods.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PODSPEC_PATH="$ROOT_DIR/Pulsar-haptics.podspec"
+PODSPEC_PATH="$ROOT_DIR/PulsarHaptics.podspec"
 LINT_ONLY=false
 ALLOW_WARNINGS=true
 

--- a/react-native/react-native-pulsar/Pulsar.podspec
+++ b/react-native/react-native-pulsar/Pulsar.podspec
@@ -2,9 +2,9 @@ require "json"
 require "fileutils"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.1.4" # pulsar-sync:rn-pulsar-ios
+pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.3.0" # pulsar-sync:rn-pulsar-ios
 
-# By default depend on the published `Pulsar-haptics` CocoaPod.
+# By default depend on the published `PulsarHaptics` CocoaPod.
 # Set USE_LOCAL_PULSAR_IOS=1 to build against the in-repo `iOS/Pulsar` sources instead.
 #
 # CocoaPods only compiles files that live inside the pod's own root — its PathList
@@ -24,7 +24,7 @@ if use_local_pulsar_ios
   FileUtils.cp_r(local_pulsar_ios_sources_dir, File.join(deps_dir, "Pulsar", "Sources"))
   Pod::UI.puts "Using local Pulsar iOS sources from #{local_pulsar_ios_sources_dir}".green
 else
-  Pod::UI.puts "Using published Pulsar-haptics pod #{pulsar_ios_pod_version}".green
+  Pod::UI.puts "Using published PulsarHaptics pod #{pulsar_ios_pod_version}".green
 end
 
 Pod::Spec.new do |s|
@@ -50,12 +50,12 @@ Pod::Spec.new do |s|
   if use_local_pulsar_ios
     s.frameworks = "AVFoundation", "CoreHaptics", "UIKit"
   else
-    s.dependency "Pulsar-haptics", pulsar_ios_pod_version
-    # The published `Pulsar-haptics` pod compiles its Swift into the `Pulsar_haptics`
-    # module, whose generated ObjC interface (`Pulsar_haptics-Swift.h`) is not on this
+    s.dependency "PulsarHaptics", pulsar_ios_pod_version
+    # The published `PulsarHaptics` pod compiles its Swift into the `PulsarHaptics`
+    # module, whose generated ObjC interface (`PulsarHaptics-Swift.h`) is not on this
     # pod's header search path by default. Expose it so the ObjC++ bridge can `#import`
     # it (C++ modules are disabled, so `@import` is not an option here).
-    pod_target_xcconfig["HEADER_SEARCH_PATHS"] = '"${PODS_CONFIGURATION_BUILD_DIR}/Pulsar-haptics/Swift Compatibility Header"'
+    pod_target_xcconfig["HEADER_SEARCH_PATHS"] = '"${PODS_CONFIGURATION_BUILD_DIR}/PulsarHaptics/Swift Compatibility Header"'
   end
 
   s.pod_target_xcconfig = pod_target_xcconfig

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -1,17 +1,14 @@
 #import "Haptics.h"
 #import <UIKit/UIKit.h>
 #if __has_include(<Pulsar/Pulsar-Swift.h>)
-// Local sources mode (USE_LOCAL_PULSAR_IOS=1): Swift is compiled into the `Pulsar` module.
+// Local sources mode (USE_LOCAL_PULSAR_IOS=1): Swift compiled into this pod's `Pulsar` module.
 #import <Pulsar/Pulsar-Swift.h>
-#elif __has_include(<Pulsar_haptics/Pulsar_haptics-Swift.h>)
-// Published pod mode with frameworks: angle-bracket header is reachable.
-#import <Pulsar_haptics/Pulsar_haptics-Swift.h>
-#elif __has_include("Pulsar_haptics-Swift.h")
-// Published pod mode (default, static libs): the `Pulsar_haptics` Swift interface header
-// is reachable via the HEADER_SEARCH_PATHS added in Pulsar.podspec.
-#import "Pulsar_haptics-Swift.h"
+#elif __has_include(<PulsarHaptics/PulsarHaptics-Swift.h>)
+// Published pod with frameworks: framework-style angle-bracket header.
+#import <PulsarHaptics/PulsarHaptics-Swift.h>
 #else
-#import "Pulsar-Swift.h"
+// Published pod, static libs: reachable via the HEADER_SEARCH_PATHS in Pulsar.podspec.
+#import "PulsarHaptics-Swift.h"
 #endif
 
 @implementation RNPulsar {

--- a/scripts/sync-sdk-versions.mjs
+++ b/scripts/sync-sdk-versions.mjs
@@ -31,7 +31,7 @@ const files = [
 // version on the marked line is replaced with the value from sdk-versions.json,
 // which keeps the sync robust without per-file regexes.
 const markedVersions = [
-  { file: 'iOS/Pulsar/Pulsar-haptics.podspec', key: 'ios-version', version: versions.ios.version },
+  { file: 'iOS/Pulsar/PulsarHaptics.podspec', key: 'ios-version', version: versions.ios.version },
   { file: 'Android/Pulsar/build.gradle.kts', key: 'android-version', version: versions.android.version },
   { file: 'react-native/react-native-pulsar/Pulsar.podspec', key: 'rn-pulsar-ios', version: versions.reactNative.pulsarCore.iosPodVersion },
   { file: 'react-native/react-native-pulsar/android/build.gradle', key: 'rn-pulsar-android', version: versions.reactNative.pulsarCore.androidMavenVersion },
@@ -113,7 +113,7 @@ dependencies: [
 
 function getIosCocoaPodsSnippet() {
   return `\`\`\`ruby
-pod 'Pulsar-haptics', '~> ${versions.ios.version}'
+pod 'PulsarHaptics', '~> ${versions.ios.version}'
 \`\`\``;
 }
 

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -11,7 +11,7 @@
     "version": "1.6.1",
     "packageName": "react-native-pulsar",
     "pulsarCore": {
-      "iosPodVersion": "1.1.4",
+      "iosPodVersion": "1.3.0",
       "androidMavenVersion": "1.1.2"
     }
   },


### PR DESCRIPTION
Makes `use_frameworks!` (on **or** off) work for the native iOS SDK and both bridges (React Native, Flutter). Supersedes the `module_name` approach from the earlier work and fixes the regression that closed #177.

## Root cause

The pod was `Pulsar-haptics` with `s.module_name = 'Pulsar'`. A pod whose **name ≠ module name** does not build under `use_frameworks!`: CocoaPods derives the framework's clang module from the **pod name** (`Pulsar_haptics`), while the override renames the Swift artifacts to `Pulsar` — leaving a Swift header no `#import` reaches. That's the `'Pulsar-Swift.h' file not found` from #10 / #26, reproduced here in every `use_frameworks!` linkage mode. It affects native CocoaPods consumers **and** the RN bridge; the Flutter bridge dodged it only via Swift's `canImport`.

Whenever pod name **==** module name (the RN bridge `Pulsar`, or the pre-override native `Pulsar-haptics`/`Pulsar_haptics`), frameworks builds work. The override is the whole problem.

## Fix

Rename the pod **`Pulsar-haptics` → `PulsarHaptics`** and drop the `module_name` override, so **pod name == module name == `PulsarHaptics`**. That name collides with neither the Flutter plugin pod (`pulsar_haptics`) nor the RN bridge pod (`Pulsar`), and because name and module agree it builds in all linkage modes. (`Pulsar` itself is taken on CocoaPods trunk and clashes with the RN bridge pod, so it isn't an option.)

- **Native:** rename podspec + `s.name`, drop `module_name`; update `publish-cocoapods.sh`, `publish-ios-cocoapods.yml`, and the sync script's CocoaPods snippet.
- **React Native:** depend on `PulsarHaptics`, point `HEADER_SEARCH_PATHS` at it, update the `Haptics.mm` `__has_include` cascade. Native pin `1.1.4 → 1.3.0`.
- **Flutter:** depend on `PulsarHaptics`; bridge shim `#if canImport(PulsarHaptics) #elseif canImport(Pulsar)`.
- Example Podfiles, `CONTRIBUTING.md`, iOS README (regenerated), and `iOS/Pulsar/CHANGELOG.md` migration note.

## Swift Package Manager is untouched

SPM (`pulsar-ios`) still exposes `Pulsar`; SPM users keep `import Pulsar`. The Flutter shim's `canImport(Pulsar)` covers the SPM path. **Only CocoaPods consumers migrate:** `pod 'Pulsar-haptics' → pod 'PulsarHaptics'`, `import Pulsar_haptics → import PulsarHaptics`.

## Verification (real builds, native `PulsarHaptics` from local sources)

| Consumer | static libs | `:linkage => :static` | dynamic frameworks |
| --- | --- | --- | --- |
| React Native | ✅ SUCCEEDED | ✅ SUCCEEDED | ✅ SUCCEEDED |
| Flutter | ✅ (known) | ✅ `✓ Built Runner.app` | ✅ (pod install, no conflicting names) |

The prior `Pulsar-haptics` + `module_name` override **failed** the frameworks builds (`'Pulsar-Swift.h' file not found`) — see #177 for that evidence.

## After merge

1. Publish the new pod on trunk under its new name: **`PulsarHaptics`** (the publish workflow now points at `PulsarHaptics.podspec`).
2. Once published, regenerate the example `Podfile.lock`s (and bump the RN/Flutter bridge releases when you cut them).

## Coordinates with #178

#178's CHANGELOG/README narrative ("module → `Pulsar`, `import Pulsar`") is **superseded** by this rename. Its Flutter CocoaPods CI cell is still useful; recommend reconciling #178 on top of this (or folding it in) and extending the guard to a `use_frameworks!` build against the separate `PulsarHaptics` pod — the configuration that actually regressed and that CI does not cover today.
