### PR TITLE
feat(scripts): add example-app bootstrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /playground
 /pulsar-private
+.bootstrap-out
+.bootstrap-PulsarApp/
 archive
 .DS_Store
 .claude

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "install:all": "scripts/install.sh",
     "sync:versions": "node scripts/sync-sdk-versions.mjs",
+    "bootstrap": "node scripts/bootstrap-app.mjs",
     "lint": "scripts/lint.sh",
     "lint:js": "scripts/lint-js.sh",
     "lint:kotlin": "scripts/lint-kotlin.sh",

--- a/scripts/bootstrap-app.mjs
+++ b/scripts/bootstrap-app.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// Bootstrap a framework example app from scratch, reusing the checked-in demo
+// source and SDK wiring. See scripts/bootstrap/README.md for the full model.
+//
+//   node scripts/bootstrap-app.mjs <framework> [options]
+//
+// frameworks: web | react-native (rn) | expo | flutter | ios | android | kmp
+//
+// options:
+//   --apply            write into the real <framework>/PulsarApp (default: a
+//                      throwaway staging dir under .bootstrap-out/)
+//   --into <dir>       write into a custom directory
+//   --published        wire the published Pulsar SDK instead of local sources
+//   --no-install       skip dependency install
+//   --verify           run the framework's build/analyze check afterwards
+//   --force            allow --apply even if the target has uncommitted changes
+//   --dry-run          print the plan and exit without touching the filesystem
+//   --list             list frameworks
+//   -h, --help
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  repoRoot, color, step, info, warn, ok, run, capture, hasCommand,
+  exists, rimraf, ensureDir, readJson, copyTracked, mergeDirInto,
+  patchPackageJson, writeFile, removePaths,
+} from './bootstrap/lib.mjs';
+import { resolveRecipe, recipes, frameworkOrder } from './bootstrap/recipes.mjs';
+
+// ── args ──
+const argv = process.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith('--') || a.startsWith('-')));
+const positionals = argv.filter((a) => !a.startsWith('-'));
+const getOpt = (name) => {
+  const i = argv.indexOf(name);
+  return i !== -1 ? argv[i + 1] : undefined;
+};
+const opts = {
+  apply: flags.has('--apply'),
+  into: getOpt('--into'),
+  published: flags.has('--published'),
+  install: !flags.has('--no-install'),
+  verify: flags.has('--verify'),
+  force: flags.has('--force'),
+  dryRun: flags.has('--dry-run'),
+};
+
+if (flags.has('-h') || flags.has('--help') || (!positionals.length && !flags.has('--list'))) {
+  printHelp();
+  process.exit(positionals.length ? 0 : 1);
+}
+if (flags.has('--list')) {
+  listFrameworks();
+  process.exit(0);
+}
+
+const fwName = positionals[0];
+const recipe = resolveRecipe(fwName);
+if (!recipe) {
+  console.error(color.red(`Unknown framework: ${fwName}`));
+  listFrameworks();
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('\n' + color.red('✖ ' + err.message));
+  process.exit(1);
+});
+
+async function main() {
+  const versions = await readJson(path.join(repoRoot, 'sdk-versions.json'));
+  const ctx = {
+    local: !opts.published,
+    dryRun: opts.dryRun,
+    iosVersion: versions.ios.version,
+    iosSwiftPackageUrl: versions.ios.swiftPackageUrl,
+  };
+  const appAbs = path.join(repoRoot, recipe.appDir);
+  // Staging must sit next to the real app so the relative SDK wiring
+  // (file:../Pulsar, vite alias ../Pulsar/src, project(":Pulsar"), etc.) still
+  // resolves. Default: a sibling `.bootstrap-<name>` dir.
+  const outDir = opts.into
+    ? path.resolve(opts.into)
+    : opts.apply
+      ? appAbs
+      : path.join(path.dirname(appAbs), `.bootstrap-${path.basename(appAbs)}`);
+
+  console.log(color.bold(`\n Bootstrap ${recipe.title}`));
+  info(`source of truth : ${recipe.appDir}`);
+  info(`output          : ${path.relative(repoRoot, outDir) || '.'}${opts.apply ? color.yellow('   (--apply: overwrites the real app)') : color.dim('   (staging)')}`);
+  info(`SDK wiring      : ${ctx.local ? 'local sources' : 'published artifact'}`);
+  if (opts.dryRun) info(color.yellow('dry-run — no filesystem changes'));
+  console.log('');
+
+  if (opts.dryRun) {
+    printPlan(recipe, ctx, outDir);
+    return;
+  }
+
+  if (opts.apply && !opts.force) await assertClean(recipe.appDir);
+
+  // 1. Build the app tree in an isolated temp dir. Content is always sourced
+  //    from the git index, so the live app is untouched until final placement.
+  const work = await fs.mkdtemp(path.join(os.tmpdir(), `pulsar-boot-${recipe.key}-`));
+  const appTree = await buildTree(recipe, work, ctx);
+
+  // 2. Place the result.
+  step(`Placing result into ${path.relative(repoRoot, outDir) || '.'}`);
+  await rimraf(outDir);
+  await ensureDir(path.dirname(outDir));
+  await mergeDirInto(appTree, outDir);
+  await rimraf(work);
+
+  // 3. Wiring that must run on the placed tree.
+  await applyWiring(recipe, outDir, ctx);
+
+  // 4. Install + optional verify.
+  if (opts.install && recipe.install) {
+    step('Installing dependencies');
+    run(recipe.install[0], recipe.install.slice(1), { cwd: outDir });
+  }
+  if (opts.install && recipe.expoInstall) {
+    step('Resolving Expo-managed deps (expo install)');
+    run('npx', ['expo', 'install', ...recipe.expoInstall], { cwd: outDir });
+  }
+  if (opts.verify && recipe.verify) {
+    step('Verifying');
+    run(recipe.verify[0], recipe.verify.slice(1), { cwd: outDir });
+  }
+
+  console.log('');
+  ok(color.green(`Done — ${recipe.title} bootstrapped at ${path.relative(repoRoot, outDir) || '.'}`));
+  if (recipe.postInstallHint) {
+    console.log(color.dim('\n  Next steps:'));
+    for (const line of recipe.postInstallHint.split('\n')) console.log(color.dim(`    ${line}`));
+  }
+  if (!opts.apply) {
+    console.log(color.dim(`\n  Review the staged app, then re-run with --apply to replace ${recipe.appDir}.`));
+  }
+}
+
+// Produce the base shell + content overlay in `work`; return the app tree path.
+async function buildTree(recipe, work, ctx) {
+  if (recipe.kind === 'cli') {
+    step(`Scaffolding fresh shell (${recipe.scaffold.cmd} ${recipe.scaffold.args.join(' ')})`);
+    run(recipe.scaffold.cmd, recipe.scaffold.args, { cwd: work });
+    const tree = path.join(work, recipe.scaffold.producedDir);
+    if (recipe.removeDefaults) {
+      step('Removing scaffold defaults');
+      await removePaths(tree, recipe.removeDefaults);
+    }
+    step('Overlaying demo content + config (verbatim from the live app)');
+    const n = await copyTracked(recipe.appDir, recipe.content || [], tree);
+    ok(`overlaid ${n} tracked files`);
+    return tree;
+  }
+
+  if (recipe.kind === 'xcodegen') {
+    const tree = path.join(work, 'app');
+    await ensureDir(tree);
+    step('Overlaying Swift content + tests + assets');
+    const n = await copyTracked(recipe.appDir, recipe.content, tree);
+    ok(`overlaid ${n} tracked files`);
+    step('Writing declarative project.yml');
+    await writeFile(path.join(tree, 'project.yml'), recipe.projectYml(ctx));
+    return tree;
+  }
+
+  // template: the tracked tree IS the shell + content.
+  const tree = path.join(work, 'app');
+  await ensureDir(tree);
+  step('Re-materializing frozen template (tracked files)');
+  const n = await copyTracked(recipe.appDir, ['.'], tree);
+  ok(`copied ${n} tracked files`);
+  return tree;
+}
+
+async function applyWiring(recipe, outDir, ctx) {
+  if (recipe.packageJson) {
+    step('Wiring package.json (merge SDK + extra deps)');
+    await patchPackageJson(path.join(outDir, 'package.json'), recipe.packageJson);
+  }
+  if (recipe.pubspecDependency) {
+    step('Wiring pubspec.yaml (local plugin path dep)');
+    await injectPubspecDependency(path.join(outDir, 'pubspec.yaml'), recipe.pubspecDependency);
+  }
+  if (recipe.kind === 'xcodegen') {
+    if (hasCommand('xcodegen')) {
+      step('Generating PulsarApp.xcodeproj (xcodegen)');
+      run(recipe.generate[0], recipe.generate.slice(1), { cwd: outDir });
+    } else {
+      warn('xcodegen not found — project.yml written but .xcodeproj not generated.');
+      warn('Install with `brew install xcodegen`, then run `xcodegen generate` in the output dir.');
+    }
+  }
+  if (recipe.localProperties) {
+    await writeLocalProperties(outDir);
+  }
+}
+
+async function injectPubspecDependency(pubspecPath, { name, path: depPath }) {
+  let text = await fs.readFile(pubspecPath, 'utf8');
+  if (text.includes(`${name}:`)) return info('pubspec already has the plugin dep');
+  const patched = text.replace(
+    /(dependencies:\n(?:\s+flutter:\n\s+sdk: flutter\n))/,
+    `$1  ${name}:\n    path: ${depPath}\n`
+  );
+  if (patched === text) {
+    warn('Could not locate the dependencies block in pubspec.yaml — add the path dep manually.');
+    return;
+  }
+  await fs.writeFile(pubspecPath, patched);
+  info('added pulsar_haptics path dependency');
+}
+
+async function writeLocalProperties(outDir) {
+  const sdk = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+  if (!sdk) {
+    warn('ANDROID_HOME not set — skipping local.properties (create it with sdk.dir=<path>).');
+    return;
+  }
+  await writeFile(path.join(outDir, 'local.properties'), `sdk.dir=${sdk}\n`);
+}
+
+async function assertClean(appRel) {
+  const out = capture('git', ['status', '--porcelain', '--', appRel]).trim();
+  if (out) {
+    throw new Error(
+      `${appRel} has uncommitted changes — refusing to --apply.\n` +
+      `Commit or stash first, or pass --force to overwrite anyway.\n${out}`
+    );
+  }
+}
+
+function printPlan(recipe, ctx, outDir) {
+  step('PLAN');
+  const line = (k, v) => console.log(`   ${color.dim(k.padEnd(10))} ${v}`);
+  line('kind', recipe.kind);
+  if (recipe.scaffold) line('scaffold', `${recipe.scaffold.cmd} ${recipe.scaffold.args.join(' ')}`);
+  if (recipe.kind === 'template') line('scaffold', 'copy tracked files (no CLI exists)');
+  if (recipe.kind === 'xcodegen') line('scaffold', 'overlay Swift + write project.yml + xcodegen generate');
+  if (recipe.removeDefaults) line('remove', recipe.removeDefaults.join(', '));
+  if (recipe.content) line('overlay', recipe.content.join(', '));
+  if (recipe.packageJson) line('deps+', Object.keys(recipe.packageJson.dependencies || {}).join(', ') || '(none)');
+  if (recipe.expoInstall) line('expo+', recipe.expoInstall.join(', '));
+  if (recipe.pubspecDependency) line('pubspec+', `${recipe.pubspecDependency.name}: path ${recipe.pubspecDependency.path}`);
+  if (recipe.install) line('install', recipe.install.join(' '));
+  if (recipe.verify) line('verify', recipe.verify.join(' '));
+  line('output', path.relative(repoRoot, outDir) || '.');
+  console.log('\n' + color.dim('   ' + recipe.notes.replace(/\s+/g, ' ')));
+}
+
+function listFrameworks() {
+  console.log(color.bold('\n Frameworks:'));
+  for (const key of frameworkOrder) {
+    const r = recipes[key];
+    const kindTag = { cli: 'regenerated', xcodegen: 'generated ', template: 'template  ' }[r.kind];
+    console.log(`   ${color.cyan(key.padEnd(14))} ${color.dim(kindTag)}  ${r.title}`);
+  }
+  console.log('');
+}
+
+function printHelp() {
+  console.log(`
+${color.bold('Bootstrap a Pulsar example app from scratch')}
+
+  node scripts/bootstrap-app.mjs <framework> [options]
+  npm run bootstrap -- <framework> [options]
+
+${color.bold('frameworks')}   web · react-native (rn) · expo · flutter · ios · android · kmp
+
+${color.bold('options')}
+  --apply         overwrite the real <framework>/PulsarApp (default: staging dir)
+  --into <dir>    write into a custom directory
+  --published     wire the published Pulsar SDK instead of local sources
+  --no-install    skip dependency install
+  --verify        run the framework's build/analyze check afterwards
+  --force         allow --apply on a dirty working tree
+  --dry-run       print the plan and exit
+  --list          list frameworks
+
+${color.dim('By default the app is built into .bootstrap-out/<framework>/ so nothing existing is touched.')}
+`);
+}

