### PR TITLE
fix(ios): work around fmt 11.0.2 consteval build error on Xcode 26

### DIFF
--- a/react-native/PulsarApp/ios/Podfile
+++ b/react-native/PulsarApp/ios/Podfile
@@ -44,6 +44,23 @@ target 'example' do
       File.join(__dir__, '..', 'node_modules', 'hermes-compiler', 'hermesc', 'osx-bin', 'hermesc')
     )
 
+    # Xcode 26's clang enforces `consteval` more strictly and rejects fmt
+    # 11.0.2's compile-time format-string checks (FMT_STRING). RN pins
+    # `fmt (= 11.0.2)`, so instead of bumping the version we degrade fmt's
+    # `consteval` to `constexpr` by disabling FMT_USE_CONSTEVAL. This must be
+    # defined for fmt itself *and* every pod that includes its headers
+    # (RCT-Folly et al.), so apply it project-wide.
+    # Removable once RN is bumped to >= 0.83.9 (fmt 12.1.0), which fixes this
+    # upstream.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        defs = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        defs = [defs] unless defs.is_a?(Array)
+        defs << 'FMT_USE_CONSTEVAL=0'
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
+      end
+    end
+
     installer.aggregate_targets.each do |aggregate_target|
       aggregate_target.xcconfigs.each do |config_name, config_file|
         config_file.attributes['HERMES_CLI_PATH'] = hermes_cli_path


### PR DESCRIPTION
## What

Adds a `post_install` step to the RN `PulsarApp` Podfile that defines `FMT_USE_CONSTEVAL=0` across all pod targets.

## Why

The RN PulsarApp iOS CI build fails on Xcode 26.6 with:

```
fmt/include/fmt/format-inl.h:59:24: error: call to consteval function
'fmt::basic_format_string<...>' is not a constant expression
```

RN 0.83.1 pins `fmt (= 11.0.2)` (via RCT-Folly). Xcode 26 ships a clang that enforces C++20 `consteval` more strictly — a `consteval` call site must itself be a constant expression — and rejects fmt's `FMT_STRING` compile-time format-string checks. Since RN hard-pins the version, we can't just bump fmt; instead we set `FMT_USE_CONSTEVAL=0` so fmt falls back to `constexpr`, which compiles cleanly.

It's applied project-wide (not just the `fmt` target) because consumers like RCT-Folly also include fmt's headers.

## Notes for reviewers

- This is a transitional workaround. It's removable once RN is bumped to **>= 0.83.9** (which brings fmt 12.1.0, fixing this upstream). A comment in the Podfile records this.
- Requires `pod install` to take effect; CI runs it automatically.