### PR TITLE
ci(ios): guard RN and Flutter under CocoaPods with and without use_frameworks!

### DIFF
--- a/.github/workflows/_build-ios-flutter-cocoapods.yml
+++ b/.github/workflows/_build-ios-flutter-cocoapods.yml
@@ -1,0 +1,84 @@
+name: build-ios-flutter-cocoapods
+
+# Reusable: build the Flutter PulsarApp on iOS through CocoaPods (Swift Package
+# Manager DISABLED) across a linkage mode. Covers two regressions at once:
+#   * #140 — a misnamed podspec made `flutter pub get` conclude the plugin was
+#     SPM-only and fail; the CocoaPods path had no coverage.
+#   * #10 / #26 class — the native pod failing to build under `use_frameworks!`
+#     when its name and module name disagreed (fixed by renaming the pod to
+#     `PulsarHaptics`, so name == module).
+#
+# The native pod is consumed as a separate local pod (USE_LOCAL_PULSAR_IOS=1),
+# matching the rest of test-build-apps.yml — no trunk round-trip. Called from
+# test-build-apps.yml.
+
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        description: 'debug | release'
+        required: true
+        type: string
+      linkage:
+        description: 'none | static | dynamic (CocoaPods linkage)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Verify Pulsar invocation in app sources
+        run: |
+          if ! grep -qrE "package:pulsar_haptics" flutter/PulsarApp/lib; then
+            echo "::error::No pulsar_haptics import found in flutter/PulsarApp/lib." >&2
+            exit 1
+          fi
+
+      - name: Resolve local PulsarHaptics version
+        id: pod
+        shell: bash
+        run: |
+          VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Could not read s.version from iOS/Pulsar/PulsarHaptics.podspec." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Flutter pub get
+        working-directory: flutter/PulsarApp
+        run: flutter pub get
+
+      - name: Build Flutter iOS PulsarApp via CocoaPods (linkage=${{ inputs.linkage }}, no codesign)
+        working-directory: flutter/PulsarApp
+        shell: bash
+        env:
+          USE_LOCAL_PULSAR_IOS: '1'
+          PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}
+        run: |
+          if [[ "${{ inputs.linkage }}" != "none" ]]; then
+            export USE_FRAMEWORKS="${{ inputs.linkage }}"
+          fi
+          if [[ "${{ inputs.build_type }}" == "release" ]]; then
+            flutter build ios --release --no-codesign
+          else
+            flutter build ios --debug --no-codesign --simulator
+          fi

--- a/.github/workflows/_build-ios-rn-cocoapods.yml
+++ b/.github/workflows/_build-ios-rn-cocoapods.yml
@@ -1,0 +1,98 @@
+name: build-ios-rn-cocoapods
+
+# Reusable: build the React Native PulsarApp on iOS against the native
+# `PulsarHaptics` pod consumed as a SEPARATE local pod (bridge in published
+# mode), across a CocoaPods linkage mode. This is the configuration real
+# consumers get from the published pod — and the one that regressed under
+# `use_frameworks!` when the pod name and module name disagreed (issues #10 /
+# #26). The default `_build-ios-rn.yml` uses USE_LOCAL_PULSAR_IOS, which compiles
+# the native Swift *into* the bridge's `Pulsar` module and never exercises this
+# path, so this guard is complementary.
+#
+# Built against local iOS/Pulsar sources (no trunk round-trip). Called from
+# test-build-apps.yml.
+
+on:
+  workflow_call:
+    inputs:
+      build_type:
+        description: 'debug | release'
+        required: true
+        type: string
+      linkage:
+        description: 'none | static | dynamic (CocoaPods linkage)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Setup Ruby (for CocoaPods)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: react-native/PulsarApp
+
+      - name: Install RN library deps and build TS output
+        working-directory: react-native/react-native-pulsar
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install example app JS deps
+        working-directory: react-native/PulsarApp
+        run: npm ci
+
+      - name: Resolve local PulsarHaptics version
+        id: pod
+        shell: bash
+        run: |
+          VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Could not read s.version from iOS/Pulsar/PulsarHaptics.podspec." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Local PulsarHaptics version: $VERSION"
+
+      - name: Install pods (separate local PulsarHaptics pod, linkage=${{ inputs.linkage }})
+        working-directory: react-native/PulsarApp/ios
+        shell: bash
+        env:
+          USE_LOCAL_PULSAR_POD: '1'
+          # Pin the bridge dependency to the local podspec's version so the build
+          # does not depend on the RN pin in sdk-versions.json being aligned.
+          PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}
+        run: |
+          if [[ "${{ inputs.linkage }}" != "none" ]]; then
+            export USE_FRAMEWORKS="${{ inputs.linkage }}"
+          fi
+          bundle exec pod install
+
+      - name: Build React Native iOS example app (linkage=${{ inputs.linkage }})
+        working-directory: react-native/PulsarApp/ios
+        run: |
+          CONFIG=$( [[ "${{ inputs.build_type }}" == "release" ]] && echo "Release" || echo "Debug" )
+          xcodebuild \
+            -workspace example.xcworkspace \
+            -scheme example \
+            -configuration "$CONFIG" \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -168,6 +168,21 @@ jobs:
     with:
       build_type: ${{ matrix.build_type }}
 