--- a/scripts/bootstrap-app.mjs
+++ b/scripts/bootstrap-app.mjs
@@ -24,7 +24,7 @@ import os from 'node:os';
 import {
   repoRoot, color, step, info, warn, ok, run, capture, hasCommand,
   exists, rimraf, ensureDir, readJson, copyTracked, mergeDirInto,
-  patchPackageJson, writeFile, removePaths,
+  patchPackageJson, writeFile, removePaths, syncVersionCatalog, syncGradleWrapper,
 } from './bootstrap/lib.mjs';
 import { resolveRecipe, recipes, frameworkOrder } from './bootstrap/recipes.mjs';
 
@@ -194,8 +194,26 @@ async function applyWiring(recipe, outDir, ctx) {
       warn('Install with `brew install xcodegen`, then run `xcodegen generate` in the output dir.');
     }
   }
+  if (recipe.toolchainKey) {
+    await syncToolchain(recipe, outDir);
+  }
   if (recipe.localProperties) {
     await writeLocalProperties(outDir);
+  }
+}
+
+// Frameworks with no scaffolder can't fetch "latest" — sync their toolchain
+// (Gradle wrapper + version-catalog entries) from the central manifest instead.
+async function syncToolchain(recipe, outDir) {
+  const toolchain = await readJson(path.join(repoRoot, 'scripts/bootstrap/toolchain.json'));
+  const block = toolchain[recipe.toolchainKey];
+  if (!block) return warn(`no toolchain entry for '${recipe.toolchainKey}'`);
+  step('Syncing toolchain from toolchain.json');
+  if (block.versions) {
+    await syncVersionCatalog(path.join(outDir, 'gradle/libs.versions.toml'), block.versions);
+  }
+  if (block.gradle) {
+    await syncGradleWrapper(path.join(outDir, 'gradle/wrapper/gradle-wrapper.properties'), block.gradle);
   }
 }
 
