### PR TITLE
chore: make sdk-versions.json the single source of SDK versions

### DIFF
--- a/.github/workflows/_build-ios-flutter-cocoapods.yml
+++ b/.github/workflows/_build-ios-flutter-cocoapods.yml
@@ -52,17 +52,6 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve local PulsarHaptics version
-        id: pod
-        shell: bash
-        run: |
-          VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
-          if [[ -z "$VERSION" ]]; then
-            echo "::error::Could not read s.version from iOS/Pulsar/PulsarHaptics.podspec." >&2
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Flutter pub get
         working-directory: flutter/PulsarApp
         run: flutter pub get
@@ -72,7 +61,6 @@ jobs:
         shell: bash
         env:
           USE_LOCAL_PULSAR_IOS: '1'
-          PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}
         run: |
           if [[ "${{ inputs.linkage }}" != "none" ]]; then
             export USE_FRAMEWORKS="${{ inputs.linkage }}"

--- a/.github/workflows/_build-ios-rn-cocoapods.yml
+++ b/.github/workflows/_build-ios-rn-cocoapods.yml
@@ -58,26 +58,11 @@ jobs:
         working-directory: react-native/PulsarApp
         run: npm ci
 
-      - name: Resolve local PulsarHaptics version
-        id: pod
-        shell: bash
-        run: |
-          VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
-          if [[ -z "$VERSION" ]]; then
-            echo "::error::Could not read s.version from iOS/Pulsar/PulsarHaptics.podspec." >&2
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Local PulsarHaptics version: $VERSION"
-
       - name: Install pods (separate local PulsarHaptics pod, linkage=${{ inputs.linkage }})
         working-directory: react-native/PulsarApp/ios
         shell: bash
         env:
           USE_LOCAL_PULSAR_POD: '1'
-          # Pin the bridge dependency to the local podspec's version so the build
-          # does not depend on the RN pin in sdk-versions.json being aligned.
-          PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}
         run: |
           if [[ "${{ inputs.linkage }}" != "none" ]]; then
             export USE_FRAMEWORKS="${{ inputs.linkage }}"

