### PR TITLE
feat(app): download & play media-synced haptics from Studio

### DIFF
--- a/PulsarApp/app/(tabs)/index.tsx
+++ b/PulsarApp/app/(tabs)/index.tsx
@@ -15,11 +15,13 @@ import ConnectionList from '@/components/home/ConnectionList';
 import HapticsSupportBanner from '@/components/home/HapticsSupportBanner';
 import NowPlayingToast from '@/components/NowPlayingToast';
 import { useConnections } from '@/contexts/ConnectionsContext';
+import { useMediaSession } from '@/contexts/MediaSessionContext';
 
 const logo = require('@/assets/images/logo.png');
 
 export default function HomeScreen() {
   const { connections, addByCode, remove, reconnect } = useConnections();
+  const { openConnection } = useMediaSession();
   const router = useRouter();
 
   const [connectingCode, setConnectingCode] = useState('');
@@ -113,6 +115,7 @@ export default function HomeScreen() {
             onRemove={remove}
             onReconnect={reconnect}
             onOpenPreview={openPreview}
+            onOpenLibrary={openConnection}
             onEdit={editConnection}
           />
 

--- a/PulsarApp/app/_layout.tsx
+++ b/PulsarApp/app/_layout.tsx
@@ -16,6 +16,8 @@ import { OnboardingProvider } from '@/contexts/OnboardingContext';
 import { PlaygroundProvider } from '@/contexts/PlaygroundContext';
 import { StoreReviewProvider } from '@/contexts/StoreReviewContext';
 import { ConnectionsProvider } from '@/contexts/ConnectionsContext';
+import { MediaSessionProvider } from '@/contexts/MediaSessionContext';
+import MediaPlayerSheet from '@/components/media/MediaPlayerSheet';
 import { posthog } from '@/src/config/posthog';
 import { SENTRY_CONFIG } from '@/src/config/public';
 
@@ -79,6 +81,7 @@ function RootLayout() {
           maxElementsCaptured: 20,
         }}
       >
+        <MediaSessionProvider>
         <ConnectionsProvider>
           <StoreReviewProvider>
             <FilterProvider>
@@ -94,6 +97,7 @@ function RootLayout() {
                       <Stack.Screen name="playgroundSettingsModal" options={{ presentation: 'modal', title: 'Playground settings', headerShown: false }} />
                       <Stack.Screen name="editConnectionModal" options={{ presentation: 'modal', title: 'Connection', headerShown: false }} />
                     </Stack>
+                    <MediaPlayerSheet />
                     <StatusBar style="auto" />
                   </ThemeProvider>
                 </PlaygroundProvider>
@@ -102,6 +106,7 @@ function RootLayout() {
             </FilterProvider>
           </StoreReviewProvider>
         </ConnectionsProvider>
+        </MediaSessionProvider>
       </PostHogProvider>
     </GestureHandlerRootView>
   );

--- a/PulsarApp/components/home/ConnectionList.tsx
+++ b/PulsarApp/components/home/ConnectionList.tsx
@@ -10,6 +10,7 @@ export default function ConnectionList({
   onRemove,
   onReconnect,
   onOpenPreview,
+  onOpenLibrary,
   onEdit,
   emptyLabel = 'No connections yet.',
 }: {
@@ -18,6 +19,8 @@ export default function ConnectionList({
   onReconnect: (id: string) => void;
   // Open the live preview for a connection that advertised a preview token.
   onOpenPreview: (token: string) => void;
+  // Open a Studio (browser) connection's media-haptics library.
+  onOpenLibrary?: (id: string) => void;
   // Long-press a row to edit its name / view details.
   onEdit?: (id: string) => void;
   emptyLabel?: string;
@@ -39,6 +42,7 @@ export default function ConnectionList({
           onRemove={() => onRemove(c.id)}
           onReconnect={() => onReconnect(c.id)}
           onOpenPreview={c.previewToken ? () => onOpenPreview(c.previewToken as string) : undefined}
+          onOpenLibrary={onOpenLibrary ? () => onOpenLibrary(c.id) : undefined}
           onEdit={onEdit ? () => onEdit(c.id) : undefined}
         />
       ))}

--- a/PulsarApp/components/home/ConnectionRow.tsx
+++ b/PulsarApp/components/home/ConnectionRow.tsx
@@ -76,7 +76,6 @@ export default function ConnectionRow({
   // be opened advertises that in its subtitle in stable states (connected or
   // offline); transient/problem states show the status instead.
   const canOpenFigma = isFigma && !!onOpenPreview;
-  // A Studio (browser) row opens its media-haptics library on tap.
   const canOpenLibrary = !isFigma && !!onOpenLibrary;
   const onPressBody = isFigma ? onOpenPreview : canOpenLibrary ? onOpenLibrary : undefined;
   const sublabel =

--- a/PulsarApp/components/home/ConnectionRow.tsx
+++ b/PulsarApp/components/home/ConnectionRow.tsx
@@ -50,12 +50,15 @@ export default function ConnectionRow({
   onRemove,
   onReconnect,
   onOpenPreview,
+  onOpenLibrary,
   onEdit,
 }: {
   connection: Connection;
   onRemove: () => void;
   onReconnect: () => void;
   onOpenPreview?: () => void;
+  // Tap handler for a Studio (browser) connection: opens its media-haptics library sheet.
+  onOpenLibrary?: () => void;
   // Long-press handler: opens the edit/details modal for this connection.
   onEdit?: () => void;
 }) {
@@ -73,22 +76,27 @@ export default function ConnectionRow({
   // be opened advertises that in its subtitle in stable states (connected or
   // offline); transient/problem states show the status instead.
   const canOpenFigma = isFigma && !!onOpenPreview;
+  // A Studio (browser) row opens its media-haptics library on tap.
+  const canOpenLibrary = !isFigma && !!onOpenLibrary;
+  const onPressBody = isFigma ? onOpenPreview : canOpenLibrary ? onOpenLibrary : undefined;
   const sublabel =
     canOpenFigma && (status === 'connected' || status === 'offline')
       ? 'Click to open figma preview'
-      : status !== 'connected'
-        ? statusLabel(status)
-        : null;
+      : canOpenLibrary && (status === 'connected' || status === 'offline')
+        ? 'Tap to view haptics'
+        : status !== 'connected'
+          ? statusLabel(status)
+          : null;
 
   return (
     <Card style={styles.connCard}>
       <View style={styles.connRow}>
         <TouchableOpacity
           style={styles.pressArea}
-          onPress={isFigma ? onOpenPreview : undefined}
+          onPress={onPressBody}
           onLongPress={onEdit}
           delayLongPress={350}
-          disabled={!onEdit && !(isFigma && onOpenPreview)}
+          disabled={!onEdit && !onPressBody}
           activeOpacity={0.6}
         >
           <View style={[styles.statusDot, { backgroundColor: statusColor(status) }]} />

--- a/PulsarApp/components/media/LottieCanvas.tsx
+++ b/PulsarApp/components/media/LottieCanvas.tsx
@@ -1,0 +1,71 @@
+import { StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+
+// Guarded require: `lottie-react-native` is a native module. If the dev client hasn't been
+// rebuilt since it was added, requiring it throws — and the AUDIO path must keep working.
+// So we fall back to a placeholder instead of taking down the whole bundle.
+let LottieView: React.ComponentType<{
+  source: { uri: string };
+  progress?: number;
+  resizeMode?: 'cover' | 'contain' | 'center';
+  style?: object;
+}> | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  LottieView = require('lottie-react-native').default;
+} catch {
+  LottieView = null;
+}
+
+/**
+ * Renders a downloaded Lottie clip, its playhead driven by `progress` (0..1) — the SAME
+ * clock the haptics run on (see MediaSessionContext), so animation and haptics stay in
+ * lockstep. `repeat` restarts both because the clock resets to 0.
+ */
+export default function LottieCanvas({ uri, progress }: { uri: string; progress: number }) {
+  if (!LottieView) {
+    return (
+      <View style={styles.fallback}>
+        <ThemedText style={styles.fallbackText}>
+          Rebuild the app to view Lottie animations here.
+        </ThemedText>
+      </View>
+    );
+  }
+  return (
+    <View style={styles.canvas}>
+      <LottieView
+        source={{ uri }}
+        progress={Math.max(0, Math.min(1, progress))}
+        resizeMode="contain"
+        style={styles.lottie}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    height: 200,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    borderWidth: 2,
+    borderColor: '#001A72',
+    overflow: 'hidden',
+    marginBottom: 12,
+  },
+  lottie: { width: '100%', height: '100%' },
+  fallback: {
+    height: 120,
+    borderRadius: 12,
+    backgroundColor: '#EAF4FB',
+    borderWidth: 2,
+    borderColor: '#001A72',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 12,
+    paddingHorizontal: 16,
+  },
+  fallbackText: { color: '#496695', fontSize: 13, textAlign: 'center' },
+});

--- a/PulsarApp/components/media/MediaPlayerSheet.tsx
+++ b/PulsarApp/components/media/MediaPlayerSheet.tsx
@@ -1,0 +1,353 @@
+import { useMemo } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Icon } from '@/components/Icon';
+import LottieCanvas from '@/components/media/LottieCanvas';
+import { ThemedText } from '@/components/themed-text';
+import { useMediaSession } from '@/contexts/MediaSessionContext';
+import { connectionDisplayName, useConnections } from '@/contexts/ConnectionsContext';
+import type { ResourceRecord } from '@/src/connections/mediaLibrary';
+
+const NAVY = '#001A72';
+const SKY = '#38ACDD';
+const SUBTLE = '#496695';
+
+function formatMs(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** A neo-brutalist progress/scrubber bar; `fraction` 0..1. */
+function ProgressBar({ fraction, color = SKY }: { fraction: number; color?: string }) {
+  const pct = `${Math.max(0, Math.min(1, fraction)) * 100}%` as const;
+  return (
+    <View style={styles.track}>
+      <View style={[styles.fill, { width: pct, backgroundColor: color }]} />
+    </View>
+  );
+}
+
+function RoundButton({
+  icon,
+  onPress,
+  label,
+  tint = NAVY,
+  disabled,
+}: {
+  icon: 'play' | 'stop' | 'refresh-cw' | 'x' | 'download' | 'arrow';
+  onPress: () => void;
+  label: string;
+  tint?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      hitSlop={8}
+      accessibilityLabel={label}
+      style={[styles.roundBtn, disabled && styles.roundBtnDisabled]}
+    >
+      <Icon name={icon} size={20} color={tint} />
+    </TouchableOpacity>
+  );
+}
+
+/**
+ * The device player for media-backed haptics received from Studio. Two faces of one
+ * component (see MediaSessionContext): a pinned mini-player that appears on an incoming
+ * push, and — when a Studio connection is tapped — a full-screen library sheet listing
+ * that connection's cached resources, each replayable/deletable. Non-blocking, dismissible.
+ */
+export default function MediaPlayerSheet() {
+  const {
+    session,
+    downloadProgress,
+    positionMs,
+    openConnectionId,
+    library,
+    openConnection,
+    collapse,
+    closeSheet,
+    playResource,
+    repeat,
+    stop,
+    removeResource,
+  } = useMediaSession();
+  const { connections } = useConnections();
+  const insets = useSafeAreaInsets();
+
+  const connectionName = useMemo(() => {
+    const c = connections.find((x) => x.id === openConnectionId);
+    return c ? connectionDisplayName(c) : 'Connection';
+  }, [connections, openConnectionId]);
+
+  const isDownloading = session?.status === 'downloading';
+  const isPlaying = session?.status === 'playing';
+  const fraction = isDownloading
+    ? downloadProgress
+    : session && session.durationMs > 0
+      ? positionMs / session.durationMs
+      : 0;
+
+  const statusText = session
+    ? session.status === 'downloading'
+      ? `Downloading… ${Math.round(downloadProgress * 100)}%`
+      : session.status === 'error'
+        ? session.error ?? 'Could not load'
+        : `${formatMs(isPlaying ? positionMs : session.durationMs)} / ${formatMs(session.durationMs)}`
+    : '';
+
+  // Nothing to show.
+  if (!session && !openConnectionId) return null;
+
+  // Play/stop toggle used by both faces.
+  const onTogglePlay = () => {
+    if (isPlaying) stop();
+    else repeat(); // replay the current record from the top
+  };
+
+  return (
+    <>
+      {/* Mini-player: pinned above the tab bar, shown whenever there's an active session
+          and the full library isn't open. */}
+      {session && !openConnectionId && (
+        <Animated.View
+          entering={FadeInDown}
+          exiting={FadeOutDown}
+          style={[styles.miniWrap, { bottom: insets.bottom + 64 }]}
+        >
+          <Pressable style={styles.mini} onPress={() => openConnection(session.connectionId)}>
+            <View style={styles.miniMain}>
+              <View style={styles.miniHeader}>
+                <Icon name={isDownloading ? 'download' : 'play'} size={16} color={NAVY} />
+                <ThemedText type="defaultSemiBold" numberOfLines={1} style={styles.miniTitle}>
+                  {session.name}
+                </ThemedText>
+              </View>
+              <ProgressBar fraction={fraction} color={isDownloading ? NAVY : SKY} />
+              <ThemedText style={styles.miniStatus} numberOfLines={1}>
+                {statusText}
+              </ThemedText>
+            </View>
+            {!isDownloading && session.status !== 'error' && (
+              <>
+                <RoundButton icon={isPlaying ? 'stop' : 'play'} onPress={onTogglePlay} label="Play/stop" />
+                <RoundButton icon="refresh-cw" onPress={repeat} label="Repeat" />
+              </>
+            )}
+            <RoundButton icon="x" onPress={closeSheet} label="Close" tint="#FF6259" />
+          </Pressable>
+        </Animated.View>
+      )}
+
+      {/* Library: full-screen sheet listing the connection's cached resources. */}
+      <Modal
+        visible={!!openConnectionId}
+        transparent
+        animationType="slide"
+        onRequestClose={collapse}
+      >
+        <Pressable style={styles.backdrop} onPress={collapse} />
+        <View style={[styles.panel, { paddingBottom: insets.bottom + 16 }]}>
+          <View style={styles.panelHeader}>
+            <View style={styles.panelHeaderText}>
+              <ThemedText type="subtitle">Haptics library</ThemedText>
+              <ThemedText style={styles.panelSubtitle}>{connectionName}</ThemedText>
+            </View>
+            <RoundButton icon="x" onPress={collapse} label="Collapse" />
+          </View>
+
+          {/* The Lottie canvas, for an animation resource that's downloaded — its
+              playhead is driven by the same clock as the haptics. */}
+          {session?.kind === 'animation' && session.localUri && (
+            <LottieCanvas uri={session.localUri} progress={fraction} />
+          )}
+
+          {/* The active player, when something is loaded. */}
+          {session && (
+            <View style={styles.nowPlaying}>
+              <ThemedText type="defaultSemiBold" numberOfLines={1}>
+                {session.name}
+              </ThemedText>
+              <ProgressBar fraction={fraction} color={isDownloading ? NAVY : SKY} />
+              <View style={styles.nowPlayingRow}>
+                <ThemedText style={styles.miniStatus}>{statusText}</ThemedText>
+                <View style={styles.controls}>
+                  {!isDownloading && session.status !== 'error' && (
+                    <>
+                      <RoundButton icon={isPlaying ? 'stop' : 'play'} onPress={onTogglePlay} label="Play/stop" />
+                      <RoundButton icon="refresh-cw" onPress={repeat} label="Repeat" />
+                    </>
+                  )}
+                </View>
+              </View>
+            </View>
+          )}
+
+          <ThemedText style={styles.listLabel}>Saved on this device</ThemedText>
+          <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+            {library.length === 0 ? (
+              <ThemedText style={styles.empty}>
+                Nothing yet. Play an audio- or animation-based haptic from Studio and it appears here.
+              </ThemedText>
+            ) : (
+              library.map((record) => (
+                <ResourceRow
+                  key={record.resourceId}
+                  record={record}
+                  active={session?.resourceId === record.resourceId}
+                  onPlay={() =>
+                    openConnectionId && playResource(openConnectionId, record.resourceId)
+                  }
+                  onDelete={() =>
+                    openConnectionId && removeResource(openConnectionId, record.resourceId)
+                  }
+                />
+              ))
+            )}
+          </ScrollView>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+function ResourceRow({
+  record,
+  active,
+  onPlay,
+  onDelete,
+}: {
+  record: ResourceRecord;
+  active: boolean;
+  onPlay: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <View style={[styles.resourceRow, active && styles.resourceRowActive]}>
+      <Icon name={record.kind === 'animation' ? 'sparkles' : 'play'} size={16} color={NAVY} />
+      <View style={styles.resourceInfo}>
+        <ThemedText type="defaultSemiBold" numberOfLines={1}>
+          {record.name}
+        </ThemedText>
+        <ThemedText style={styles.resourceMeta}>
+          {record.kind === 'animation' ? 'Animation' : 'Audio'} · {formatMs(record.durationMs)}
+        </ThemedText>
+      </View>
+      <RoundButton icon="play" onPress={onPlay} label="Play" />
+      <RoundButton icon="x" onPress={onDelete} label="Delete" tint="#FF6259" />
+    </View>
+  );
+}
+
+const brutalist = {
+  borderWidth: 2,
+  borderColor: NAVY,
+  shadowColor: SKY,
+  shadowOffset: { width: -3, height: 3 },
+  shadowOpacity: 1,
+  shadowRadius: 0,
+  elevation: 4,
+} as const;
+
+const styles = StyleSheet.create({
+  miniWrap: {
+    position: 'absolute',
+    left: 12,
+    right: 12,
+  },
+  mini: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#fff',
+    borderRadius: 14,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    ...brutalist,
+  },
+  miniMain: { flex: 1 },
+  miniHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  miniTitle: { flexShrink: 1, fontSize: 15, lineHeight: 20 },
+  miniStatus: { fontSize: 12, color: SUBTLE, marginTop: 4 },
+  track: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#D5E6F2',
+    overflow: 'hidden',
+  },
+  fill: { height: '100%', borderRadius: 3 },
+  roundBtn: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#EAF4FB',
+    borderWidth: 2,
+    borderColor: NAVY,
+  },
+  roundBtnDisabled: { opacity: 0.4 },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,26,114,0.25)',
+  },
+  panel: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    maxHeight: '80%',
+    backgroundColor: '#E1F3FA',
+    borderTopLeftRadius: 22,
+    borderTopRightRadius: 22,
+    borderWidth: 2,
+    borderColor: NAVY,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  panelHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  panelHeaderText: { flex: 1 },
+  panelSubtitle: { fontSize: 13, color: SUBTLE, marginTop: 2 },
+  nowPlaying: {
+    marginTop: 14,
+    backgroundColor: '#fff',
+    borderRadius: 14,
+    padding: 12,
+    ...brutalist,
+  },
+  nowPlayingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+  },
+  controls: { flexDirection: 'row', gap: 8 },
+  listLabel: { fontSize: 13, color: SUBTLE, marginTop: 18, marginBottom: 6 },
+  list: { marginBottom: 4 },
+  listContent: { gap: 8, paddingBottom: 8 },
+  empty: { color: SUBTLE, fontSize: 14, lineHeight: 20, paddingVertical: 12 },
+  resourceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderWidth: 2,
+    borderColor: NAVY,
+  },
+  resourceRowActive: { backgroundColor: '#F0F8FF', borderColor: SKY },
+  resourceInfo: { flex: 1 },
+  resourceMeta: { fontSize: 12, color: SUBTLE, marginTop: 2 },
+});

--- a/PulsarApp/components/media/MediaPlayerSheet.tsx
+++ b/PulsarApp/components/media/MediaPlayerSheet.tsx
@@ -102,10 +102,8 @@ export default function MediaPlayerSheet() {
         : `${formatMs(isPlaying ? positionMs : session.durationMs)} / ${formatMs(session.durationMs)}`
     : '';
 
-  // Nothing to show.
   if (!session && !openConnectionId) return null;
 
-  // Play/stop toggle used by both faces.
   const onTogglePlay = () => {
     if (isPlaying) stop();
     else repeat(); // replay the current record from the top

--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -11,6 +11,7 @@ import React, {
 import { Presets, usePatternComposer, type Pattern } from 'react-native-pulsar';
 
 import { handleServerMessage, type ServerMessageHandlers } from '@/src/connections/serverMessages';
+import { useMediaSession } from '@/contexts/MediaSessionContext';
 import { loadPersistedConnections, persistConnections } from '@/src/connections/storage';
 import { useDeepLinkPairing } from '@/src/connections/useDeepLinkPairing';
 import { useForegroundReconnect } from '@/src/connections/useForegroundReconnect';
@@ -78,6 +79,12 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   const composerRef = useRef(composer);
   composerRef.current = composer;
 
+  // Media-backed haptics (audio / Lottie) are downloaded and played by the media session,
+  // read through a ref for the same reason as the composer.
+  const media = useMediaSession();
+  const mediaRef = useRef(media);
+  mediaRef.current = media;
+
   const newId = useCallback(() => `conn-${Date.now().toString(36)}-${idCounter.current++}`, []);
 
   const patchConnection = useCallback((id: string, patch: Partial<Connection>) => {
@@ -101,6 +108,8 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
         return false;
       }
     },
+    startAudioHaptics: (id, message) => mediaRef.current.startAudioHaptics(id, message),
+    startAnimationHaptics: (id, message) => mediaRef.current.startAnimationHaptics(id, message),
     emitPreviewUpdate: (id, update) => {
       // Match on the producer-supplied previewToken, falling back to the one
       // this connection advertised at pairing time.
@@ -157,6 +166,8 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
     (id: string) => {
       sockets.teardown(id);
       setConnections((prev) => prev.filter((c) => c.id !== id));
+      // Its cached media clips live only as long as the connection does.
+      mediaRef.current.handleConnectionRemoved(id);
       Presets.powerDown();
       track('device_disconnected');
     },

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -1,0 +1,370 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { usePatternComposer } from 'react-native-pulsar';
+
+import type {
+  AudioHapticsBroadcast,
+  AnimationHapticsBroadcast,
+} from '@/src/connections/serverMessages';
+import {
+  downloadClip,
+  extForContentType,
+  getResource,
+  listResources,
+  purgeConnection,
+  removeResource as removeResourceFromLibrary,
+  upsertResource,
+  type MediaKind,
+  type ResourceRecord,
+} from '@/src/connections/mediaLibrary';
+
+/**
+ * The device-side player for media-backed haptics (audio, and — phase 2 — Lottie) received
+ * from a Studio connection.
+ *
+ * It owns its OWN pattern composer (separate from the connection's confirmation buzzes),
+ * downloads the clip, plays the haptics in sync with the media, and tracks a playback
+ * clock manually — the SDK exposes no progress/`onComplete`, so elapsed time against the
+ * known duration is the only signal. Cached clips live per-connection (see mediaLibrary),
+ * so a resource can be replayed from the phone even when Studio isn't pushing.
+ */
+
+type SessionStatus = 'downloading' | 'ready' | 'playing' | 'stopped' | 'error';
+
+export interface MediaSession {
+  connectionId: string;
+  resourceId: string;
+  kind: MediaKind;
+  name: string;
+  durationMs: number;
+  status: SessionStatus;
+  /** `file://` uri of the downloaded clip, once ready. */
+  localUri?: string;
+  error?: string;
+}
+
+interface MediaSessionContextValue {
+  /** The active player session (download/playback), or null when idle. */
+  session: MediaSession | null;
+  /** Download fraction 0..1 while `status === 'downloading'`. */
+  downloadProgress: number;
+  /** Playback position in ms (drives the scrubber). */
+  positionMs: number;
+  /** Which connection's library sheet is open, or null. */
+  openConnectionId: string | null;
+  /** Cached resources for `openConnectionId`. */
+  library: ResourceRecord[];
+
+  // Called by the connection message handlers on an incoming push.
+  startAudioHaptics: (connectionId: string, message: AudioHapticsBroadcast) => void;
+  startAnimationHaptics: (connectionId: string, message: AnimationHapticsBroadcast) => void;
+
+  /** Open a connection's library sheet. */
+  openConnection: (connectionId: string) => void;
+  /** Collapse the expanded library back to the mini-player (playback continues). */
+  collapse: () => void;
+  /** Hide the sheet and stop playback. */
+  closeSheet: () => void;
+  /** Play a cached resource from the library. */
+  playResource: (connectionId: string, resourceId: string) => void;
+  /** Replay the current resource from the top (media + haptics). */
+  repeat: () => void;
+  /** Stop playback (keeps the sheet open). */
+  stop: () => void;
+  /** Delete a cached resource (file + record). */
+  removeResource: (connectionId: string, resourceId: string) => void;
+  /** Purge a removed connection's cache and close the sheet if it was showing it. */
+  handleConnectionRemoved: (connectionId: string) => void;
+}
+
+const MediaSessionContext = createContext<MediaSessionContextValue | undefined>(undefined);
+
+export function MediaSessionProvider({ children }: { children: ReactNode }) {
+  const composer = usePatternComposer(undefined);
+  const composerRef = useRef(composer);
+  composerRef.current = composer;
+
+  const [session, setSession] = useState<MediaSession | null>(null);
+  const [downloadProgress, setDownloadProgress] = useState(0);
+  const [positionMs, setPositionMs] = useState(0);
+  const [openConnectionId, setOpenConnectionId] = useState<string | null>(null);
+  const [library, setLibrary] = useState<ResourceRecord[]>([]);
+
+  const openRef = useRef<string | null>(null);
+  openRef.current = openConnectionId;
+  const sessionRef = useRef<MediaSession | null>(null);
+  sessionRef.current = session;
+  const currentRecordRef = useRef<ResourceRecord | null>(null);
+  // The active rAF handle for the playback clock. Held in a ref so a newer play() can
+  // cancel an older loop before it publishes a stale position.
+  const rafRef = useRef<number | null>(null);
+
+  const stopClock = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  // Drive the scrubber off wall-clock elapsed vs the known duration — the SDK gives no
+  // position, so this is the authority for "where are we" and "when did it end".
+  const startClock = useCallback(
+    (durationMs: number) => {
+      stopClock();
+      const start = Date.now();
+      const tick = () => {
+        const elapsed = Date.now() - start;
+        if (elapsed >= durationMs) {
+          setPositionMs(durationMs);
+          rafRef.current = null;
+          setSession((s) => (s ? { ...s, status: 'stopped' } : s));
+          return;
+        }
+        setPositionMs(elapsed);
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [stopClock],
+  );
+
+  const refreshLibrary = useCallback(async (connectionId: string) => {
+    const list = await listResources(connectionId);
+    if (openRef.current === connectionId) setLibrary(list);
+  }, []);
+
+  // Parse + play one cached record, and start the shared clock. Audio rides on
+  // `pattern.sound`; an animation plays the pattern alone (its visual is driven off the
+  // same clock in the sheet).
+  const playRecord = useCallback(
+    (connectionId: string, record: ResourceRecord) => {
+      currentRecordRef.current = record;
+      try {
+        const pattern =
+          record.kind === 'audio'
+            ? {
+                ...record.pattern,
+                sound: {
+                  uri: record.localUri,
+                  volume: record.volume ?? 1,
+                  offset: record.offset ?? 0,
+                  // The SDK plays only [start, start+duration] of the downloaded file, so a
+                  // trimmed design honors the trim without a re-download.
+                  start: record.soundStartMs ?? 0,
+                  duration: record.soundDurationMs ?? 0,
+                },
+              }
+            : record.pattern;
+        composerRef.current.parse(pattern);
+        composerRef.current.play();
+      } catch {
+        // Haptics may fail on an unsupported device; the media/clock still run.
+      }
+      setSession({
+        connectionId,
+        resourceId: record.resourceId,
+        kind: record.kind,
+        name: record.name,
+        durationMs: record.durationMs,
+        status: 'playing',
+        localUri: record.localUri,
+      });
+      setPositionMs(0);
+      startClock(record.durationMs);
+    },
+    [startClock],
+  );
+
+  const startMedia = useCallback(
+    async (
+      connectionId: string,
+      message: AudioHapticsBroadcast | AnimationHapticsBroadcast,
+      kind: MediaKind,
+    ) => {
+      const media = kind === 'audio'
+        ? (message as AudioHapticsBroadcast).audio
+        : (message as AnimationHapticsBroadcast).animation;
+      const { resourceId, name, version, durationMs, pattern } = message;
+
+      stopClock();
+      // A push shows the compact mini-player; it doesn't force the full library open —
+      // the user expands it by tapping the connection (or the bar).
+      setDownloadProgress(0);
+      setPositionMs(0);
+      setSession({ connectionId, resourceId, kind, name, durationMs, status: 'downloading' });
+
+      try {
+        const ext = extForContentType(media.contentType);
+        // downloadClip skips the network when the clip file already exists — so an
+        // unchanged resend (same clipId) plays straight from disk.
+        const localUri = await downloadClip(
+          connectionId,
+          media.clipId,
+          ext,
+          media.downloadUrl,
+          setDownloadProgress,
+        );
+
+        const audioWindow = (message as AudioHapticsBroadcast).window;
+        const record: ResourceRecord = {
+          resourceId,
+          name,
+          kind,
+          version,
+          clipId: media.clipId,
+          localUri,
+          contentType: media.contentType,
+          sizeBytes: media.size,
+          durationMs,
+          pattern,
+          volume: (message as AudioHapticsBroadcast).volume,
+          offset: (message as AudioHapticsBroadcast).offsetMs,
+          soundStartMs: audioWindow?.startMs,
+          soundDurationMs: audioWindow?.durationMs,
+          receivedAt: Date.now(),
+        };
+        await upsertResource(connectionId, record);
+        void refreshLibrary(connectionId);
+
+        // The user may have dismissed/replaced this session while the download ran.
+        if (sessionRef.current?.resourceId !== resourceId) return;
+        playRecord(connectionId, record);
+      } catch (error) {
+        setSession((s) =>
+          s && s.resourceId === resourceId
+            ? { ...s, status: 'error', error: error instanceof Error ? error.message : 'Could not load media' }
+            : s,
+        );
+      }
+    },
+    [playRecord, refreshLibrary, stopClock],
+  );
+
+  const startAudioHaptics = useCallback(
+    (connectionId: string, message: AudioHapticsBroadcast) => {
+      void startMedia(connectionId, message, 'audio');
+    },
+    [startMedia],
+  );
+
+  const startAnimationHaptics = useCallback(
+    (connectionId: string, message: AnimationHapticsBroadcast) => {
+      void startMedia(connectionId, message, 'animation');
+    },
+    [startMedia],
+  );
+
+  const openConnection = useCallback(
+    (connectionId: string) => {
+      setOpenConnectionId(connectionId);
+      void refreshLibrary(connectionId);
+    },
+    [refreshLibrary],
+  );
+
+  const stop = useCallback(() => {
+    stopClock();
+    try {
+      composerRef.current.stop();
+    } catch {
+      // no-op
+    }
+    setSession((s) => (s ? { ...s, status: 'stopped' } : s));
+    setPositionMs(0);
+  }, [stopClock]);
+
+  const collapse = useCallback(() => {
+    setOpenConnectionId(null);
+    setLibrary([]);
+  }, []);
+
+  const closeSheet = useCallback(() => {
+    stop();
+    setSession(null);
+    setOpenConnectionId(null);
+    setLibrary([]);
+  }, [stop]);
+
+  const playResource = useCallback(
+    async (connectionId: string, resourceId: string) => {
+      const record = await getResource(connectionId, resourceId);
+      if (!record) return;
+      setOpenConnectionId(connectionId);
+      playRecord(connectionId, record);
+    },
+    [playRecord],
+  );
+
+  const repeat = useCallback(() => {
+    const record = currentRecordRef.current;
+    const active = sessionRef.current;
+    if (record && active) playRecord(active.connectionId, record);
+  }, [playRecord]);
+
+  const removeResource = useCallback(
+    (connectionId: string, resourceId: string) => {
+      if (sessionRef.current?.resourceId === resourceId) {
+        stop();
+        setSession(null);
+      }
+      void removeResourceFromLibrary(connectionId, resourceId).then(() =>
+        refreshLibrary(connectionId),
+      );
+    },
+    [refreshLibrary, stop],
+  );
+
+  const handleConnectionRemoved = useCallback(
+    (connectionId: string) => {
+      if (openRef.current === connectionId) {
+        stop();
+        setSession(null);
+        setOpenConnectionId(null);
+        setLibrary([]);
+      }
+      void purgeConnection(connectionId);
+    },
+    [stop],
+  );
+
+  useEffect(() => () => stopClock(), [stopClock]);
+
+  return (
+    <MediaSessionContext.Provider
+      value={{
+        session,
+        downloadProgress,
+        positionMs,
+        openConnectionId,
+        library,
+        startAudioHaptics,
+        startAnimationHaptics,
+        openConnection,
+        collapse,
+        closeSheet,
+        playResource,
+        repeat,
+        stop,
+        removeResource,
+        handleConnectionRemoved,
+      }}
+    >
+      {children}
+    </MediaSessionContext.Provider>
+  );
+}
+
+export function useMediaSession() {
+  const context = useContext(MediaSessionContext);
+  if (context === undefined) {
+    throw new Error('useMediaSession must be used within a MediaSessionProvider');
+  }
+  return context;
+}

--- a/PulsarApp/package-lock.json
+++ b/PulsarApp/package-lock.json
@@ -33,6 +33,7 @@
         "expo-system-ui": "~57.0.2",
         "expo-updates": "~57.0.12",
         "expo-web-browser": "~57.0.2",
+        "lottie-react-native": "~7.3.8",
         "posthog-react-native": "^4.41.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -57,7 +58,7 @@
       }
     },
     "../react-native/react-native-pulsar": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^19.8.1",
@@ -10141,6 +10142,26 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lottie-react-native": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-7.3.8.tgz",
+      "integrity": "sha512-GAOl99TKi0c6xCcB1AJ+o70mgOPIAI/7K2G+Gs+o4po/qBhgvWijPNCKH8h6yNmlwFTg+RN3DmzRvHNFGxZMKQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@lottiefiles/dotlottie-react": "^0.13.5",
+        "react": "*",
+        "react-native": ">=0.46",
+        "react-native-windows": ">=0.63.x"
+      },
+      "peerDependenciesMeta": {
+        "@lottiefiles/dotlottie-react": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/lru-cache": {

--- a/PulsarApp/package.json
+++ b/PulsarApp/package.json
@@ -38,6 +38,7 @@
     "expo-system-ui": "~57.0.2",
     "expo-updates": "~57.0.12",
     "expo-web-browser": "~57.0.2",
+    "lottie-react-native": "~7.3.8",
     "posthog-react-native": "^4.41.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/PulsarApp/src/connections/mediaLibrary.ts
+++ b/PulsarApp/src/connections/mediaLibrary.ts
@@ -1,0 +1,186 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+// The legacy API is the progress-capable download surface (createDownloadResumable) and
+// exposes documentDirectory directly. SDK 54 keeps it under this subpath.
+import * as FileSystem from 'expo-file-system/legacy';
+import type { Pattern } from 'react-native-pulsar';
+
+/**
+ * The phone's on-device library of media-backed haptics received from a Studio connection.
+ *
+ * Two stores, kept in step:
+ *   - an AsyncStorage INDEX, `connectionId -> ResourceRecord[]` (small metadata), and
+ *   - the CLIP FILES under documentDirectory (persistent — survives restarts, unlike the
+ *     cache directory the OS may evict).
+ *
+ * Retention is scoped to the connection: a connection's clips live as long as the
+ * connection row does (`purgeConnection` on remove), plus a per-resource manual delete.
+ */
+
+export type MediaKind = 'audio' | 'animation';
+
+export interface ResourceRecord {
+  /** Stable identity = the Studio preset id. A re-push with a new version replaces it. */
+  resourceId: string;
+  name: string;
+  kind: MediaKind;
+  /** Content hash from Studio; the dedupe key that decides re-download vs reuse. */
+  version: string;
+  /** Addresses the delivered bytes (content hash / source id) — the on-disk filename. */
+  clipId: string;
+  /** `file://` path to the downloaded clip. */
+  localUri: string;
+  contentType: string;
+  sizeBytes: number;
+  durationMs: number;
+  /** The haptic pattern to play. */
+  pattern: Pattern;
+  volume?: number;
+  offset?: number;
+  /** Trim window into the audio file, ms (absent = whole file). Played by the SDK natively. */
+  soundStartMs?: number;
+  soundDurationMs?: number;
+  receivedAt: number;
+}
+
+const STORAGE_KEY = 'pulsar:media-library';
+const MEDIA_ROOT = `${FileSystem.documentDirectory ?? ''}pulsar-media/`;
+
+type LibraryIndex = Record<string, ResourceRecord[]>;
+
+async function readIndex(): Promise<LibraryIndex> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as LibraryIndex) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeIndex(index: LibraryIndex): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(index));
+  } catch {
+    // Storage disabled/full — the session still works in memory this run.
+  }
+}
+
+/** Map a stored content-type to a filename extension for the on-disk clip. */
+export function extForContentType(contentType: string): string {
+  if (/wav/i.test(contentType)) return 'wav';
+  if (/mpeg|mp3/i.test(contentType)) return 'mp3';
+  if (/zip/i.test(contentType)) return 'lottie';
+  if (/json/i.test(contentType)) return 'json';
+  return 'bin';
+}
+
+const connectionDir = (connectionId: string) => `${MEDIA_ROOT}${connectionId}/`;
+
+export function localPathFor(connectionId: string, clipId: string, ext: string): string {
+  return `${connectionDir(connectionId)}${clipId}.${ext}`;
+}
+
+/** Create a connection's media directory if it isn't there yet. Idempotent. */
+async function ensureConnectionDir(connectionId: string): Promise<void> {
+  const dir = connectionDir(connectionId);
+  const info = await FileSystem.getInfoAsync(dir);
+  if (!info.exists) await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
+}
+
+async function fileExists(uri: string): Promise<boolean> {
+  try {
+    return (await FileSystem.getInfoAsync(uri)).exists;
+  } catch {
+    return false;
+  }
+}
+
+async function deleteFile(uri: string): Promise<void> {
+  try {
+    await FileSystem.deleteAsync(uri, { idempotent: true });
+  } catch {
+    // Already gone is fine.
+  }
+}
+
+/** The resources cached for a connection, most-recent first. */
+export async function listResources(connectionId: string): Promise<ResourceRecord[]> {
+  const index = await readIndex();
+  return [...(index[connectionId] ?? [])].sort((a, b) => b.receivedAt - a.receivedAt);
+}
+
+/** The cached record for a resource, or undefined. */
+export async function getResource(
+  connectionId: string,
+  resourceId: string,
+): Promise<ResourceRecord | undefined> {
+  const index = await readIndex();
+  return (index[connectionId] ?? []).find((r) => r.resourceId === resourceId);
+}
+
+/**
+ * Download a clip to its persistent path, reporting progress, and return the local uri.
+ * Skips the network entirely when a file for this exact clip already exists on disk.
+ */
+export async function downloadClip(
+  connectionId: string,
+  clipId: string,
+  ext: string,
+  url: string,
+  onProgress?: (fraction: number) => void,
+): Promise<string> {
+  await ensureConnectionDir(connectionId);
+  const dest = localPathFor(connectionId, clipId, ext);
+  if (await fileExists(dest)) {
+    onProgress?.(1);
+    return dest;
+  }
+  const task = FileSystem.createDownloadResumable(url, dest, {}, (p) => {
+    if (p.totalBytesExpectedToWrite > 0) {
+      onProgress?.(p.totalBytesWritten / p.totalBytesExpectedToWrite);
+    }
+  });
+  const result = await task.downloadAsync();
+  if (!result) throw new Error('Download did not complete');
+  return result.uri;
+}
+
+/**
+ * Insert or replace a resource by (connectionId, resourceId). If a record with the same
+ * resourceId but a DIFFERENT clip already existed, its stale file is deleted so an edited
+ * design doesn't leave the old clip on disk forever.
+ */
+export async function upsertResource(
+  connectionId: string,
+  record: ResourceRecord,
+): Promise<void> {
+  const index = await readIndex();
+  const list = index[connectionId] ?? [];
+  const previous = list.find((r) => r.resourceId === record.resourceId);
+  if (previous && previous.localUri !== record.localUri) {
+    await deleteFile(previous.localUri);
+  }
+  index[connectionId] = [...list.filter((r) => r.resourceId !== record.resourceId), record];
+  await writeIndex(index);
+}
+
+/** Remove one resource: its file and its index entry. */
+export async function removeResource(connectionId: string, resourceId: string): Promise<void> {
+  const index = await readIndex();
+  const list = index[connectionId] ?? [];
+  const target = list.find((r) => r.resourceId === resourceId);
+  if (target) await deleteFile(target.localUri);
+  index[connectionId] = list.filter((r) => r.resourceId !== resourceId);
+  await writeIndex(index);
+}
+
+/** Drop everything for a connection — its whole directory and all its index entries. */
+export async function purgeConnection(connectionId: string): Promise<void> {
+  await deleteFile(connectionDir(connectionId));
+  const index = await readIndex();
+  if (index[connectionId]) {
+    delete index[connectionId];
+    await writeIndex(index);
+  }
+}

--- a/PulsarApp/src/connections/serverMessages.ts
+++ b/PulsarApp/src/connections/serverMessages.ts
@@ -14,10 +14,59 @@ interface ServerMessage {
   figmaProjectName?: string;
 }
 
+// A media clip a phone downloads to play in sync with the haptics. Mirrors Studio's
+// `MediaRef` (device/toPattern.ts): `clipId` addresses the delivered bytes (the phone's
+// cache/dedupe key), `downloadUrl` is where it fetches them.
+export interface BroadcastMediaRef {
+  clipId: string;
+  downloadUrl: string;
+  contentType: string;
+  size: number;
+}
+
+// A preset scored to an AUDIO file, pushed from Studio (see device/toPattern.ts). The
+// clip is already trimmed, so the pattern and the audio both play from t=0.
+export interface AudioHapticsBroadcast {
+  kind: 'audio-haptics';
+  resourceId: string;
+  version: string;
+  name: string;
+  durationMs: number;
+  pattern: Pattern;
+  audio: BroadcastMediaRef;
+  volume?: number;
+  offsetMs?: number;
+  // The trim window into the audio file (absent = whole file). The SDK plays only this
+  // window via `Pattern.sound` start/duration, so the whole file is downloaded once and a
+  // trim change never re-downloads.
+  window?: { startMs: number; durationMs: number };
+}
+
+// A preset scored to a Lottie ANIMATION, pushed from Studio. The animation is downloaded
+// and rendered in lockstep with the haptics off a shared clock.
+export interface AnimationHapticsBroadcast {
+  kind: 'animation-haptics';
+  resourceId: string;
+  version: string;
+  name: string;
+  durationMs: number;
+  pattern: Pattern;
+  animation: BroadcastMediaRef & {
+    totalFrames: number;
+    frameRate: number;
+    width: number;
+    height: number;
+  };
+}
+
 export interface ServerMessageHandlers {
   patchConnection: (id: string, patch: Partial<Connection>) => void;
   notify: (found: boolean, name: string) => void;
   playPreset: (pattern: Pattern) => boolean;
+  // A media-backed haptic (audio / Lottie) — downloaded, then played in sync on the
+  // per-connection player sheet. `id` is the connection it arrived on.
+  startAudioHaptics: (id: string, message: AudioHapticsBroadcast) => void;
+  startAnimationHaptics: (id: string, message: AnimationHapticsBroadcast) => void;
   emitPreviewUpdate: (id: string, update: Omit<PreviewUpdate, 'nonce'>) => void;
   track: Track;
 }
@@ -53,6 +102,18 @@ function handleBroadcast(id: string, message: unknown, handlers: ServerMessageHa
     // ignore it: the backward-compat seam.
     const preset = message as { kind: string; name?: string; pattern: Pattern };
     handlers.notify(handlers.playPreset(preset.pattern), preset.name ?? 'Haptic preset');
+    return;
+  }
+
+  // A media-backed haptic from Studio: an audio clip or a Lottie animation the phone
+  // downloads and plays in sync (see MediaSessionContext). Older app builds don't match
+  // these kinds and harmlessly ignore them — the same backward-compat seam.
+  if (kind === 'audio-haptics' && (message as { audio?: unknown }).audio) {
+    handlers.startAudioHaptics(id, message as AudioHapticsBroadcast);
+    return;
+  }
+  if (kind === 'animation-haptics' && (message as { animation?: unknown }).animation) {
+    handlers.startAnimationHaptics(id, message as AnimationHapticsBroadcast);
     return;
   }
 


### PR DESCRIPTION
Part of the media-synced-haptics feature (PulsarApp).

Receives audio- and Lottie-scored haptics pushed from Pulsar Studio, downloads the media to a persistent per-connection cache, and plays it in sync with the haptics.

- **MediaSessionContext:** own composer, download via `expo-file-system`, manual playback clock (SDK has no progress/onComplete), repeat/stop.
- **mediaLibrary:** AsyncStorage index + files under `documentDirectory`, deduped by `clipId`, purged when a connection is removed; per-resource delete.
- **serverMessages:** handle new `audio-haptics` / `animation-haptics` broadcast kinds (older builds ignore them).
- **MediaPlayerSheet:** bottom-sheet mini-player + tap-a-connection library; Lottie rendered off the same clock (`lottie-react-native`, guarded require).

**Verification:** typechecks clean; the whole app Metro-bundles for iOS.

⚠️ **Depends on https://github.com/software-mansion/pulsar/pull/195** (needs `Sound.start`/`duration` for trimmed-audio playback). Also adds `lottie-react-native` (native) — needs a dev-client rebuild to run.