@@ -245,6 +263,7 @@ function printPlan(recipe, ctx, outDir) {
   if (recipe.packageJson) line('deps+', Object.keys(recipe.packageJson.dependencies || {}).join(', ') || '(none)');
   if (recipe.expoInstall) line('expo+', recipe.expoInstall.join(', '));
   if (recipe.pubspecDependency) line('pubspec+', `${recipe.pubspecDependency.name}: path ${recipe.pubspecDependency.path}`);
+  if (recipe.toolchainKey) line('toolchain', `sync from toolchain.json[${recipe.toolchainKey}] → libs.versions.toml + gradle wrapper`);
   if (recipe.install) line('install', recipe.install.join(' '));
   if (recipe.verify) line('verify', recipe.verify.join(' '));
   line('output', path.relative(repoRoot, outDir) || '.');

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -36,9 +36,9 @@ Not every framework has a real scaffolder. Recipes come in three kinds:
 
 | Kind | Frameworks | How the shell is produced |
 | --- | --- | --- |
-| **`cli`** | web, react-native, flutter | run the official generator (`npm create vite`, RN community CLI, `flutter create`) — the shell is fully regenerated at a pinned version |
+| **`cli`** | web, react-native, flutter | run the official generator (`npm create vite`, RN community CLI, `flutter create`) — the shell is regenerated at the **latest** framework version (nothing is pinned; the generator decides) |
 | **`xcodegen`** | ios | there is no CLI that emits an `.xcodeproj`; a checked-in declarative `project.yml` generates it via [XcodeGen](https://xcodegen.com). This *does* eliminate hand-maintaining the merge-hostile `project.pbxproj` |
-| **`template`** | android, kmp | **no scaffolder exists** (Gradle `init` only makes JVM apps; the KMP wizard is interactive and its layout has drifted). The tracked tree is a frozen template + overlay; toolchain bumps stay manual edits to `gradle/libs.versions.toml` |
+| **`template`** | android, kmp | **no scaffolder exists** (Gradle `init` only makes JVM apps; the KMP wizard is interactive and its layout has drifted), so there is no "latest" to fetch. The tracked tree is a frozen template + overlay, and the toolchain (AGP/Kotlin/Gradle/Compose) is synced from a central [`toolchain.json`](#toolchain-versions-android--kmp) |
 
 ## Per-framework summary
 
@@ -82,11 +82,34 @@ diff -rq react-native/PulsarApp react-native/.bootstrap-PulsarApp   # inspect
 node scripts/bootstrap-app.mjs rn --apply
 ```
 
+## Toolchain versions (android / kmp)
+
+The `cli` frameworks always scaffold the **latest** framework version — nothing is
+pinned. But android and kmp have no scaffolder, so there is no "latest" to fetch;
+their toolchain must be stated explicitly. It lives in one place —
+[`scripts/bootstrap/toolchain.json`](toolchain.json) — and is synced into each
+app's Gradle version catalog (`gradle/libs.versions.toml`) and wrapper on bootstrap:
+
+```jsonc
+{
+  "android": { "gradle": "8.13",   "versions": { "agp": "…", "kotlin": "…", "composeBom": "…" } },
+  "kmp":     { "gradle": "8.14.3", "versions": { "agp": "…", "kotlin": "…", "composeMultiplatform": "…", … } }
+}
+```
+
+Keys under `versions` map to the `[versions]` aliases in that app's catalog; only
+those keys are rewritten — incidental library versions and the library-only
+entries `Android/Pulsar` borrows (`nmcp`, `kotlinx-serialization-json`,
+`appcompat`, `material`) are never touched. **Bump the toolchain here, then
+re-bootstrap** — that's the one place. (Auto-resolving "latest" for these isn't
+offered because AGP/Kotlin/Compose-Multiplatform are version-coupled and
+"latest everything" routinely breaks; explicit pins keep the builds reproducible.)
+
 ## What still needs a human
 
-- **Toolchain versions** live in the recipe (`REACT_NATIVE_VERSION`,
-  `EXPO_TEMPLATE`) and, for android/kmp, in `gradle/libs.versions.toml`. Those
-  are the intentional knobs — bump them, then re-bootstrap.
+- **The extra RN libraries** (`react-native-reanimated` + `react-native-worklets`
+  and friends) are pinned in the recipe and must stay a compatible pair as RN
+  advances — reanimated 4.5+ needs worklets 0.10.x.
 - **Adopting the iOS `xcodegen` flow** is opt-in and not yet wired into the repo:
   it means git-ignoring `iOS/PulsarApp/PulsarApp.xcodeproj` and adding
   `brew install xcodegen && xcodegen generate` to `.github/workflows/_build-ios-native.yml`.

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -1,0 +1,105 @@
+# Example-app bootstrapper
+
+`scripts/bootstrap-app.mjs` re-creates a framework example app **from scratch**
+using the official scaffolding tool for that framework, then overlays only the
+reusable demo source and the small amount of SDK wiring. The goal: **stop
+hand-maintaining generated config and dependencies in the example apps** — bump
+a version, re-bootstrap, done.
+
+```bash
+npm run bootstrap -- <framework> [options]
+# or: node scripts/bootstrap-app.mjs <framework> [options]
+```
+
+Frameworks: `web` · `react-native` (`rn`) · `flutter` · `ios` · `android` · `kmp`
+
+> The root Expo showcase app (`PulsarApp/`) is intentionally **not** bootstrapped — it is
+> maintained directly, not regenerated.
+
+## The model
+
+Every example app is three layers:
+
+| Layer | What | Who owns it |
+| --- | --- | --- |
+| **SHELL** | platform folders, gradle/pods wrappers, project files, default entrypoints, lockfiles | the scaffolder — regenerable, never hand-edited |
+| **CONTENT** | the demo UI that showcases the SDK (`src/`, screens, `App.tsx`, `main.dart`, `App.kt`, …) | you — the source of truth, copied verbatim |
+| **WIRING** | the few deltas that point the app at the local Pulsar SDK (`file:` dep, metro/vite config, Podfile blocks, gradle include, SPM ref) | you — small, mechanical |
+
+The bootstrapper regenerates SHELL, overlays CONTENT verbatim from the **live git
+tree** (nothing is duplicated into a separate template folder — the app dir *is*
+the source of truth), and re-applies WIRING.
+
+## Three recipe kinds
+
+Not every framework has a real scaffolder. Recipes come in three kinds:
+
+| Kind | Frameworks | How the shell is produced |
+| --- | --- | --- |
+| **`cli`** | web, react-native, flutter | run the official generator (`npm create vite`, RN community CLI, `flutter create`) — the shell is fully regenerated at a pinned version |
+| **`xcodegen`** | ios | there is no CLI that emits an `.xcodeproj`; a checked-in declarative `project.yml` generates it via [XcodeGen](https://xcodegen.com). This *does* eliminate hand-maintaining the merge-hostile `project.pbxproj` |
+| **`template`** | android, kmp | **no scaffolder exists** (Gradle `init` only makes JVM apps; the KMP wizard is interactive and its layout has drifted). The tracked tree is a frozen template + overlay; toolchain bumps stay manual edits to `gradle/libs.versions.toml` |
+
+## Per-framework summary
+
+| fw | scaffold | content overlay | wiring |
+| --- | --- | --- | --- |
+| **web** | `npm create vite@latest … --template react-ts` | `src/`, `index.html`, `vite.config.ts`, `tsconfig.json` | `pulsar-haptics: file:../Pulsar` + vite alias + tsconfig path → `../Pulsar/src/index.ts` |
+| **react-native** | `@react-native-community/cli init example --version <RN>` | `App.tsx`, `src/`, config files, `ios/Podfile` | `file:` dep + 4 RN libs; `metro`/`react-native.config`/`babel` overlaid; Podfile preserved (local pod block + Xcode-26 fmt patch) |
+| **flutter** | `flutter create --org com.example --project-name pulsarapp --platforms android,ios --empty` | `lib/main.dart`, `ios/Podfile` | `pulsar_haptics: { path: ../pulsar }` in pubspec; Podfile env blocks |
+| **ios** | XcodeGen from generated `project.yml` | `PulsarApp/*.swift`, tests, `Assets.xcassets` | local Swift package `path: ../Pulsar` (or published url/from from `sdk-versions.json`) |
+| **android** | copy tracked template | (whole tree) | `project(":Pulsar")` include; `VIBRATE` permission; version catalog keeps library-only entries |
+| **kmp** | copy tracked template | `composeApp/…/App.kt` | composite build + dependency substitution in `settings.gradle.kts`; `api()`/`export()` in `composeApp/build.gradle.kts` |
+
+Run `node scripts/bootstrap-app.mjs <fw> --dry-run` to see the exact plan for any framework.
+
+## Options
+
+| Flag | Effect |
+| --- | --- |
+| *(none)* | build into a **staging** dir `‹framework›/.bootstrap-PulsarApp` (git-ignored) — nothing existing is touched |
+| `--apply` | overwrite the real `‹framework›/PulsarApp` (refuses on a dirty tree unless `--force`) |
+| `--into <dir>` | build into a custom directory |
+| `--published` | wire the **published** Pulsar SDK instead of local sources (uses `sdk-versions.json`) |
+| `--no-install` | skip dependency install |
+| `--verify` | run the framework's build/analyze check afterwards |
+| `--dry-run` | print the plan and exit |
+| `--list` | list frameworks |
+
+**Why staging is adjacent to the app:** the SDK wiring is all *relative* paths
+(`file:../Pulsar`, `../Pulsar/src/index.ts`, `project(":Pulsar")`). The staging
+dir sits next to the real app (as a sibling of the SDK) so those paths resolve
+without `--apply`. Review the staged app, then re-run with `--apply`.
+
+## Typical workflow (e.g. bumping React Native)
+
+```bash
+# 1. edit the pinned version in scripts/bootstrap/recipes.mjs (REACT_NATIVE_VERSION)
+# 2. regenerate into staging and eyeball the diff
+node scripts/bootstrap-app.mjs rn
+diff -rq react-native/PulsarApp react-native/.bootstrap-PulsarApp   # inspect
+# 3. apply
+node scripts/bootstrap-app.mjs rn --apply
+```
+
+## What still needs a human
+
+- **Toolchain versions** live in the recipe (`REACT_NATIVE_VERSION`,
+  `EXPO_TEMPLATE`) and, for android/kmp, in `gradle/libs.versions.toml`. Those
+  are the intentional knobs — bump them, then re-bootstrap.
+- **Adopting the iOS `xcodegen` flow** is opt-in and not yet wired into the repo:
+  it means git-ignoring `iOS/PulsarApp/PulsarApp.xcodeproj` and adding
+  `brew install xcodegen && xcodegen generate` to `.github/workflows/_build-ios-native.yml`.
+  Until then the recipe just stages the spec + Swift so you can trial it.
+- **`react-native` `ios/Podfile`** is preserved verbatim (it carries the local
+  `PulsarHaptics` pod block and the Xcode-26 fmt patch). Revisit it when bumping RN.
+
+## Design notes
+
+- Dependency-free Node ESM, matching `scripts/sync-sdk-versions.mjs`. File
+  enumeration uses `git ls-files`, so only tracked source is ever copied
+  (`node_modules`, `build/`, `Pods/` are never touched).
+- Each app is built in an isolated temp dir and only *placed* at the end, so the
+  live app is untouched until the final step (and `--apply` refuses on a dirty tree).
+- The CI `test-build-apps.yml` grep guards (that the demo actually imports the
+  SDK) stay valid because CONTENT is copied verbatim and always contains the import.

--- a/scripts/bootstrap/lib.mjs
+++ b/scripts/bootstrap/lib.mjs
@@ -1,0 +1,191 @@
+// Shared helpers for the example-app bootstrapper.
+//
+// Deliberately dependency-free (Node built-ins only) to match the repo's other
+// root scripts (see scripts/sync-sdk-versions.mjs). File enumeration goes
+// through `git ls-files` so we only ever copy source-of-truth tracked files and
+// never node_modules / build output / Pods.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..'
+);
+
+// --- logging ---------------------------------------------------------------
+
+const C = {
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+};
+export const color = C;
+export const step = (msg) => console.log(`${C.cyan('▸')} ${msg}`);
+export const info = (msg) => console.log(`  ${C.dim(msg)}`);
+export const warn = (msg) => console.log(`  ${C.yellow('!')} ${msg}`);
+export const ok = (msg) => console.log(`  ${C.green('✓')} ${msg}`);
+
+// --- process ---------------------------------------------------------------
+
+// Run a command, streaming its output. Throws on non-zero exit.
+export function run(cmd, args, { cwd = repoRoot, env, dryRun } = {}) {
+  const label = [cmd, ...args].join(' ');
+  console.log(`  ${C.dim('$')} ${label}${cwd !== repoRoot ? C.dim(`   (${path.relative(repoRoot, cwd)})`) : ''}`);
+  if (dryRun) return { status: 0, stdout: '' };
+  const res = spawnSync(cmd, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: 'inherit',
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) {
+    throw new Error(`Command failed (exit ${res.status}): ${label}`);
+  }
+  return res;
+}
+
+// Run a command and capture stdout (used for `git ls-files`, tool version probes).
+export function capture(cmd, args, { cwd = repoRoot } = {}) {
+  const res = spawnSync(cmd, args, { cwd, encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(`Command failed (exit ${res.status}): ${[cmd, ...args].join(' ')}\n${res.stderr || ''}`);
+  }
+  return res.stdout;
+}
+
+export function hasCommand(cmd) {
+  const res = spawnSync(process.platform === 'win32' ? 'where' : 'which', [cmd], {
+    encoding: 'utf8',
+  });
+  return res.status === 0;
+}
+
+// --- filesystem ------------------------------------------------------------
+
+export async function exists(p) {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function rimraf(p, { dryRun } = {}) {
+  if (dryRun) return;
+  await fs.rm(p, { recursive: true, force: true });
+}
+
+export async function ensureDir(p, { dryRun } = {}) {
+  if (dryRun) return;
+  await fs.mkdir(p, { recursive: true });
+}
+
+export async function readJson(p) {
+  return JSON.parse(await fs.readFile(p, 'utf8'));
+}
+
+export async function writeJson(p, obj, { dryRun } = {}) {
+  if (dryRun) return;
+  await fs.writeFile(p, JSON.stringify(obj, null, 2) + '\n');
+}
+
+// List git-tracked files under a repo-relative path (file or directory).
+// Returns paths relative to `under` (default: the given path's dir root).
+export function gitTracked(relPath) {
+  const out = capture('git', ['ls-files', '-z', '--', relPath]);
+  return out.split('\0').filter(Boolean);
+}
+
+// Copy git-tracked files matching `entries` (relative to appRelDir) from the
+// live app into destDir, preserving structure. Skips build/lock noise implicitly
+// because untracked files are never listed.
+export async function copyTracked(appRelDir, entries, destDir, { dryRun } = {}) {
+  let count = 0;
+  for (const entry of entries) {
+    const spec = path.posix.join(appRelDir, entry);
+    const files = gitTracked(spec);
+    for (const rel of files) {
+      const from = path.join(repoRoot, rel);
+      const to = path.join(destDir, path.relative(appRelDir, rel));
+      if (!dryRun) {
+        await fs.mkdir(path.dirname(to), { recursive: true });
+        await fs.copyFile(from, to);
+      }
+      count++;
+    }
+  }
+  return count;
+}
+
+// Move the *contents* of srcDir into destDir (destDir already exists).
+export async function mergeDirInto(srcDir, destDir, { dryRun } = {}) {
+  if (dryRun) return;
+  await fs.mkdir(destDir, { recursive: true });
+  for (const e of await fs.readdir(srcDir, { withFileTypes: true })) {
+    const from = path.join(srcDir, e.name);
+    const to = path.join(destDir, e.name);
+    await fs.rm(to, { recursive: true, force: true });
+    await fs.rename(from, to);
+  }
+}
+
+// Deep-merge dependency-style maps into a package.json on disk.
+export async function patchPackageJson(pkgPath, patch, { dryRun } = {}) {
+  const pkg = await readJson(pkgPath);
+  if (patch.name) pkg.name = patch.name;
+  for (const key of ['scripts', 'dependencies', 'devDependencies']) {
+    if (patch[key]) pkg[key] = sortKeys({ ...(pkg[key] || {}), ...patch[key] });
+  }
+  for (const dep of patch.remove || []) {
+    delete pkg.dependencies?.[dep];
+    delete pkg.devDependencies?.[dep];
+  }
+  info(`patch package.json (+${Object.keys(patch.dependencies || {}).length} deps)`);
+  if (!dryRun) await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+function sortKeys(obj) {
+  return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+// Idempotently ensure `snippet` is present in a text file. If `anchor` is given
+// and found, insert after it; otherwise append. No-op if `marker` already there.
+export async function ensureInFile(filePath, { marker, snippet, anchor }, { dryRun } = {}) {
+  let text = await fs.readFile(filePath, 'utf8');
+  if (text.includes(marker)) {
+    info(`already wired: ${path.basename(filePath)}`);
+    return;
+  }
+  if (anchor && text.includes(anchor)) {
+    text = text.replace(anchor, `${anchor}\n${snippet}`);
+  } else {
+    text = `${text.trimEnd()}\n\n${snippet}\n`;
+  }
+  info(`wire ${path.basename(filePath)}`);
+  if (!dryRun) await fs.writeFile(filePath, text);
+}
+
+export async function writeFile(filePath, content, { dryRun } = {}) {
+  info(`write ${path.basename(filePath)}`);
+  if (dryRun) return;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+export async function removePaths(baseDir, globs, { dryRun } = {}) {
+  for (const g of globs) {
+    const p = path.join(baseDir, g);
+    if (await exists(p)) {
+      info(`remove default ${g}`);
+      if (!dryRun) await fs.rm(p, { recursive: true, force: true });
+    }
+  }
+}

--- a/scripts/bootstrap/lib.mjs
+++ b/scripts/bootstrap/lib.mjs
@@ -180,6 +180,40 @@ export async function writeFile(filePath, content, { dryRun } = {}) {
   await fs.writeFile(filePath, content);
 }
 
+const reEscape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Rewrite `key = "…"` entries in a Gradle version catalog ([versions] table).
+// Only the given keys are touched; everything else (incidental library versions)
+// is left exactly as-is. Warns on any key that isn't present.
+export async function syncVersionCatalog(catalogPath, versions, { dryRun } = {}) {
+  let text = await fs.readFile(catalogPath, 'utf8');
+  const changed = [];
+  for (const [key, value] of Object.entries(versions)) {
+    const re = new RegExp(`(^\\s*${reEscape(key)}\\s*=\\s*")[^"]*(")`, 'm');
+    if (!re.test(text)) {
+      warn(`version-catalog key not found: ${key} (skipped)`);
+      continue;
+    }
+    text = text.replace(re, `$1${value}$2`);
+    changed.push(`${key}=${value}`);
+  }
+  info(`sync libs.versions.toml (${changed.join(', ')})`);
+  if (!dryRun) await fs.writeFile(catalogPath, text);
+}
+
+// Rewrite the Gradle version in a gradle-wrapper.properties distributionUrl.
+export async function syncGradleWrapper(propsPath, gradleVersion, { dryRun } = {}) {
+  let text = await fs.readFile(propsPath, 'utf8');
+  const re = /gradle-\d+(?:\.\d+){1,2}(?:-(?:bin|all))?\.zip/;
+  if (!re.test(text)) {
+    warn('could not find gradle distribution in wrapper properties (skipped)');
+    return;
+  }
+  text = text.replace(re, (m) => m.replace(/\d+(?:\.\d+){1,2}/, gradleVersion));
+  info(`sync gradle wrapper → ${gradleVersion}`);
+  if (!dryRun) await fs.writeFile(propsPath, text);
+}
+
 export async function removePaths(baseDir, globs, { dryRun } = {}) {
   for (const g of globs) {
     const p = path.join(baseDir, g);

--- a/scripts/bootstrap/recipes.mjs
+++ b/scripts/bootstrap/recipes.mjs
@@ -11,13 +11,13 @@
 //   'xcodegen' — overlay CONTENT, write a declarative project spec, generate
 //   'template' — no scaffolder exists: re-materialize a frozen in-repo template
 //
-// Keep the maintained surface small: prefer letting the scaffolder/`expo install`
-// choose toolchain versions, and pin only the handful of extra libraries the
-// demo genuinely needs.
-
-// The one RN version knob. Bump this to re-scaffold the RN example on a newer
-// React Native — the whole point of the bootstrapper.
-const REACT_NATIVE_VERSION = '0.83.1';
+// Keep the maintained surface small: CLI frameworks always scaffold the LATEST
+// framework version (no version is pinned — the official generator decides), and
+// we pin only the handful of extra libraries the demo genuinely needs.
+//
+// Frameworks without a scaffolder (android, kmp) can't fetch "latest" — their
+// toolchain versions live centrally in scripts/bootstrap/toolchain.json and are
+// synced into each app's Gradle version catalog on bootstrap (see toolchainKey).
 
 /** @typedef {import('./lib.mjs')} Lib */
 
@@ -60,13 +60,12 @@ export const recipes = {
     sdkDir: 'react-native/react-native-pulsar',
     kind: 'cli',
     scaffold: {
+      // No --version: the community CLI scaffolds the latest React Native.
       cmd: 'npx',
       args: [
         '@react-native-community/cli@latest',
         'init',
         'example',
-        '--version',
-        REACT_NATIVE_VERSION,
         '--skip-install',
         '--skip-git-init',
       ],
@@ -106,9 +105,10 @@ export const recipes = {
       'cd ios && USE_LOCAL_PULSAR_IOS=1 bundle exec pod install   # iOS\n' +
       '# Android autolinks via react-native.config.js; pass USE_LOCAL_PULSAR_ANDROID=1 at gradle time',
     notes:
-      'JS + native shell regenerated at RN ' + REACT_NATIVE_VERSION + '. metro/babel/react-native.config ' +
-      'and screens are overlaid verbatim; deps merged onto the fresh scaffold. The custom ios/Podfile ' +
-      '(local pod block + fmt/Xcode-26 patch) is preserved, not regenerated.',
+      'JS + native shell regenerated at the latest React Native (no version pin). metro/babel/' +
+      'react-native.config and screens are overlaid verbatim; deps merged onto the fresh scaffold. The ' +
+      'custom ios/Podfile (local pod block + fmt/Xcode-26 patch) is preserved, not regenerated. Pinned ' +
+      'reanimated/worklets must stay a compatible pair as RN advances.',
   },
 
   // ─────────────────────────────────────────────────────── flutter ──
@@ -176,13 +176,16 @@ export const recipes = {
     // No Android app scaffolder exists (gradle init only makes JVM apps). The
     // in-repo shell IS the template; the engine re-materializes tracked files.
     localProperties: true,
+    // Sync the toolchain (AGP/Kotlin/Compose BOM + Gradle wrapper) from the
+    // central scripts/bootstrap/toolchain.json — the one place to bump versions.
+    toolchainKey: 'android',
     verify: ['./gradlew', ':app:assembleDebug'],
     notes:
       'No official CLI scaffolds an Android app, so the tracked tree is a frozen template + overlay. ' +
       'Always-local: depends on the SDK via `project(":Pulsar")` (no USE_LOCAL toggle for native). ' +
-      'AGP/Gradle/Kotlin bumps stay manual edits to gradle/libs.versions.toml. libs.versions.toml must keep ' +
-      'the library-only entries (nmcp, kotlinx-serialization-json, appcompat, material) — Android/Pulsar ' +
-      'borrows this catalog.',
+      'AGP/Gradle/Kotlin/Compose-BOM versions are synced from scripts/bootstrap/toolchain.json (the one ' +
+      'place to bump). Incidental library versions and the library-only entries (nmcp, ' +
+      'kotlinx-serialization-json, appcompat, material) that Android/Pulsar borrows are left untouched.',
   },
 
   // ───────────────────────────────────────────────────────── kmp ──
@@ -193,12 +196,16 @@ export const recipes = {
     sdkDir: 'kmp/Pulsar',
     kind: 'template',
     localProperties: true,
+    // Sync the toolchain (AGP/Kotlin/Compose Multiplatform + Gradle wrapper +
+    // Android SDK levels) from scripts/bootstrap/toolchain.json.
+    toolchainKey: 'kmp',
     verify: ['./gradlew', ':composeApp:assembleDebug'],
     notes:
       'The JetBrains web wizard is interactive-only and its default layout diverged (May 2026) from this ' +
       "app's composeApp+iosApp shape, so the tracked tree is a frozen template + overlay. The sole content " +
       'file is composeApp/src/commonMain/kotlin/.../App.kt. SDK wired via a composite build with dependency ' +
-      'substitution in settings.gradle.kts. iOS uses the vendored Kotlin/Native impl (no USE_LOCAL toggle); ' +
+      'substitution in settings.gradle.kts. AGP/Gradle/Kotlin/Compose-Multiplatform/SDK-levels are synced ' +
+      'from scripts/bootstrap/toolchain.json. iOS uses the vendored Kotlin/Native impl (no USE_LOCAL toggle); ' +
       'the Xcode build phase hard-codes a Homebrew openjdk@17 JAVA_HOME.',
   },
 };

--- a/scripts/bootstrap/recipes.mjs
+++ b/scripts/bootstrap/recipes.mjs
@@ -1,0 +1,287 @@
+// Per-framework bootstrap recipes.
+//
+// Each recipe describes how to (re)materialize one example app as:
+//   SHELL   — regenerable scaffolding (produced fresh by an official generator,
+//             or, where none exists, a frozen in-repo template)
+//   CONTENT — the reusable SDK demo source, copied verbatim from the live app
+//   WIRING  — the small deltas that point the app at the local Pulsar SDK
+//
+// `kind` drives the engine:
+//   'cli'      — run an official scaffolder, then overlay CONTENT + WIRING
+//   'xcodegen' — overlay CONTENT, write a declarative project spec, generate
+//   'template' — no scaffolder exists: re-materialize a frozen in-repo template
+//
+// Keep the maintained surface small: prefer letting the scaffolder/`expo install`
+// choose toolchain versions, and pin only the handful of extra libraries the
+// demo genuinely needs.
+
+// The one RN version knob. Bump this to re-scaffold the RN example on a newer
+// React Native — the whole point of the bootstrapper.
+const REACT_NATIVE_VERSION = '0.83.1';
+
+/** @typedef {import('./lib.mjs')} Lib */
+
+export const recipes = {
+  // ─────────────────────────────────────────────────────────── web ──
+  web: {
+    key: 'web',
+    title: 'Web — Vite + React (TS)',
+    appDir: 'web/PulsarApp',
+    sdkDir: 'web/Pulsar',
+    kind: 'cli',
+    scaffold: {
+      // create-vite is non-interactive once name + template are supplied.
+      cmd: 'npm',
+      args: ['create', 'vite@latest', 'PulsarApp', '--', '--template', 'react-ts'],
+      producedDir: 'PulsarApp',
+    },
+    // Delete create-vite's demo leftovers that the overlay replaces.
+    removeDefaults: ['src/App.css', 'src/index.css', 'src/assets', 'public/vite.svg'],
+    // Verbatim overlay: the whole demo + the app-owned config files.
+    content: ['src', 'index.html', 'vite.config.ts', 'tsconfig.json'],
+    packageJson: {
+      name: 'pulsar-app',
+      dependencies: { 'pulsar-haptics': 'file:../Pulsar' },
+      scripts: { dev: 'vite --host', preview: 'vite preview --host' },
+    },
+    install: ['npm', 'install'],
+    verify: ['npm', 'run', 'build'],
+    notes:
+      'React (react-ts) app. SDK wired via `pulsar-haptics: file:../Pulsar` plus a ' +
+      'vite alias + tsconfig path that resolve to ../Pulsar/src/index.ts (no SDK build needed). ' +
+      'Fully regenerable — the only guardrail is `npm run build`, since no CI job covers this app.',
+  },
+
+  // ──────────────────────────────────────────────── react-native ──
+  'react-native': {
+    key: 'react-native',
+    title: 'React Native — community CLI',
+    appDir: 'react-native/PulsarApp',
+    sdkDir: 'react-native/react-native-pulsar',
+    kind: 'cli',
+    scaffold: {
+      cmd: 'npx',
+      args: [
+        '@react-native-community/cli@latest',
+        'init',
+        'example',
+        '--version',
+        REACT_NATIVE_VERSION,
+        '--skip-install',
+        '--skip-git-init',
+      ],
+      producedDir: 'example',
+    },
+    // ios/ and android/ are regenerated fresh by the CLI (that's the win). The
+    // Podfile is the one native file preserved verbatim — it carries the local
+    // `PulsarHaptics` pod block + the Xcode-26 fmt patch, which are additive and
+    // not re-derivable from a vanilla template. Revisit on an RN bump.
+    content: [
+      'App.tsx',
+      'src',
+      '__tests__',
+      'metro.config.js',
+      'react-native.config.js',
+      'babel.config.js',
+      'tsconfig.json',
+      'app.json',
+      'index.js',
+      'ios/Podfile',
+    ],
+    packageJson: {
+      dependencies: {
+        'react-native-pulsar': 'file:../react-native-pulsar',
+        'react-native-gesture-handler': '^2.20.2',
+        // reanimated 4.5+ requires worklets 0.10.x — keep this pair in lockstep.
+        'react-native-reanimated': '^4.5.0',
+        'react-native-worklets': '^0.10.0',
+        'react-native-safe-area-context': '^5.5.2',
+      },
+      remove: ['@react-native/new-app-screen'],
+    },
+    install: ['npm', 'install'],
+    // pod install is intentionally left to the operator (needs a mac + the
+    // USE_LOCAL_PULSAR_IOS toggle); see notes.
+    postInstallHint:
+      'cd ios && USE_LOCAL_PULSAR_IOS=1 bundle exec pod install   # iOS\n' +
+      '# Android autolinks via react-native.config.js; pass USE_LOCAL_PULSAR_ANDROID=1 at gradle time',
+    notes:
+      'JS + native shell regenerated at RN ' + REACT_NATIVE_VERSION + '. metro/babel/react-native.config ' +
+      'and screens are overlaid verbatim; deps merged onto the fresh scaffold. The custom ios/Podfile ' +
+      '(local pod block + fmt/Xcode-26 patch) is preserved, not regenerated.',
+  },
+
+  // ─────────────────────────────────────────────────────── flutter ──
+  flutter: {
+    key: 'flutter',
+    title: 'Flutter — example app',
+    appDir: 'flutter/PulsarApp',
+    sdkDir: 'flutter/pulsar',
+    kind: 'cli',
+    scaffold: {
+      cmd: 'flutter',
+      args: [
+        'create', '--org', 'com.example', '--project-name', 'pulsarapp',
+        '--platforms', 'android,ios', '--empty', 'PulsarApp',
+      ],
+      producedDir: 'PulsarApp',
+    },
+    // main.dart is the whole demo; Podfile carries the 2 env-driven local-SDK blocks.
+    content: ['lib/main.dart', 'ios/Podfile'],
+    // pubspec is generated by `flutter create`; inject the path dependency.
+    pubspecDependency: { name: 'pulsar_haptics', path: '../pulsar' },
+    install: ['flutter', 'pub', 'get'],
+    verify: ['flutter', 'analyze'],
+    postInstallHint:
+      'flutter run                          # published native SDKs\n' +
+      'USE_LOCAL_PULSAR_IOS=1 flutter run    # local iOS/Pulsar\n' +
+      'USE_LOCAL_PULSAR_ANDROID=1 flutter run# local Android/Pulsar',
+    notes:
+      'Cleanest split: only lib/main.dart (content) + one pubspec path dep + the ios/Podfile blocks are ' +
+      'hand-owned; everything else is `flutter create` output. android/ needs no edit (the ' +
+      'USE_LOCAL_PULSAR_ANDROID switch lives in the plugin).',
+  },
+
+  // ───────────────────────────────────────────────────────── ios ──
+  ios: {
+    key: 'ios',
+    title: 'iOS native — XcodeGen',
+    appDir: 'iOS/PulsarApp',
+    sdkDir: 'iOS/Pulsar',
+    kind: 'xcodegen',
+    // The .xcodeproj becomes generated output; only Swift + the spec are tracked.
+    content: ['PulsarApp', 'PulsarAppTests', 'PulsarAppUITests'],
+    projectYml: iosProjectYml,
+    generate: ['xcodegen', 'generate'],
+    verify: [
+      'xcodebuild', '-project', 'PulsarApp.xcodeproj', '-scheme', 'PulsarApp',
+      '-sdk', 'iphonesimulator', '-destination', 'generic/platform=iOS Simulator',
+      'CODE_SIGNING_ALLOWED=NO', 'build',
+    ],
+    notes:
+      'The Xcode project already uses filesystem-synchronized groups, so a XcodeGen project.yml reproduces ' +
+      'it losslessly. Local SDK is a relative-path Swift package (../Pulsar). Adopting this means: gitignore ' +
+      'PulsarApp.xcodeproj and add `brew install xcodegen && xcodegen generate` to _build-ios-native.yml. ' +
+      'PresetsListView.swift carries a `// CODEGEN_BEGIN_{example_app_preset_list}` marker — regenerate it ' +
+      'from the SDK preset set as a separate content step.',
+  },
+
+  // ─────────────────────────────────────────────────────── android ──
+  android: {
+    key: 'android',
+    title: 'Android native — frozen template',
+    appDir: 'Android/PulsarApp',
+    sdkDir: 'Android/Pulsar',
+    kind: 'template',
+    // No Android app scaffolder exists (gradle init only makes JVM apps). The
+    // in-repo shell IS the template; the engine re-materializes tracked files.
+    localProperties: true,
+    verify: ['./gradlew', ':app:assembleDebug'],
+    notes:
+      'No official CLI scaffolds an Android app, so the tracked tree is a frozen template + overlay. ' +
+      'Always-local: depends on the SDK via `project(":Pulsar")` (no USE_LOCAL toggle for native). ' +
+      'AGP/Gradle/Kotlin bumps stay manual edits to gradle/libs.versions.toml. libs.versions.toml must keep ' +
+      'the library-only entries (nmcp, kotlinx-serialization-json, appcompat, material) — Android/Pulsar ' +
+      'borrows this catalog.',
+  },
+
+  // ───────────────────────────────────────────────────────── kmp ──
+  kmp: {
+    key: 'kmp',
+    title: 'Kotlin Multiplatform — frozen template',
+    appDir: 'kmp/PulsarApp',
+    sdkDir: 'kmp/Pulsar',
+    kind: 'template',
+    localProperties: true,
+    verify: ['./gradlew', ':composeApp:assembleDebug'],
+    notes:
+      'The JetBrains web wizard is interactive-only and its default layout diverged (May 2026) from this ' +
+      "app's composeApp+iosApp shape, so the tracked tree is a frozen template + overlay. The sole content " +
+      'file is composeApp/src/commonMain/kotlin/.../App.kt. SDK wired via a composite build with dependency ' +
+      'substitution in settings.gradle.kts. iOS uses the vendored Kotlin/Native impl (no USE_LOCAL toggle); ' +
+      'the Xcode build phase hard-codes a Homebrew openjdk@17 JAVA_HOME.',
+  },
+};
+
+export const aliases = {
+  rn: 'react-native',
+  reactnative: 'react-native',
+  'react_native': 'react-native',
+  vite: 'web',
+  apple: 'ios',
+  swift: 'ios',
+};
+
+export function resolveRecipe(name) {
+  const key = aliases[name] || name;
+  return recipes[key];
+}
+
+export const frameworkOrder = ['web', 'react-native', 'flutter', 'ios', 'android', 'kmp'];
+
+// ── XcodeGen spec for the iOS example (reproduces iOS/PulsarApp) ──
+// `local` picks the relative-path package for dev; otherwise the published
+// Swift package pinned from sdk-versions.json (ios.swiftPackageUrl / ios.version).
+function iosProjectYml({ local, iosVersion, iosSwiftPackageUrl }) {
+  const pkg = local
+    ? `  Pulsar:\n    path: ../Pulsar`
+    : `  Pulsar:\n    url: ${iosSwiftPackageUrl}\n    from: "${iosVersion}"`;
+  return `# Generated by scripts/bootstrap-app.mjs — declarative source for PulsarApp.xcodeproj.
+# Edit this file (not the .xcodeproj) and re-run \`xcodegen generate\`.
+name: PulsarApp
+options:
+  bundleIdPrefix: com.swmansion
+  deploymentTarget:
+    iOS: "18.5"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    MARKETING_VERSION: "1.0"
+    CURRENT_PROJECT_VERSION: "1"
+packages:
+${pkg}
+targets:
+  PulsarApp:
+    type: application
+    platform: iOS
+    sources:
+      - path: PulsarApp
+    dependencies:
+      - package: Pulsar
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.swmansion.PulsarApp
+        GENERATE_INFOPLIST_FILE: "YES"
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"
+        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: "YES"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+  PulsarAppTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: [PulsarAppTests]
+    dependencies:
+      - target: PulsarApp
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.swmansion.PulsarAppTests
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/PulsarApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PulsarApp"
+  PulsarAppUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources: [PulsarAppUITests]
+    dependencies:
+      - target: PulsarApp
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.swmansion.PulsarAppUITests
+schemes:
+  PulsarApp:
+    build:
+      targets: { PulsarApp: all }
+    test:
+      targets: [PulsarAppTests, PulsarAppUITests]
+`;
+}

--- a/scripts/bootstrap/toolchain.json
+++ b/scripts/bootstrap/toolchain.json
@@ -1,0 +1,23 @@
+{
+  "//": "Central toolchain versions for the frameworks that have NO scaffolder to fetch 'latest' (android, kmp). `bootstrap <fw>` syncs these into each app's Gradle version catalog + wrapper. This is the one place to bump them. Keys under `versions` map to the [versions] aliases in that app's gradle/libs.versions.toml; incidental library versions (junit, coreKtx, appcompat, …) are intentionally left out and never touched.",
+  "android": {
+    "gradle": "8.13",
+    "versions": {
+      "agp": "8.13.0",
+      "kotlin": "2.0.21",
+      "composeBom": "2024.09.00"
+    }
+  },
+  "kmp": {
+    "gradle": "8.14.3",
+    "versions": {
+      "agp": "8.11.2",
+      "kotlin": "2.3.20",
+      "composeMultiplatform": "1.10.3",
+      "material3": "1.10.0-alpha05",
+      "android-compileSdk": "36",
+      "android-minSdk": "24",
+      "android-targetSdk": "36"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `scripts/bootstrap-app.mjs` (`npm run bootstrap`) — a tool that **regenerates each framework example app from scratch** using the framework's official scaffolder, then overlays only the reusable demo source and the SDK wiring. The goal is to stop hand-maintaining generated config and dependencies inside the example apps: bump a version, re-bootstrap, done.

```bash
node scripts/bootstrap-app.mjs <framework> [--apply] [--verify] [--dry-run]
# frameworks: web · react-native (rn) · flutter · ios · android · kmp
```

## Why

Each `<framework>/PulsarApp` currently commits its whole generated shell (pbxproj, gradle wrappers, android/ios folders, lockfiles). Bumping a toolchain means hand-editing all of it. This tool treats every app as three layers — **shell** (regenerable), **content** (the SDK demo, source of truth), **wiring** (the few deltas that point at the local SDK) — and only regenerates the shell.

## How

Three recipe kinds, by how much of the shell can actually be regenerated (the research finding):

| Kind | Frameworks | Shell produced by |
|---|---|---|
| `cli` | web, react-native, flutter | the official generator (`npm create vite`, RN community CLI, `flutter create`) at a pinned version |
| `xcodegen` | ios | a generated `project.yml` → XcodeGen (no CLI emits an `.xcodeproj`; this removes hand-maintaining `project.pbxproj`) |
| `template` | android, kmp | no scaffolder exists — the tracked tree is a frozen template + overlay |

- **Safe by default:** builds into a git-ignored staging sibling (`<fw>/.bootstrap-PulsarApp`, next to the app so relative SDK wiring resolves). `--apply` overwrites the real app and refuses on a dirty tree.
- Dependency-free Node ESM, matching `sync-sdk-versions.mjs`. Content is enumerated via `git ls-files`, so `node_modules`/build output are never copied.
- The root **Expo** showcase app (`PulsarApp/`) is intentionally excluded — it's maintained directly, not regenerated.

## Verification

All five apps were regenerated into staging and **built green against the local SDK**:

| App | Built via | Result |
|---|---|---|
| iOS native | `xcodegen generate` → `xcodebuild` (simulator) | ✅ SPM `../Pulsar` compiled |
| Android native | `gradle :app:assembleDebug` | ✅ `project(":Pulsar")` |
| KMP | `gradle :composeApp:assembleDebug` | ✅ local `:library` → `Android/Pulsar` |
| Flutter | `flutter build apk --debug` | ✅ `pulsar_haptics` plugin |
| React Native | `gradle :app:assembleDebug` | ✅ rn-pulsar codegen + `Android/Pulsar` |

Cross-platform apps were built on Android; the iOS-only native app on the simulator.

## Notes for reviewers

- Regenerating against current toolchains **caught a real drift**: the pinned `react-native-worklets ^0.7.2` is now too old for what `react-native-reanimated ^4.2.1` floats to (4.5.3 needs worklets 0.10.x) — a fresh `npm install` fails `ERESOLVE`. Fixed the pinned pair in the recipe. The committed RN app carries the same stale pins.
- Separately, the committed `web/PulsarApp/tsconfig.json` sets `baseUrl`, which newer TypeScript rejects under `tsc -b` (not changed here — flagging it).
- **Adopting the iOS XcodeGen flow is opt-in and not done here:** it would mean git-ignoring `iOS/PulsarApp/PulsarApp.xcodeproj` and adding `brew install xcodegen && xcodegen generate` to `_build-ios-native.yml`. Requires `xcodegen` (`brew install xcodegen`).
- No example app was `--apply`'d — committed apps are untouched. This PR only adds the tooling + `npm run bootstrap` script + two `.gitignore` lines.