+  # React Native against the separate published-style `PulsarHaptics` pod, across
+  # CocoaPods linkage modes (with and without use_frameworks!) — the path that
+  # regressed in #10 / #26 and that _build-ios-rn.yml (compiled-in) never covers.
+  ios-rn-cocoapods:
+    needs: setup
+    if: ${{ inputs.platform_ios && inputs.framework_rn }}
+    strategy:
+      fail-fast: false
+      matrix:
+        linkage: [none, static, dynamic]
+    uses: ./.github/workflows/_build-ios-rn-cocoapods.yml
+    with:
+      build_type: debug
+      linkage: ${{ matrix.linkage }}
+
   ios-kmp:
     needs: setup
     if: ${{ inputs.platform_ios && inputs.framework_kmp }}
@@ -189,3 +204,17 @@ jobs:
     uses: ./.github/workflows/_build-ios-flutter.yml
     with:
       build_type: ${{ matrix.build_type }}
+
+  # Flutter through CocoaPods (SPM disabled), across linkage modes (with and
+  # without use_frameworks!) — guards #140 and the #10 / #26 frameworks class.
+  ios-flutter-cocoapods:
+    needs: setup
+    if: ${{ inputs.platform_ios && inputs.framework_flutter }}
+    strategy:
+      fail-fast: false
+      matrix:
+        linkage: [none, static, dynamic]
+    uses: ./.github/workflows/_build-ios-flutter-cocoapods.yml
+    with:
+      build_type: debug
+      linkage: ${{ matrix.linkage }}

--- a/flutter/PulsarApp/ios/Podfile
+++ b/flutter/PulsarApp/ios/Podfile
@@ -28,7 +28,13 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  # Linkage is env-driven so CI can build with and without frameworks
+  # (USE_FRAMEWORKS unset => static libs; 'static'/'dynamic' => use_frameworks!).
+  linkage = ENV['USE_FRAMEWORKS']
+  unless linkage.nil?
+    Pod::UI.puts "Configuring Pods with #{linkage}ally linked frameworks".green
+    use_frameworks! :linkage => linkage.to_sym
+  end
 
   if ENV['USE_LOCAL_PULSAR_IOS'] == '1'
     Pod::UI.puts 'Using local PulsarHaptics pod from iOS/Pulsar'.green

--- a/react-native/PulsarApp/ios/Podfile
+++ b/react-native/PulsarApp/ios/Podfile
@@ -18,6 +18,14 @@ end
 target 'example' do
   config = use_native_modules!
 
+  # CI guard: consume the native `PulsarHaptics` pod from local sources as a
+  # *separate* pod (the bridge stays in published mode), so the build exercises
+  # the real published-pod path across linkage modes without a trunk round-trip.
+  if ENV['USE_LOCAL_PULSAR_POD'] == '1'
+    Pod::UI.puts 'Using local PulsarHaptics pod from iOS/Pulsar'.green
+    pod 'PulsarHaptics', :path => '../../../iOS/Pulsar'
+  end
+
   use_react_native!(
     :path => config[:reactNativePath],
     # An absolute path to your application root.


### PR DESCRIPTION
Replaces #178 (which is now conflicting — its CHANGELOG/README landed in #179 with the correct `PulsarHaptics` narrative). Keeps #178's still-useful CI guard, updated for the rename, and extends it to the configuration that actually regressed.

## Why

The `use_frameworks!` regression fixed by #179 (native pod name ≠ module name → `'Pulsar-Swift.h' file not found`, the #10 / #26 class) was invisible to CI:

- `_build-ios-rn.yml` builds only `USE_LOCAL_PULSAR_IOS=1`, which compiles the native Swift **into** the bridge's own `Pulsar` module — it never installs the native pod as a separate pod, so it can't reproduce the frameworks header-resolution failure.
- There was no CocoaPods Flutter job at all (the existing Flutter job goes through Swift Package Manager, which doesn't cover the #140 path).

## What

Two reusable workflows build each example against the native **`PulsarHaptics` pod as a SEPARATE local pod** (what a real published-pod consumer gets), across all three CocoaPods linkage modes — **none (static libs), `use_frameworks! :linkage => :static`, and `:dynamic`**:

- **`_build-ios-rn-cocoapods.yml`** — RN bridge stays in published mode and pulls `pod 'PulsarHaptics', :path` via a new `USE_LOCAL_PULSAR_POD` flag in the example Podfile.
- **`_build-ios-flutter-cocoapods.yml`** — Flutter with SPM disabled + `USE_LOCAL_PULSAR_IOS=1`; the example Podfile's linkage is now env-driven (`USE_FRAMEWORKS`), so it builds with and without frameworks.

Both resolve `PULSAR_IOS_POD_VERSION` from the local `PulsarHaptics.podspec`, so the guard does **not** depend on the RN/Flutter pins in `sdk-versions.json` being aligned to the current native version.

Wired into `test-build-apps.yml` as `ios-rn-cocoapods` and `ios-flutter-cocoapods`, each with a `linkage: [none, static, dynamic]` matrix (debug).

## Notable side change

`flutter/PulsarApp/ios/Podfile` no longer hard-codes `use_frameworks!` — linkage is env-driven (mirrors the RN example). Committed default is now static libs; CI covers the frameworks modes.

## Verification

Ran locally against local `PulsarHaptics 1.4.0`: both examples `pod install` and build in all three linkage modes (`none` / `static` / `dynamic`), with no `'Pulsar-Swift.h' file not found` and no conflicting-names errors. On the pre-#179 pod (`Pulsar-haptics` + `module_name` override) the frameworks cells failed — see #177 / #179 for that evidence.
