### PR TITLE
docs(flutter): add 0.1.0 changelog entry

### DIFF
--- a/flutter/pulsar/CHANGELOG.md
+++ b/flutter/pulsar/CHANGELOG.md
@@ -11,3 +11,12 @@
 ## 0.0.3
 
 * Fix SwiftPM support for iOS platform.
+
+## 0.1.0
+
+* Rename the iOS podspec to `pulsar_haptics.podspec` so CocoaPods resolves the plugin under its pub package name.
+* Depend on the renamed `PulsarHaptics` CocoaPod, which builds under every CocoaPods linkage mode — including `use_frameworks!` with both `:static` and `:dynamic` linkage.
+* Declare the `pulsar-ios` Swift package dependency in the SPM manifest so the plugin builds with Flutter's Swift Package Manager support.
+* Bump the native cores to pulsar-ios `1.4.0` and pulsar-android `1.3.0`.
+
+  No Dart API changes — this release is packaging and native dependency work only.


### PR DESCRIPTION
`flutter/pulsar/CHANGELOG.md` stopped at `0.0.3` while `pubspec.yaml` is already at `0.1.0`. This adds the missing `0.1.0` entry.

`0.1.0` is tagged (`pulsar_haptics-flutter-0.1.0`) but **not on pub.dev** — the latest published version there is still `0.0.3` — so the entry covers everything in `flutter/pulsar/` since `0.0.3`, including the post-tag `PulsarHaptics` pod rename and the pulsar-ios `1.4.0` bump.

Changes covered:
- #141 — iOS podspec renamed to `pulsar_haptics.podspec`
- #179 / #181 — depend on the renamed `PulsarHaptics` pod; builds under `use_frameworks!` (static and dynamic)
- #55 — `pulsar-ios` declared as an SPM dependency
- #175 / #182 — native cores at pulsar-ios `1.4.0`, pulsar-android `1.3.0`

No Dart API changes in this range (`RealtimeComposer.start()` from #46 was reverted in #107, so it nets out).

Kept the file's existing oldest-first ordering and `*` bullet style.