--- a/flutter/pulsar/android/build.gradle.kts
+++ b/flutter/pulsar/android/build.gradle.kts
@@ -36,7 +36,7 @@ fun getStringPropertyOrEnv(name: String, defaultValue: String): String {
 // artifact. Set USE_LOCAL_PULSAR_ANDROID=1 to compile against the in-repo sources
 // under Android/Pulsar instead (useful when iterating on the native SDK).
 val useLocalPulsarAndroid = getStringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-val pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.3.0") // pulsar-sync:flutter-pulsar-android
+val pulsarAndroidVersion = "1.3.0" // pulsar-sync:flutter-pulsar-android
 val localPulsarAndroidSourceDir = file("../../../Android/Pulsar/src/main/java")
 
 if (useLocalPulsarAndroid) {

--- a/flutter/pulsar/ios/pulsar_haptics.podspec
+++ b/flutter/pulsar/ios/pulsar_haptics.podspec
@@ -5,7 +5,7 @@
 # File name and `s.name` must stay equal to the pub package name — Flutter
 # derives both the podspec path it looks for and the module it imports from it.
 #
-pulsar_ios_pod_version = ENV['PULSAR_IOS_POD_VERSION'] || '1.3.0' # pulsar-sync:flutter-pulsar-ios
+pulsar_ios_pod_version = '1.3.0' # pulsar-sync:flutter-pulsar-ios
 
 Pod::Spec.new do |s|
   s.name             = 'pulsar_haptics'

--- a/kmp/Pulsar/library/build.gradle.kts
+++ b/kmp/Pulsar/library/build.gradle.kts
@@ -17,7 +17,7 @@ fun stringPropertyOrEnv(name: String, defaultValue: String): String =
 // Android: by default depend on the published `com.swmansion:pulsar` Maven artifact.
 // Set USE_LOCAL_PULSAR_ANDROID=1 to compile against the local `Android/Pulsar` sources instead.
 val useLocalPulsarAndroid = stringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-val pulsarAndroidVersion = stringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.1") // pulsar-sync:kmp-pulsar-android
+val pulsarAndroidVersion = "1.1.1" // pulsar-sync:kmp-pulsar-android
 val localPulsarAndroidSourceDir = rootDir.resolve("../../Android/Pulsar/src/main/java")
 
 // When compiling the local Android sources we must also provide the `com.swmansion.pulsar.BuildConfig`

--- a/react-native/react-native-pulsar/Pulsar.podspec
+++ b/react-native/react-native-pulsar/Pulsar.podspec
@@ -2,7 +2,7 @@ require "json"
 require "fileutils"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-pulsar_ios_pod_version = ENV["PULSAR_IOS_POD_VERSION"] || "1.3.0" # pulsar-sync:rn-pulsar-ios
+pulsar_ios_pod_version = "1.3.0" # pulsar-sync:rn-pulsar-ios
 
 # By default depend on the published `PulsarHaptics` CocoaPod.
 # Set USE_LOCAL_PULSAR_IOS=1 to build against the in-repo `iOS/Pulsar` sources instead.

--- a/react-native/react-native-pulsar/android/build.gradle
+++ b/react-native/react-native-pulsar/android/build.gradle
@@ -31,7 +31,7 @@ def getStringPropertyOrEnv(name, defaultValue) {
 }
 
 def useLocalPulsarAndroid = getStringPropertyOrEnv("USE_LOCAL_PULSAR_ANDROID", "0") == "1"
-def pulsarAndroidVersion = getStringPropertyOrEnv("PULSAR_ANDROID_MAVEN_VERSION", "1.1.2") // pulsar-sync:rn-pulsar-android
+def pulsarAndroidVersion = "1.1.2" // pulsar-sync:rn-pulsar-android
 def localPulsarAndroidDir = new File(projectDir, "../../../Android/Pulsar")
 def localPulsarAndroidSourceDir = new File(localPulsarAndroidDir, "src/main/java")
 


### PR DESCRIPTION
## What

`some SDK configuration used PULSAR_IOS_POD_VERSION / PULSAR_ANDROID_MAVEN_VERSION` as a version indicator. Those env overrides are no longer needed — `sdk-versions.json` (propagated by `scripts/sync-sdk-versions.mjs`) is now the sole source of truth for SDK versions.

## Changes

**Build files** — drop the env read, keep the synced hardcoded version and its `pulsar-sync:` marker:
- `react-native/react-native-pulsar/Pulsar.podspec`
- `flutter/pulsar/ios/pulsar_haptics.podspec`
- `react-native/react-native-pulsar/android/build.gradle`
- `flutter/pulsar/android/build.gradle.kts`
- `kmp/Pulsar/library/build.gradle.kts`

The `getStringPropertyOrEnv` / `stringPropertyOrEnv` helpers stay — they still drive `USE_LOCAL_PULSAR_ANDROID`.

**CI workflows** — remove the "Resolve local PulsarHaptics version" step and the `PULSAR_IOS_POD_VERSION` override:
- `.github/workflows/_build-ios-rn-cocoapods.yml`
- `.github/workflows/_build-ios-flutter-cocoapods.yml`

**Alignment** — bump `reactNative.pulsarCore.iosPodVersion` and `flutter.pulsarCore.iosPodVersion` to `1.4.0` in `sdk-versions.json` to match the local `iOS/Pulsar` pod, so the CocoaPods local-pod CI jobs resolve without the override.

## Notes

- The two CocoaPods CI jobs now build the bridge against PulsarHaptics `1.4.0` (resolving to the in-repo pod on the local path). Going forward these iOS pins must be kept aligned with `iOS/Pulsar` in `sdk-versions.json` rather than auto-derived in CI.
- Android pins were intentionally left untouched — no CI overrode them and they can legitimately trail `android.version`.