### PR TITLE
ci: read publish version from sdk-versions.json

### DIFF
--- a/.github/workflows/publish-ios-cocoapods.yml
+++ b/.github/workflows/publish-ios-cocoapods.yml
@@ -2,11 +2,6 @@ name: Publish iOS package to CocoaPods
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 1.1.2)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -33,30 +28,24 @@ jobs:
         id: release
         shell: bash
         run: |
-          VERSION="${{ inputs.version }}"
+          VERSION="$(ruby -rjson -e 'puts JSON.parse(File.read("sdk-versions.json")).fetch("ios").fetch("version")')"
 
           if [[ -z "$VERSION" ]]; then
-            echo "Release version could not be determined." >&2
+            echo "Release version could not be determined from sdk-versions.json." >&2
             exit 1
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing version $VERSION"
+          echo "Publishing version $VERSION (from sdk-versions.json)"
 
       - name: Verify iOS version metadata
         shell: bash
         run: |
           EXPECTED_VERSION="${{ steps.release.outputs.version }}"
-          SDK_VERSION="$(ruby -rjson -e 'puts JSON.parse(File.read("sdk-versions.json")).fetch("ios").fetch("version")')"
           PODSPEC_VERSION="$(sed -n "s/.*s\\.version[[:space:]]*=[[:space:]]*'\\([^']*\\)'.*/\\1/p" iOS/Pulsar/PulsarHaptics.podspec | head -n 1)"
 
-          if [[ "$SDK_VERSION" != "$EXPECTED_VERSION" ]]; then
-            echo "sdk-versions.json iOS version ($SDK_VERSION) does not match requested version ($EXPECTED_VERSION)." >&2
-            exit 1
-          fi
-
           if [[ "$PODSPEC_VERSION" != "$EXPECTED_VERSION" ]]; then
-            echo "PulsarHaptics.podspec version ($PODSPEC_VERSION) does not match requested version ($EXPECTED_VERSION)." >&2
+            echo "PulsarHaptics.podspec version ($PODSPEC_VERSION) does not match sdk-versions.json version ($EXPECTED_VERSION)." >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-rn-stable.yml
+++ b/.github/workflows/publish-rn-stable.yml
@@ -3,10 +3,6 @@ name: Publish React Native to npm
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (x.y.z). Leave empty to infer from branch name.'
-        required: false
-        default: ''
       tag:
         description: 'npm tag to publish under'
         required: false
@@ -36,13 +32,27 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Resolve release version
+        id: release
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./sdk-versions.json').reactNative.version")"
+
+          if [[ -z "$VERSION" ]]; then
+            echo "Release version could not be determined from sdk-versions.json." >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION (from sdk-versions.json)"
+
       - name: Publish stable
         uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
         with:
           package-name: react-native-pulsar
           package-json-path: react-native/react-native-pulsar/package.json
           release-type: stable
-          version: ${{ github.event.inputs.version || '' }}
+          version: ${{ steps.release.outputs.version }}
           tag: ${{ github.event.inputs.tag || 'latest' }}
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-web-haptics.yml
+++ b/.github/workflows/publish-web-haptics.yml
@@ -3,10 +3,6 @@ name: Publish pulsar-haptics to npm
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (x.y.z). Leave empty to infer from branch name.'
-        required: false
-        default: ''
       tag:
         description: 'npm tag to publish under'
         required: false
@@ -46,13 +42,27 @@ jobs:
         working-directory: web/Pulsar
         run: npm test
 
+      - name: Resolve release version
+        id: release
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./sdk-versions.json').web.version")"
+
+          if [[ -z "$VERSION" ]]; then
+            echo "Release version could not be determined from sdk-versions.json." >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION (from sdk-versions.json)"
+
       - name: Publish stable
         uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
         with:
           package-name: pulsar-haptics
           package-json-path: web/Pulsar/package.json
           release-type: stable
-          version: ${{ github.event.inputs.version || '' }}
+          version: ${{ steps.release.outputs.version }}
           tag: ${{ github.event.inputs.tag || 'latest' }}
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm ci


### PR DESCRIPTION
## What

Make `sdk-versions.json` the single source of truth for artifact publish versions. The publish workflows that previously took a manual `version` input now resolve the version from `sdk-versions.json` instead.

## Changes

| Workflow | Version source |
|---|---|
| `publish-ios-cocoapods.yml` | `.ios.version` |
| `publish-rn-stable.yml` | `.reactNative.version` |
| `publish-web-haptics.yml` | `.web.version` |

- Removed the `version` `workflow_dispatch` input from all three workflows.
- Added a `Resolve release version` step that reads the value from `sdk-versions.json` (`ruby -rjson` on iOS, `node -p` on the npm workflows).
- iOS: the existing metadata check now verifies the podspec against `sdk-versions.json` directly (the redundant "sdk-versions == requested input" comparison is gone).
- RN / web: the `tag` and `dry-run` inputs are unchanged.

## Notes

The Android, KMP, and Flutter publish workflows were left untouched — they don't take a version input (gradle / tag-driven).