### PR TITLE
feat(app): advertise haptics-support level when pairing

### DIFF
--- a/PulsarApp/src/connections/hapticsSupport.ts
+++ b/PulsarApp/src/connections/hapticsSupport.ts
@@ -1,0 +1,40 @@
+import { Settings, HapticSupport } from 'react-native-pulsar';
+
+/**
+ * What level of haptics this phone's hardware can actually render, as a short stable
+ * token for the pairing handshake (`&hapticsSupport=`). The relay hands it to the
+ * producer alongside the device name, so a designer tool (Pulsar Studio) can show whether
+ * a paired phone will feel the full designed pattern or just a plain buzz.
+ *
+ * The tokens are the lower-cased names of `react-native-pulsar`'s own `HapticSupport`
+ * scale — the value `Settings.getHapticsSupportLevel()` returns — so the wire format is
+ * self-describing and doesn't depend on the enum's numbers:
+ *   NO_SUPPORT → 'none', LIMITED_SUPPORT → 'limited',
+ *   STANDARD_SUPPORT → 'standard', ADVANCED_SUPPORT → 'advanced'.
+ */
+const TOKENS: Record<HapticSupport, string> = {
+  [HapticSupport.NO_SUPPORT]: 'none',
+  [HapticSupport.LIMITED_SUPPORT]: 'limited',
+  [HapticSupport.STANDARD_SUPPORT]: 'standard',
+  [HapticSupport.ADVANCED_SUPPORT]: 'advanced',
+};
+
+// The level is fixed for the lifetime of the process, so probe the native module once.
+// `undefined` = not probed yet; `null` = probe failed / unknown value (advertise nothing).
+let cached: string | null | undefined;
+
+/**
+ * The haptics-support token to advertise, or `null` to advertise nothing. Never throws:
+ * a capability probe must not be able to break pairing, so a failed or unrecognised
+ * reading falls back to null — which the producer treats exactly like an older app that
+ * reports no level at all.
+ */
+export function localHapticsSupport(): string | null {
+  if (cached !== undefined) return cached;
+  try {
+    cached = TOKENS[Settings.getHapticsSupportLevel()] ?? null;
+  } catch {
+    cached = null;
+  }
+  return cached;
+}

--- a/PulsarApp/src/connections/useLiveSockets.ts
+++ b/PulsarApp/src/connections/useLiveSockets.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { SOCKET_SERVER_URL } from '@/constants/Connection';
 
 import { localDeviceName } from './deviceName';
+import { localHapticsSupport } from './hapticsSupport';
 import type { ConnectionStatus } from './types';
 
 const PING_INTERVAL_MS = 25_000;
@@ -60,10 +61,16 @@ export function useLiveSockets({ onStatus, onMessage, onFailed }: Callbacks) {
         kind === 'new'
           ? `type=receiver&action=new_connection&code=${encodeURIComponent(value)}`
           : `type=receiver&action=reuse_connection&token=${encodeURIComponent(value)}`;
-      // Advertise this phone's model so the producer can label it. It MUST go on both
-      // paths: the relay reads identity off the socket at notification time, so a
-      // reconnect that omitted it would silently drop the name on every restore.
-      const identity = `&name=${encodeURIComponent(localDeviceName())}`;
+      // Advertise this phone's model (so the producer can label it) and the level of
+      // haptics its hardware can render (so the producer can show what it will feel). Both
+      // MUST go on both paths: the relay reads identity off the socket at notification
+      // time, so a reconnect that omitted them would silently drop them on every restore.
+      // hapticsSupport is optional — a failed probe advertises nothing, exactly like an
+      // older app build, which the producer handles.
+      const support = localHapticsSupport();
+      const identity =
+        `&name=${encodeURIComponent(localDeviceName())}` +
+        (support ? `&hapticsSupport=${support}` : '');
       const socket = new WebSocket(`${SOCKET_SERVER_URL}?${query}${identity}`);
       const entry: LiveSocket = { socket, ping: null, timeout: null };
       live.current.set(id, entry);


### PR DESCRIPTION
## What

The phone now advertises **what level of haptics its hardware can render** when it pairs, so a designer tool (Pulsar Studio) can show whether a paired device will feel the full designed pattern or just a plain buzz.

This is the producer side of a three-part change — the phone already sends its model on the handshake; this adds the haptics-support level next to it.

## How

- New `src/connections/hapticsSupport.ts` reads `react-native-pulsar`'s `Settings.getHapticsSupportLevel()` and maps the `HapticSupport` enum to a short, stable, self-describing token: `none | limited | standard | advanced`. The probe is cached (the level is fixed for the process) and wrapped in try/catch.
- `src/connections/useLiveSockets.ts` appends `&hapticsSupport=<token>` to the identity string, alongside `&name=`. It rides both `new_connection` and `reuse_connection`, because the relay reads identity off the socket at notification time — so it must be re-sent on every reconnect (same rule the device name already follows).

## Safety / compatibility

- **Non-fatal:** a capability probe must never break pairing. A throw or an unrecognised value advertises nothing, which the producer treats exactly like an older app build that reports no level.
- **Additive:** the relay forwards the token verbatim; older producers ignore an unknown query param, and no other client changes.

## The other two parts (in `software-mansion-labs/pulsar-private`)

1. **server** — relays the phone's `hapticsSupport` to the paired sender (mirrors how `deviceName` is relayed).
2. **studio** — displays it as a pill on the device row (Full haptics / Amplitude only / Basic vibration / No haptics), using this exact `HapticSupport` scale.

## Verification

`tsc` reports no errors in the two changed files. (The repo has no jest setup, so no unit test was added; the pre-existing `Cannot find name 'global'` tsc noise is unrelated to this change.)
