### PR TITLE
fix(ios): resolve Pulsar-Swift.h in local sources + static libraries mode

### DIFF
--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -1,8 +1,14 @@
 #import "Haptics.h"
 #import <UIKit/UIKit.h>
 #if __has_include(<Pulsar/Pulsar-Swift.h>)
-// Local sources mode (USE_LOCAL_PULSAR_IOS=1): Swift compiled into this pod's `Pulsar` module.
+// Local sources mode (USE_LOCAL_PULSAR_IOS=1) under use_frameworks!: Swift compiled
+// into this pod's `Pulsar` module and exposed as a framework header.
 #import <Pulsar/Pulsar-Swift.h>
+#elif __has_include("Pulsar-Swift.h")
+// Local sources mode with static libraries (the default): the `Pulsar` module's own
+// generated Swift header is not reachable via the framework-style <Pulsar/...> path,
+// only via the quote form on the target's own header search path.
+#import "Pulsar-Swift.h"
 #elif __has_include(<PulsarHaptics/PulsarHaptics-Swift.h>)
 // Published pod with frameworks: framework-style angle-bracket header.
 #import <PulsarHaptics/PulsarHaptics-Swift.h>


### PR DESCRIPTION
## Summary

The `__has_include` cascade in `react-native/react-native-pulsar/ios/Haptics.mm` didn't cover all four mode × linkage configurations. In **local sources mode (`USE_LOCAL_PULSAR_IOS=1`) with static libraries** (the default, i.e. no `use_frameworks!`), the `Pulsar` module's generated Swift header is not reachable via the framework-style `<Pulsar/Pulsar-Swift.h>` path — only via the quote form `"Pulsar-Swift.h"` on the target's own header search path.

Adds that missing branch and clarifies the comment on the existing framework branch.

## Test plan

- [ ] Build the RN example app on iOS with `USE_LOCAL_PULSAR_IOS=1` and static libraries (default)
- [ ] Build with `use_frameworks!` to confirm the existing branches still resolve