### PR TITLE
feat(sdk): audio play-window (start/duration) on Pattern.sound

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioHapticPlayer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioHapticPlayer.kt
@@ -21,10 +21,6 @@ class AudioHapticPlayer(
         private const val LOAD_SUCCESS = 0
     }
 
-    // A trim window (start/duration) can't be expressed with SoundPool — it has no seek —
-    // so a windowed clip plays through MediaPlayer instead. Whole-file playback and
-    // coupled-haptics (.ogg) keep using SoundPool. A windowed clip is always a plain
-    // mp3/wav, i.e. non-coupled, so the two paths never overlap.
     private val windowed = sound.startMs > 0L || sound.durationMs > 0L
 
     private var soundPool: SoundPool? = null
@@ -88,8 +84,6 @@ class AudioHapticPlayer(
         if (windowed) startMediaPlayer() else startSoundPool()
     }
 
-    // ---- SoundPool: whole file / coupled-haptics ----
-
     private fun loadSoundPool() {
         val pool = SoundPool.Builder()
             .setMaxStreams(4)
@@ -133,8 +127,6 @@ class AudioHapticPlayer(
         return pool.load(path, 1)
     }
 
-    // ---- MediaPlayer: windowed (seek to start, stop after duration) ----
-
     private fun loadMediaPlayer() {
         val mp = MediaPlayer()
         try {
@@ -167,7 +159,6 @@ class AudioHapticPlayer(
             val name = uri.substringAfterLast('/').substringBeforeLast('.')
             val resId = context.resources.getIdentifier(name, "raw", context.packageName)
             if (resId != 0) {
-                // Held open until release — MediaPlayer reads from this descriptor.
                 val afd = context.resources.openRawResourceFd(resId)
                 openedFd = afd
                 mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioHapticPlayer.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/audio/AudioHapticPlayer.kt
@@ -1,7 +1,9 @@
 package com.swmansion.pulsar.audio
 
+import android.content.res.AssetFileDescriptor
 import android.content.Context
 import android.media.AudioAttributes
+import android.media.MediaPlayer
 import android.media.SoundPool
 import android.os.Build
 import android.os.Handler
@@ -19,25 +21,79 @@ class AudioHapticPlayer(
         private const val LOAD_SUCCESS = 0
     }
 
+    // A trim window (start/duration) can't be expressed with SoundPool — it has no seek —
+    // so a windowed clip plays through MediaPlayer instead. Whole-file playback and
+    // coupled-haptics (.ogg) keep using SoundPool. A windowed clip is always a plain
+    // mp3/wav, i.e. non-coupled, so the two paths never overlap.
+    private val windowed = sound.startMs > 0L || sound.durationMs > 0L
+
     private var soundPool: SoundPool? = null
     private var soundId: Int = 0
     private var streamId: Int = 0
+    private var mediaPlayer: MediaPlayer? = null
+    private var openedFd: AssetFileDescriptor? = null
     private var isLoaded = false
     private var playPending = false
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun load() {
-        val attributesBuilder = AudioAttributes.Builder()
+    private fun audioAttributes(): AudioAttributes {
+        val builder = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_MEDIA)
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            attributesBuilder.setHapticChannelsMuted(hapticChannelsMuted)
+            builder.setHapticChannelsMuted(hapticChannelsMuted)
         }
+        return builder.build()
+    }
 
+    fun load() {
+        if (windowed) loadMediaPlayer() else loadSoundPool()
+    }
+
+    fun play() {
+        if (isLoaded) scheduleStream() else playPending = true
+    }
+
+    fun stop() {
+        playPending = false
+        mainHandler.removeCallbacksAndMessages(null)
+        if (windowed) {
+            mediaPlayer?.let { if (it.isPlaying) it.pause() }
+        } else if (streamId != 0) {
+            soundPool?.stop(streamId)
+            streamId = 0
+        }
+    }
+
+    fun release() {
+        stop()
+        soundPool?.release()
+        soundPool = null
+        mediaPlayer?.release()
+        mediaPlayer = null
+        openedFd?.close()
+        openedFd = null
+        isLoaded = false
+    }
+
+    private fun scheduleStream() {
+        if (sound.offset > 0) {
+            mainHandler.postDelayed({ startStream() }, sound.offset)
+        } else {
+            startStream()
+        }
+    }
+
+    private fun startStream() {
+        if (windowed) startMediaPlayer() else startSoundPool()
+    }
+
+    // ---- SoundPool: whole file / coupled-haptics ----
+
+    private fun loadSoundPool() {
         val pool = SoundPool.Builder()
             .setMaxStreams(4)
-            .setAudioAttributes(attributesBuilder.build())
+            .setAudioAttributes(audioAttributes())
             .build()
 
         pool.setOnLoadCompleteListener { _, sampleId, status ->
@@ -56,39 +112,7 @@ class AudioHapticPlayer(
         soundPool = pool
     }
 
-    fun play() {
-        if (isLoaded) {
-            scheduleStream()
-        } else {
-            playPending = true
-        }
-    }
-
-    fun stop() {
-        playPending = false
-        mainHandler.removeCallbacksAndMessages(null)
-        if (streamId != 0) {
-            soundPool?.stop(streamId)
-            streamId = 0
-        }
-    }
-
-    fun release() {
-        stop()
-        soundPool?.release()
-        soundPool = null
-        isLoaded = false
-    }
-
-    private fun scheduleStream() {
-        if (sound.offset > 0) {
-            mainHandler.postDelayed({ startStream() }, sound.offset)
-        } else {
-            startStream()
-        }
-    }
-
-    private fun startStream() {
+    private fun startSoundPool() {
         val pool = soundPool ?: return
         streamId = pool.play(soundId, sound.volume, sound.volume, 1, 0, 1f)
     }
@@ -107,5 +131,69 @@ class AudioHapticPlayer(
 
         val path = if (uri.startsWith("file://")) uri.removePrefix("file://") else uri
         return pool.load(path, 1)
+    }
+
+    // ---- MediaPlayer: windowed (seek to start, stop after duration) ----
+
+    private fun loadMediaPlayer() {
+        val mp = MediaPlayer()
+        try {
+            mp.setAudioAttributes(audioAttributes())
+            setMediaPlayerSource(mp)
+            mp.setVolume(sound.volume, sound.volume)
+            mp.setOnPreparedListener {
+                isLoaded = true
+                if (playPending) {
+                    playPending = false
+                    scheduleStream()
+                }
+            }
+            mp.setOnErrorListener { _, what, extra ->
+                Log.w(TAG, "MediaPlayer error ($what, $extra): ${sound.uri}")
+                true
+            }
+            mp.prepareAsync()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to load windowed sound: ${sound.uri}", e)
+        }
+        mediaPlayer = mp
+    }
+
+    private fun setMediaPlayerSource(mp: MediaPlayer) {
+        val uri = sound.uri
+        val isPath = uri.startsWith("/") || uri.startsWith("file://")
+
+        if (!isPath) {
+            val name = uri.substringAfterLast('/').substringBeforeLast('.')
+            val resId = context.resources.getIdentifier(name, "raw", context.packageName)
+            if (resId != 0) {
+                // Held open until release — MediaPlayer reads from this descriptor.
+                val afd = context.resources.openRawResourceFd(resId)
+                openedFd = afd
+                mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                return
+            }
+        }
+
+        val path = if (uri.startsWith("file://")) uri.removePrefix("file://") else uri
+        mp.setDataSource(path)
+    }
+
+    private fun startMediaPlayer() {
+        val mp = mediaPlayer ?: return
+        if (sound.startMs > 0L) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                mp.seekTo(sound.startMs, MediaPlayer.SEEK_CLOSEST)
+            } else {
+                mp.seekTo(sound.startMs.toInt())
+            }
+        }
+        mp.start()
+        if (sound.durationMs > 0L) {
+            mainHandler.postDelayed(
+                { mediaPlayer?.let { if (it.isPlaying) it.pause() } },
+                sound.durationMs,
+            )
+        }
     }
 }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/Points.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/Points.kt
@@ -54,6 +54,8 @@ data class SoundData(
   val volume: Float = 1f,
   val offset: Long = 0L,
   val hapticChannels: Boolean = true,
+  val startMs: Long = 0L,
+  val durationMs: Long = 0L,
 )
 
 data class PatternData(

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/PulsarPlugin.kt
@@ -337,6 +337,8 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val uri = data["uri"] as? String ?: return null
         val volume = (data["volume"] as? Number)?.toFloat() ?: 1f
         val offset = (data["offset"] as? Number)?.toLong() ?: 0L
-        return SoundData(uri = uri, volume = volume, offset = offset)
+        val startMs = (data["start"] as? Number)?.toLong() ?: 0L
+        val durationMs = (data["duration"] as? Number)?.toLong() ?: 0L
+        return SoundData(uri = uri, volume = volume, offset = offset, startMs = startMs, durationMs = durationMs)
     }
 }

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -188,6 +188,8 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
       }
       let volume = (sound["volume"] as? NSNumber)?.floatValue ?? 1.0
       let offset = (sound["offset"] as? NSNumber)?.doubleValue ?? 0.0
+      let start = (sound["start"] as? NSNumber)?.doubleValue ?? 0.0
+      let duration = (sound["duration"] as? NSNumber)?.doubleValue ?? 0.0
       let composerId = args?["composerId"] as? Int
       let resolvedComposerId = composerId ?? nextPatternComposerId
       if composerId == nil {
@@ -198,7 +200,7 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
         patternComposers[resolvedComposerId] = composer
         return composer
       }()
-      patternComposer.parsePatternWithSound(hapticsData: patternData, uri: uri, volume: volume, offset: offset)
+      patternComposer.parsePatternWithSound(hapticsData: patternData, uri: uri, volume: volume, offset: offset, start: start, duration: duration)
       result(resolvedComposerId)
 
     case "PatternComposer_playPattern":

--- a/flutter/pulsar/lib/pulsar_types.dart
+++ b/flutter/pulsar/lib/pulsar_types.dart
@@ -185,7 +185,13 @@ class PatternData {
 /// A short authored sound to play in sync with a haptic pattern.
 class Sound {
   /// Creates a [Sound] source.
-  const Sound({required this.uri, this.volume = 1.0, this.offset = 0});
+  const Sound({
+    required this.uri,
+    this.volume = 1.0,
+    this.offset = 0,
+    this.start = 0,
+    this.duration = 0,
+  });
 
   /// Local file path, `file://` uri, or bundled resource name (no extension needed
   /// — defaults to `.wav`).
@@ -197,9 +203,20 @@ class Sound {
   /// Shift of the audio relative to the haptics, in milliseconds.
   final int offset;
 
+  /// Where in the source file playback begins, in ms — a seek into the file, so the
+  /// whole file can be shipped once and a trimmed window played from it. Defaults to 0
+  /// (the top). The native side slices the audio to this window before playing.
+  final int start;
+
+  /// How much of the file to play from [start], in ms. Defaults to 0, which plays to
+  /// the end of the file. Together with [start] this is the trim window.
+  final int duration;
+
   Map<String, dynamic> toMap() => {
     'uri': uri,
     'volume': volume,
     'offset': offset,
+    'start': start,
+    'duration': duration,
   };
 }

--- a/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
@@ -14,6 +14,10 @@ public class PatternComposer: NSObject {
   private var audioBuffer: AVAudioPCMBuffer?
   private var audioSimulator: AudioSimulator!
   private var hasSound = false
+  // A temp file holding the trimmed audio window, when `start`/`duration` were given
+  // (Core Haptics registers an audio resource by URL only, so a windowed clip has to be
+  // sliced to a file first). Removed on the next parse and on dispose.
+  private var tempAudioURL: URL?
 
   public convenience init(engine: HapticEngineWrapper, audioSimulator: AudioSimulator) {
     self.init()
@@ -29,8 +33,10 @@ public class PatternComposer: NSObject {
     parse(hapticsData: hapticsData, audioEvent: nil)
   }
 
-  @objc public func parsePatternWithSound(hapticsData: PatternData, uri: String, volume: Float = 1, offset: Double = 0) {
-    let audioEvent = makeAudioEvent(uri: uri, volume: volume, offset: offset)
+  @objc public func parsePatternWithSound(hapticsData: PatternData, uri: String, volume: Float = 1, offset: Double = 0, start: Double = 0, duration: Double = 0) {
+    // A new parse replaces any previous windowed temp clip.
+    removeTempAudio()
+    let audioEvent = makeAudioEvent(uri: uri, volume: volume, offset: offset, start: start, duration: duration)
     parse(hapticsData: hapticsData, audioEvent: audioEvent)
   }
 
@@ -97,10 +103,20 @@ public class PatternComposer: NSObject {
     self.play()
   }
 
-  private func makeAudioEvent(uri: String, volume: Float, offset: Double) -> CHHapticEvent? {
-    guard let url = PatternComposer.resolveSoundURL(uri) else {
+  private func makeAudioEvent(uri: String, volume: Float, offset: Double, start: Double = 0, duration: Double = 0) -> CHHapticEvent? {
+    guard let sourceURL = PatternComposer.resolveSoundURL(uri) else {
       print("Pulsar: could not resolve sound uri: \(uri)")
       return nil
+    }
+    // Play the whole file, unless a window was requested — then slice it to a temp clip
+    // and register that, so the audio starts at `start` and lasts `duration`. There is no
+    // seek into a registered Core Haptics audio resource, so the trim happens here.
+    var url = sourceURL
+    if start > 0 || duration > 0 {
+      if let windowed = PatternComposer.sliceAudioToTempFile(sourceURL, startMs: start, durationMs: duration) {
+        tempAudioURL = windowed
+        url = windowed
+      }
     }
     guard let resourceID = engine.registerAudioResource(url: url) else { return nil }
     return CHHapticEvent(
@@ -108,6 +124,42 @@ public class PatternComposer: NSObject {
       parameters: [CHHapticEventParameter(parameterID: .audioVolume, value: volume)],
       relativeTime: max(0, offset) / 1000.0
     )
+  }
+
+  /// Decode `sourceURL`, cut `[startMs, startMs+durationMs]` (durationMs<=0 ⇒ to the end),
+  /// and write that slice to a temp file, returning its URL — or nil if it can't be read.
+  static func sliceAudioToTempFile(_ sourceURL: URL, startMs: Double, durationMs: Double) -> URL? {
+    do {
+      let file = try AVAudioFile(forReading: sourceURL)
+      let format = file.processingFormat
+      let sampleRate = format.sampleRate
+      let totalFrames = file.length
+
+      let startFrame = max(0, min(totalFrames, AVAudioFramePosition((startMs / 1000.0) * sampleRate)))
+      let requested = durationMs > 0 ? AVAudioFramePosition((durationMs / 1000.0) * sampleRate) : totalFrames - startFrame
+      let frameCount = AVAudioFrameCount(max(0, min(requested, totalFrames - startFrame)))
+      if frameCount == 0 { return nil }
+
+      guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return nil }
+      file.framePosition = startFrame
+      try file.read(into: buffer, frameCount: frameCount)
+
+      let tempURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("pulsar-audio-\(UUID().uuidString).caf")
+      let out = try AVAudioFile(forWriting: tempURL, settings: format.settings)
+      try out.write(from: buffer)
+      return tempURL
+    } catch {
+      print("Pulsar: could not slice audio window: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  private func removeTempAudio() {
+    if let url = tempAudioURL {
+      try? FileManager.default.removeItem(at: url)
+      tempAudioURL = nil
+    }
   }
 
   @objc public func play() {
@@ -147,5 +199,6 @@ public class PatternComposer: NSObject {
     discretePattern = nil
     audioBuffer = nil
     hasSound = false
+    removeTempAudio()
   }
 }

--- a/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
@@ -34,7 +34,6 @@ public class PatternComposer: NSObject {
   }
 
   @objc public func parsePatternWithSound(hapticsData: PatternData, uri: String, volume: Float = 1, offset: Double = 0, start: Double = 0, duration: Double = 0) {
-    // A new parse replaces any previous windowed temp clip.
     removeTempAudio()
     let audioEvent = makeAudioEvent(uri: uri, volume: volume, offset: offset, start: start, duration: duration)
     parse(hapticsData: hapticsData, audioEvent: audioEvent)
@@ -108,9 +107,6 @@ public class PatternComposer: NSObject {
       print("Pulsar: could not resolve sound uri: \(uri)")
       return nil
     }
-    // Play the whole file, unless a window was requested — then slice it to a temp clip
-    // and register that, so the audio starts at `start` and lasts `duration`. There is no
-    // seek into a registered Core Haptics audio resource, so the trim happens here.
     var url = sourceURL
     if start > 0 || duration > 0 {
       if let windowed = PatternComposer.sliceAudioToTempFile(sourceURL, startMs: start, durationMs: duration) {
@@ -126,8 +122,6 @@ public class PatternComposer: NSObject {
     )
   }
 
-  /// Decode `sourceURL`, cut `[startMs, startMs+durationMs]` (durationMs<=0 ⇒ to the end),
-  /// and write that slice to a temp file, returning its URL — or nil if it can't be read.
   static func sliceAudioToTempFile(_ sourceURL: URL, startMs: Double, durationMs: Double) -> URL? {
     do {
       let file = try AVAudioFile(forReading: sourceURL)

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
@@ -372,7 +372,7 @@ private class AndroidRealtimeComposerHandle(
 }
 
 private fun SoundData.toAndroidSoundData(): AndroidSoundData {
-    return AndroidSoundData(uri = uri, volume = volume, offset = offset)
+    return AndroidSoundData(uri = uri, volume = volume, offset = offset, startMs = startMs, durationMs = durationMs)
 }
 
 private fun PatternData.toAndroidPatternData(): AndroidPatternData {

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
@@ -40,9 +40,7 @@ data class SoundData(
     val uri: String,
     val volume: Float = 1f,
     val offset: Long = 0L,
-    /** Where in the source file playback begins, in ms (a seek). 0 plays from the top. */
     val startMs: Long = 0L,
-    /** How much to play from [startMs], in ms. 0 plays to the end of the file. */
     val durationMs: Long = 0L,
 )
 

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
@@ -40,6 +40,10 @@ data class SoundData(
     val uri: String,
     val volume: Float = 1f,
     val offset: Long = 0L,
+    /** Where in the source file playback begins, in ms (a seek). 0 plays from the top. */
+    val startMs: Long = 0L,
+    /** How much to play from [startMs], in ms. 0 plays to the end of the file. */
+    val durationMs: Long = 0L,
 )
 
 data class PatternData(

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/PatternComposer.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/PatternComposer.kt
@@ -10,6 +10,16 @@ import com.swmansion.pulsar.kmp.iosimpl.haptics.IOSDiscreteLine
 import com.swmansion.pulsar.kmp.iosimpl.haptics.IOSHapticEngineWrapper
 import com.swmansion.pulsar.kmp.iosimpl.haptics.log
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.AVFAudio.AVAudioFile
+import platform.AVFAudio.AVAudioPCMBuffer
+import platform.Foundation.NSError
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSUUID
 import platform.CoreHaptics.CHHapticEvent
 import platform.CoreHaptics.CHHapticEventParameter
 import platform.CoreHaptics.CHHapticEventParameterIDAudioVolume
@@ -34,12 +44,17 @@ internal class IOSPatternComposerHandle(
     private var discretePattern: CHHapticPattern? = null
     private var audioBuffer: IOSAudioBuffer? = null
     private var hasSound = false
+    // A temp file holding the trimmed audio window, when start/duration were given (Core
+    // Haptics registers an audio resource by URL only, so a windowed clip is sliced to a
+    // file first). Removed on the next parse and on dispose.
+    private var tempAudioURL: NSURL? = null
 
     override fun parsePattern(pattern: PatternData) {
         parse(pattern, audioEvent = null)
     }
 
     override fun parsePatternWithSound(pattern: PatternData, sound: SoundData) {
+        removeTempAudio()
         parse(pattern, audioEvent = makeAudioEvent(sound))
     }
 
@@ -106,9 +121,18 @@ internal class IOSPatternComposerHandle(
     }
 
     private fun makeAudioEvent(sound: SoundData): CHHapticEvent? {
-        val url = resolveSoundURL(sound.uri) ?: run {
+        val sourceUrl = resolveSoundURL(sound.uri) ?: run {
             log("could not resolve sound uri: ${sound.uri}")
             return null
+        }
+        // Play the whole file, unless a window was requested — then slice it to a temp clip
+        // and register that (there is no seek into a registered Core Haptics audio resource,
+        // so the trim happens here). A failed slice falls back to the whole file.
+        val url = if (sound.startMs > 0L || sound.durationMs > 0L) {
+            sliceAudioToTempFile(sourceUrl, sound.startMs, sound.durationMs)?.also { tempAudioURL = it }
+                ?: sourceUrl
+        } else {
+            sourceUrl
         }
         val resourceId = engine.registerAudioResource(url) ?: return null
         return CHHapticEvent(
@@ -118,6 +142,50 @@ internal class IOSPatternComposerHandle(
             ),
             relativeTime = maxOf(0L, sound.offset).toDouble() / 1000.0,
         )
+    }
+
+    /**
+     * Decode [sourceUrl], cut `[startMs, startMs+durationMs]` (durationMs<=0 ⇒ to the end),
+     * and write that slice to a temp file, returning its url — or null if it can't be read.
+     * Best-effort: any failure returns null and the caller plays the whole file.
+     */
+    private fun sliceAudioToTempFile(sourceUrl: NSURL, startMs: Long, durationMs: Long): NSURL? {
+        return runCatching {
+            memScoped {
+                val readErr = alloc<ObjCObjectVar<NSError?>>()
+                val file = AVAudioFile(forReading = sourceUrl, error = readErr.ptr) ?: return@memScoped null
+                val format = file.processingFormat
+                val sampleRate = format.sampleRate
+                val totalFrames = file.length
+
+                val startFrame = maxOf(0L, minOf(totalFrames, (startMs.toDouble() / 1000.0 * sampleRate).toLong()))
+                val requested =
+                    if (durationMs > 0L) (durationMs.toDouble() / 1000.0 * sampleRate).toLong()
+                    else totalFrames - startFrame
+                val frameCount = maxOf(0L, minOf(requested, totalFrames - startFrame)).toUInt()
+                if (frameCount == 0u) return@memScoped null
+
+                val buffer = AVAudioPCMBuffer(pCMFormat = format, frameCapacity = frameCount)
+                    ?: return@memScoped null
+                file.framePosition = startFrame
+                if (!file.readIntoBuffer(buffer, frameCount, readErr.ptr)) return@memScoped null
+
+                val tempPath = NSTemporaryDirectory() + "pulsar-audio-" + NSUUID().UUIDString + ".caf"
+                val tempURL = NSURL.fileURLWithPath(tempPath)
+                val writeErr = alloc<ObjCObjectVar<NSError?>>()
+                val out = AVAudioFile(forWriting = tempURL, settings = format.settings, error = writeErr.ptr)
+                    ?: return@memScoped null
+                if (!out.writeFromBuffer(buffer, writeErr.ptr)) return@memScoped null
+                tempURL
+            }
+        }.onFailure { log("could not slice audio window: ${it.message}") }.getOrNull()
+    }
+
+    private fun removeTempAudio() {
+        tempAudioURL?.path?.let { path ->
+            runCatching { NSFileManager.defaultManager.removeItemAtPath(path, null) }
+        }
+        tempAudioURL = null
     }
 
     private fun resolveSoundURL(uri: String): NSURL? {
@@ -160,5 +228,6 @@ internal class IOSPatternComposerHandle(
         discretePattern = null
         audioBuffer = null
         hasSound = false
+        removeTempAudio()
     }
 }

--- a/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/PatternComposer.kt
+++ b/kmp/Pulsar/library/src/iosMain/kotlin/com/swmansion/pulsar/iosimpl/composers/PatternComposer.kt
@@ -125,9 +125,7 @@ internal class IOSPatternComposerHandle(
             log("could not resolve sound uri: ${sound.uri}")
             return null
         }
-        // Play the whole file, unless a window was requested — then slice it to a temp clip
-        // and register that (there is no seek into a registered Core Haptics audio resource,
-        // so the trim happens here). A failed slice falls back to the whole file.
+
         val url = if (sound.startMs > 0L || sound.durationMs > 0L) {
             sliceAudioToTempFile(sourceUrl, sound.startMs, sound.durationMs)?.also { tempAudioURL = it }
                 ?: sourceUrl
@@ -144,11 +142,6 @@ internal class IOSPatternComposerHandle(
         )
     }
 
-    /**
-     * Decode [sourceUrl], cut `[startMs, startMs+durationMs]` (durationMs<=0 ⇒ to the end),
-     * and write that slice to a temp file, returning its url — or null if it can't be read.
-     * Best-effort: any failure returns null and the caller plays the whole file.
-     */
     private fun sliceAudioToTempFile(sourceUrl: NSURL, startMs: Long, durationMs: Long): NSURL? {
         return runCatching {
             memScoped {

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarModule.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarModule.kt
@@ -185,7 +185,9 @@ class PulsarModule(reactContext: ReactApplicationContext) :
     data: ReadableMap?,
     uri: String?,
     volume: Double,
-    offset: Double
+    offset: Double,
+    start: Double,
+    duration: Double
   ): Double {
     val patternComposer = pulsar.getPatternComposer()
 
@@ -197,7 +199,9 @@ class PulsarModule(reactContext: ReactApplicationContext) :
           SoundData(
             uri = uri,
             volume = volume.toFloat(),
-            offset = offset.toLong()
+            offset = offset.toLong(),
+            startMs = start.toLong(),
+            durationMs = duration.toLong()
           )
         )
       } else {

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -171,14 +171,18 @@ static PatternData *PatternDataFromJSPattern(JS::NativeRNPulsar::Pattern &data) 
 - (nonnull NSNumber *)PatternComposer_parsePatternWithSound:(JS::NativeRNPulsar::Pattern &)data
                                                        uri:(nonnull NSString *)uri
                                                     volume:(double)volume
-                                                    offset:(double)offset {
+                                                    offset:(double)offset
+                                                     start:(double)start
+                                                  duration:(double)duration {
   auto patternComposer = [pulsar_ getPatternComposer];
 
   PatternData *patternData = PatternDataFromJSPattern(data);
   [patternComposer parsePatternWithSoundWithHapticsData:patternData
                                                     uri:uri
                                                  volume:(float)volume
-                                                 offset:offset];
+                                                 offset:offset
+                                                  start:start
+                                               duration:duration];
 
   int currentId = nextId;
   nextId++;

--- a/react-native/react-native-pulsar/src/NativeRNPulsar.ts
+++ b/react-native/react-native-pulsar/src/NativeRNPulsar.ts
@@ -42,7 +42,7 @@ export interface Spec extends TurboModule {
   RealtimeComposer_playDiscrete(amplitude: number, frequency: number): void;
 
   PatternComposer_parsePattern(data: Pattern): number;
-  PatternComposer_parsePatternWithSound(data: Pattern, uri: string, volume: number, offset: number): number;
+  PatternComposer_parsePatternWithSound(data: Pattern, uri: string, volume: number, offset: number, start: number, duration: number): number;
   PatternComposer_play(patternId: number): void;
   PatternComposer_stop(patternId: number): void;
   PatternComposer_release(patternId: number): void;

--- a/react-native/react-native-pulsar/src/types.ts
+++ b/react-native/react-native-pulsar/src/types.ts
@@ -27,6 +27,18 @@ export type Sound = {
   volume?: number,
   /** Shift of the audio relative to the haptics, in ms. Defaults to 0. */
   offset?: number,
+  /**
+   * Where in the source file playback begins, in ms — a seek into the file, so the whole
+   * file can be shipped once and a trimmed window played from it. Defaults to 0 (the top).
+   * The native side slices the audio to this window before playing, so audio and haptics
+   * stay sample-accurate (there is no runtime seek on the audio itself).
+   */
+  start?: number,
+  /**
+   * How much of the file to play from `start`, in ms. Defaults to 0, which plays to the
+   * end of the file. Together with `start` this is the trim window.
+   */
+  duration?: number,
 }
 
 export type Pattern = {

--- a/react-native/react-native-pulsar/src/usePatternComposer.ts
+++ b/react-native/react-native-pulsar/src/usePatternComposer.ts
@@ -37,8 +37,8 @@ export default function usePatternComposer(pattern?: Pattern): PatternComposer {
     const resolvedUri = pattern.sound ? resolveSoundUri(pattern.sound.uri) : undefined;
     let newPatternId: number;
     if (pattern.sound && resolvedUri) {
-      const { volume = 1, offset = 0 } = pattern.sound;
-      newPatternId = Pulsar.PatternComposer_parsePatternWithSound(pattern, resolvedUri, volume, offset);
+      const { volume = 1, offset = 0, start = 0, duration = 0 } = pattern.sound;
+      newPatternId = Pulsar.PatternComposer_parsePatternWithSound(pattern, resolvedUri, volume, offset, start, duration);
     } else {
       newPatternId = Pulsar.PatternComposer_parsePattern(pattern);
     }


### PR DESCRIPTION
Part of the media-synced-haptics feature (SDK slice).

Adds an optional play-window to `Pattern.sound` so the whole audio file can be shipped once and a **trimmed window** played from it, in sync with the haptics — there's no runtime seek on the audio, so the native side slices to the window.

- **RN binding:** `Sound.start`/`Sound.duration` (ms), threaded through `usePatternComposer` and the `PatternComposer_parsePatternWithSound` TurboModule spec + iOS/Android bridges.
- **iOS:** slice the decoded buffer to a temp `.caf` and register it with Core Haptics (keeps sample-accurate coupling); temp cleaned up on next parse/dispose.
- **Android:** windowed (non-coupled) clips play via `MediaPlayer` (seekTo + delayed stop); `SoundPool` still handles whole-file / coupled `.ogg`.

**Verification:** iOS Swift core `BUILD SUCCEEDED`; Android core + RN module `BUILD SUCCESSFUL` (codegen regenerated the 6-arg signature and the Kotlin bridge matches).

Backward-compatible: `start`/`duration` default to 0 (whole file), so existing `sound` usage is unchanged. No dependency on the other PRs.