### PR TITLE
ci: add configurable use_local_pulsar parameter to app-build workflows

### DIFF
--- a/.github/workflows/_build-android-flutter.yml
+++ b/.github/workflows/_build-android-flutter.yml
@@ -1,9 +1,10 @@
 name: build-android-flutter
 
-# Reusable: build the Flutter PulsarApp APK against the local Pulsar
-# Android sources (via USE_LOCAL_PULSAR_ANDROID). Building the PulsarApp
-# APK transitively builds the flutter/pulsar plugin. Called from
-# test-build-apps.yml.
+# Reusable: build the Flutter PulsarApp APK. Building the PulsarApp APK
+# transitively builds the flutter/pulsar plugin. By default it builds against
+# the local Pulsar Android sources (via USE_LOCAL_PULSAR_ANDROID); pass
+# use_local_pulsar: false to build against the published com.swmansion:pulsar
+# artifact instead. Called from test-build-apps.yml.
 
 on:
   workflow_call:
@@ -12,6 +13,11 @@ on:
         description: 'debug | release'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Build against local Android/Pulsar sources (true) or the published com.swmansion:pulsar artifact (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -48,7 +54,7 @@ jobs:
       - name: Build Flutter Android PulsarApp
         working-directory: flutter/PulsarApp
         env:
-          USE_LOCAL_PULSAR_ANDROID: '1'
+          USE_LOCAL_PULSAR_ANDROID: ${{ inputs.use_local_pulsar && '1' || '0' }}
         run: |
           if [[ "${{ inputs.build_type }}" == "release" ]]; then
             flutter build apk --release

--- a/.github/workflows/_build-android-kmp.yml
+++ b/.github/workflows/_build-android-kmp.yml
@@ -1,10 +1,13 @@
 name: build-android-kmp
 
-# Reusable: build the KMP composeApp on Android against the local Pulsar
-# Android sources. The kmp/PulsarApp settings.gradle.kts uses
-# includeBuild("../Pulsar") with a dependency substitution, so assembling
-# the composeApp transitively builds the local KMP library — no separate
-# library-assemble step needed. Called from test-build-apps.yml.
+# Reusable: build the KMP composeApp on Android. The kmp/PulsarApp
+# settings.gradle.kts uses includeBuild("../Pulsar") with a dependency
+# substitution, so assembling the composeApp transitively builds the local KMP
+# library — no separate library-assemble step needed. The KMP library's own
+# Android dependency is what use_local_pulsar toggles: by default it compiles
+# the local Android/Pulsar sources (USE_LOCAL_PULSAR_ANDROID); pass
+# use_local_pulsar: false to depend on the published com.swmansion:pulsar
+# artifact instead. Called from test-build-apps.yml.
 
 on:
   workflow_call:
@@ -13,6 +16,11 @@ on:
         description: 'debug | release'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'KMP library builds against local Android/Pulsar sources (true) or the published com.swmansion:pulsar artifact (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -39,7 +47,7 @@ jobs:
       - name: Build KMP Android PulsarApp (composeApp)
         working-directory: kmp/PulsarApp
         env:
-          USE_LOCAL_PULSAR_ANDROID: '1'
+          USE_LOCAL_PULSAR_ANDROID: ${{ inputs.use_local_pulsar && '1' || '0' }}
         run: |
           if [[ "${{ inputs.build_type }}" == "release" ]]; then
             ./gradlew :composeApp:assembleRelease

--- a/.github/workflows/_build-android-rn.yml
+++ b/.github/workflows/_build-android-rn.yml
@@ -1,8 +1,9 @@
 name: build-android-rn
 
-# Reusable: build the React Native PulsarApp on Android against the local
-# Pulsar Android sources (via USE_LOCAL_PULSAR_ANDROID). Called from
-# test-build-apps.yml.
+# Reusable: build the React Native PulsarApp on Android. By default it builds
+# against the local Pulsar Android sources (via USE_LOCAL_PULSAR_ANDROID); pass
+# use_local_pulsar: false to build against the published com.swmansion:pulsar
+# artifact instead. Called from test-build-apps.yml.
 
 on:
   workflow_call:
@@ -11,6 +12,11 @@ on:
         description: 'debug | release'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Build against local Android/Pulsar sources (true) or the published com.swmansion:pulsar artifact (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -49,16 +55,16 @@ jobs:
             exit 1
           fi
 
-      - name: Build local Pulsar Android library (via RN bridge module)
+      - name: Build Pulsar Android library (via RN bridge module, local sources = ${{ inputs.use_local_pulsar }})
         working-directory: react-native/PulsarApp/android
         env:
-          USE_LOCAL_PULSAR_ANDROID: '1'
+          USE_LOCAL_PULSAR_ANDROID: ${{ inputs.use_local_pulsar && '1' || '0' }}
         run: ./gradlew :react-native-pulsar:assembleDebug
 
       - name: Build React Native Android example app
         working-directory: react-native/PulsarApp/android
         env:
-          USE_LOCAL_PULSAR_ANDROID: '1'
+          USE_LOCAL_PULSAR_ANDROID: ${{ inputs.use_local_pulsar && '1' || '0' }}
         run: |
           if [[ "${{ inputs.build_type }}" == "release" ]]; then
             ./gradlew :app:assembleRelease

--- a/.github/workflows/_build-ios-flutter-cocoapods.yml
+++ b/.github/workflows/_build-ios-flutter-cocoapods.yml
@@ -8,9 +8,10 @@ name: build-ios-flutter-cocoapods
 #     when its name and module name disagreed (fixed by renaming the pod to
 #     `PulsarHaptics`, so name == module).
 #
-# The native pod is consumed as a separate local pod (USE_LOCAL_PULSAR_IOS=1),
-# matching the rest of test-build-apps.yml — no trunk round-trip. Called from
-# test-build-apps.yml.
+# By default the native pod is consumed as a separate local pod
+# (USE_LOCAL_PULSAR_IOS=1), matching the rest of test-build-apps.yml — no trunk
+# round-trip. Pass use_local_pulsar_ios: false to build against the published
+# PulsarHaptics pod instead. Called from test-build-apps.yml.
 
 on:
   workflow_call:
@@ -23,6 +24,11 @@ on:
         description: 'none | static | dynamic (CocoaPods linkage)'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Build against local iOS/Pulsar sources (true) or the published PulsarHaptics pod (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -71,7 +77,7 @@ jobs:
         working-directory: flutter/PulsarApp
         shell: bash
         env:
-          USE_LOCAL_PULSAR_IOS: '1'
+          USE_LOCAL_PULSAR_IOS: ${{ inputs.use_local_pulsar && '1' || '0' }}
           PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}
         run: |
           if [[ "${{ inputs.linkage }}" != "none" ]]; then

--- a/.github/workflows/_build-ios-flutter.yml
+++ b/.github/workflows/_build-ios-flutter.yml
@@ -1,13 +1,14 @@
 name: build-ios-flutter
 
-# Reusable: build the Flutter PulsarApp on iOS Simulator against the local
-# Pulsar Swift Package. Called from test-build-apps.yml.
+# Reusable: build the Flutter PulsarApp on iOS Simulator against the Pulsar
+# Swift Package. Called from test-build-apps.yml.
 #
 # The plugin's published Package.swift depends on Pulsar-ios by URL pinned
-# to `from: "1.1.4"`. We rewrite that to a path dep pointing at the local
-# iOS/Pulsar tree — routed through a uniquely-named symlink in
+# to `from: "1.1.4"`. By default we rewrite that to a path dep pointing at the
+# local iOS/Pulsar tree — routed through a uniquely-named symlink in
 # `$RUNNER_TEMP` to avoid an SPM identity collision (see the comment on
-# the patch step for the gory details).
+# the patch step for the gory details). Pass use_local_pulsar: false to skip
+# the patch and resolve the published remote package instead.
 
 on:
   workflow_call:
@@ -16,6 +17,11 @@ on:
         description: 'debug | release'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Patch the plugin SPM dep to local iOS/Pulsar sources (true) or resolve the published remote package (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -55,6 +61,7 @@ jobs:
       # mirror is `pulsar_haptics` now, so keep the symlink only as a
       # guard against the next name that collides.
       - name: Patch plugin SPM dep to local iOS/Pulsar sources
+        if: ${{ inputs.use_local_pulsar }}
         env:
           PULSAR_ABS_PATH: ${{ github.workspace }}/iOS/Pulsar
         run: |

--- a/.github/workflows/_build-ios-rn-cocoapods.yml
+++ b/.github/workflows/_build-ios-rn-cocoapods.yml
@@ -9,8 +9,9 @@ name: build-ios-rn-cocoapods
 # the native Swift *into* the bridge's `Pulsar` module and never exercises this
 # path, so this guard is complementary.
 #
-# Built against local iOS/Pulsar sources (no trunk round-trip). Called from
-# test-build-apps.yml.
+# By default built against local iOS/Pulsar sources (no trunk round-trip); pass
+# use_local_pulsar: false to consume the published PulsarHaptics pod from trunk
+# instead. Called from test-build-apps.yml.
 
 on:
   workflow_call:
@@ -23,6 +24,11 @@ on:
         description: 'none | static | dynamic (CocoaPods linkage)'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Consume the PulsarHaptics pod from local iOS/Pulsar sources (true) or from the published trunk pod (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -70,11 +76,11 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Local PulsarHaptics version: $VERSION"
 
-      - name: Install pods (separate local PulsarHaptics pod, linkage=${{ inputs.linkage }})
+      - name: Install pods (separate PulsarHaptics pod, local sources = ${{ inputs.use_local_pulsar }}, linkage=${{ inputs.linkage }})
         working-directory: react-native/PulsarApp/ios
         shell: bash
         env:
-          USE_LOCAL_PULSAR_POD: '1'
+          USE_LOCAL_PULSAR_POD: ${{ inputs.use_local_pulsar && '1' || '0' }}
           # Pin the bridge dependency to the local podspec's version so the build
           # does not depend on the RN pin in sdk-versions.json being aligned.
           PULSAR_IOS_POD_VERSION: ${{ steps.pod.outputs.version }}

--- a/.github/workflows/_build-ios-rn.yml
+++ b/.github/workflows/_build-ios-rn.yml
@@ -1,8 +1,10 @@
 name: build-ios-rn
 
-# Reusable: build the React Native PulsarApp on iOS Simulator against the
-# local Pulsar iOS sources (via USE_LOCAL_PULSAR_IOS, which flips the pod
-# install to the local podspec). Called from test-build-apps.yml.
+# Reusable: build the React Native PulsarApp on iOS Simulator. By default it
+# builds against the local Pulsar iOS sources (via USE_LOCAL_PULSAR_IOS, which
+# flips the pod install to the local podspec); pass use_local_pulsar_ios: false
+# to build against the published PulsarHaptics pod instead. Called from
+# test-build-apps.yml.
 
 on:
   workflow_call:
@@ -11,6 +13,11 @@ on:
         description: 'debug | release'
         required: true
         type: string
+      use_local_pulsar:
+        description: 'Build against local iOS/Pulsar sources (true) or the published PulsarHaptics pod (false)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -53,10 +60,10 @@ jobs:
             exit 1
           fi
 
-      - name: Install pods (using local Pulsar iOS sources)
+      - name: Install pods (local Pulsar iOS sources = ${{ inputs.use_local_pulsar }})
         working-directory: react-native/PulsarApp/ios
         env:
-          USE_LOCAL_PULSAR_IOS: '1'
+          USE_LOCAL_PULSAR_IOS: ${{ inputs.use_local_pulsar && '1' || '0' }}
         run: bundle exec pod install
 
       - name: Build React Native iOS example app

--- a/.github/workflows/test-build-apps.yml
+++ b/.github/workflows/test-build-apps.yml
@@ -52,6 +52,10 @@ on:
         description: 'Build type: Release'
         type: boolean
         default: false
+      use_local_pulsar:
+        description: 'Build the framework example apps against the local Pulsar sources (USE_LOCAL_PULSAR_ANDROID / USE_LOCAL_PULSAR_IOS). Uncheck to build against the published artifacts instead. Does not affect the native or KMP cells, which are always local.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -121,6 +125,7 @@ jobs:
     uses: ./.github/workflows/_build-android-rn.yml
     with:
       build_type: ${{ matrix.build_type }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   android-kmp:
     needs: setup
@@ -132,6 +137,7 @@ jobs:
     uses: ./.github/workflows/_build-android-kmp.yml
     with:
       build_type: ${{ matrix.build_type }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   android-flutter:
     needs: setup
@@ -143,6 +149,7 @@ jobs:
     uses: ./.github/workflows/_build-android-flutter.yml
     with:
       build_type: ${{ matrix.build_type }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   # --- iOS jobs ----------------------------------------------------------
 
@@ -167,6 +174,7 @@ jobs:
     uses: ./.github/workflows/_build-ios-rn.yml
     with:
       build_type: ${{ matrix.build_type }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   # React Native against the separate published-style `PulsarHaptics` pod, across
   # CocoaPods linkage modes (with and without use_frameworks!) — the path that
@@ -182,6 +190,7 @@ jobs:
     with:
       build_type: debug
       linkage: ${{ matrix.linkage }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   ios-kmp:
     needs: setup
@@ -204,6 +213,7 @@ jobs:
     uses: ./.github/workflows/_build-ios-flutter.yml
     with:
       build_type: ${{ matrix.build_type }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}
 
   # Flutter through CocoaPods (SPM disabled), across linkage modes (with and
   # without use_frameworks!) — guards #140 and the #10 / #26 frameworks class.
@@ -218,3 +228,4 @@ jobs:
     with:
       build_type: debug
       linkage: ${{ matrix.linkage }}
+      use_local_pulsar: ${{ inputs.use_local_pulsar }}


### PR DESCRIPTION
## What

Adds a single **\`use_local_pulsar\`** boolean input to the **Test Build Apps** dispatch form (\`workflow_dispatch\`, default \`true\`), threaded through to every framework example-app cell. It replaces the previous per-platform hardcoding of the local-source flags with one uniform knob.

## Why

Every Android example-app cell already built against local sources via \`USE_LOCAL_PULSAR_ANDROID\`, but the iOS cells were inconsistent — only some carried \`USE_LOCAL_PULSAR_IOS\`, and there was no way to flip any cell to build against the *published* artifacts (what real consumers get). This unifies the toggle so a single checkbox switches local ↔ published across all framework cells.

## How it maps

Each reusable workflow declares a \`use_local_pulsar\` \`workflow_call\` input (default \`true\`) and maps it to its own integration mechanism:

| Cell | Mechanism driven |
|---|---|
| \`android-rn\`, \`android-kmp\`, \`android-flutter\` | \`USE_LOCAL_PULSAR_ANDROID\` = \`1\`/\`0\` → local \`Android/Pulsar\` vs published \`com.swmansion:pulsar\` |
| \`ios-rn\`, \`ios-flutter-cocoapods\` | \`USE_LOCAL_PULSAR_IOS\` = \`1\`/\`0\` → local \`iOS/Pulsar\` vs published \`PulsarHaptics\` pod |
| \`ios-rn-cocoapods\` | \`USE_LOCAL_PULSAR_POD\` = \`1\`/\`0\` → separate local pod vs published trunk pod |
| \`ios-flutter\` (SPM) | \`if:\`-gated manifest-patch step → local path symlink vs published remote package |

Mapping expression: \`\${{ inputs.use_local_pulsar && '1' || '0' }}\`.

## Out of scope

\`android-native\`, \`ios-native\`, and \`ios-kmp\` reference the SDK by in-repo path/project (Gradle \`:Pulsar\` include, \`XCLocalSwiftPackageReference\`, \`includeBuild\`) and have no published path without rewiring checked-in project files — they stay always-local and are untouched.

## Notes

- Defaults keep every existing invocation building local, so nothing regresses.
- With the box **unchecked**, affected cells resolve published artifacts from trunk/Maven, so they only pass once a matching version is actually published — expected for that mode.

Generated with Claude Code.