### PR TITLE
feat(app): resolve backend tier from EXPO_PUBLIC_PULSAR_ENV

### DIFF
--- a/PulsarApp/.env.example
+++ b/PulsarApp/.env.example
@@ -1,0 +1,12 @@
+# PulsarApp build-time configuration. Copy the values you need into `.env`
+# (which is gitignored). `EXPO_PUBLIC_*` vars are inlined into the build.
+
+# Which Pulsar backend tier this build talks to: local | staging | production.
+# Unset → a dev (Metro) build targets local, a release build targets production.
+# Set it to point a dev build at a remote tier, e.g. staging:
+# EXPO_PUBLIC_PULSAR_ENV=staging
+
+# Sentry source-map upload (release builds only). See app.config.js.
+# SENTRY_ORG=
+# SENTRY_PROJECT=
+# SENTRY_AUTH_TOKEN=

--- a/PulsarApp/constants/Connection.ts
+++ b/PulsarApp/constants/Connection.ts
@@ -1,14 +1,12 @@
-export const API_SERVER_URL = 'https://pulsar-server.swmansion.com';
-// export const API_SERVER_URL = 'http://localhost:8080';
+// Backend hosts for the current tier (local | staging | production). The tier is
+// resolved once in constants/env.ts — set `EXPO_PUBLIC_PULSAR_ENV` in `.env` to
+// override, otherwise a dev build targets local and a release build targets
+// production. See constants/env.ts for the full host map and resolution rules.
 
-export const SOCKET_SERVER_URL = 'wss://pulsar-server.swmansion.com';
-// export const SOCKET_SERVER_URL = 'ws://localhost:8080';
+import { PULSAR_HOSTS } from '@/constants/env';
 
-export const FIGMA_PREVIEW_URL = 'https://docs.swmansion.com/pulsar/figma-preview/';
-// Local override for testing live haptics-config updates against a
-// listener-equipped preview before docs is redeployed: run
-// `cd pulsar-private/figma/preview && npm run dev` (serves :5173) and swap the line above for
-// the one below. iOS simulator reaches the host via localhost; a physical
-// device needs the machine's LAN IP instead.
-// export const FIGMA_PREVIEW_URL = 'http://localhost:5173/';
+export const API_SERVER_URL = PULSAR_HOSTS.api;
 
+export const SOCKET_SERVER_URL = PULSAR_HOSTS.socket;
+
+export const FIGMA_PREVIEW_URL = PULSAR_HOSTS.preview;

--- a/PulsarApp/constants/env.ts
+++ b/PulsarApp/constants/env.ts
@@ -1,0 +1,60 @@
+// Which Pulsar backend tier this build talks to, and the hosts for each tier.
+//
+// PulsarApp is an Expo/React Native app, so the tier is fixed at BUILD time.
+// Resolution:
+//   1. An explicit `EXPO_PUBLIC_PULSAR_ENV` (local | staging | production) wins —
+//      set it in `.env` to point a build at a specific tier (e.g. run a dev build
+//      against staging). Expo inlines `EXPO_PUBLIC_*` values at build time.
+//   2. Otherwise it follows the build mode: `__DEV__` → local, release → production.
+//      So a Metro dev build automatically targets your local server and a release
+//      build targets production, with no source edits.
+//
+// This mirrors Studio (`studio/src/env.ts`) and the Figma plugin
+// (`figma/src/ui/lib/env.ts`) in pulsar-private — the same `local | staging |
+// production` concept and host map, adapted to Expo. This is the one place the
+// mobile app's backend hosts live; before this they were hard-coded to production
+// in constants/Connection.ts with a commented-out localhost line you swapped by hand.
+
+export type PulsarEnv = 'local' | 'staging' | 'production';
+
+export interface PulsarHosts {
+  /** Relay/pairing HTTP API (create-channel, broadcast). */
+  api: string;
+  /** Relay/pairing WebSocket. */
+  socket: string;
+  /** Figma live-preview base URL (opened inside the app's WebView). */
+  preview: string;
+}
+
+const HOSTS: Record<PulsarEnv, PulsarHosts> = {
+  local: {
+    api: 'http://localhost:8080',
+    socket: 'ws://localhost:8080',
+    // iOS simulator reaches the host via localhost; a physical device needs the
+    // machine's LAN IP instead (swap localhost for it in your local `.env` build).
+    preview: 'http://localhost:5173/',
+  },
+  staging: {
+    api: 'https://pulsar-server.swmtest.xyz',
+    socket: 'wss://pulsar-server.swmtest.xyz',
+    preview: 'https://pulsar.swmtest.xyz/studio/figma-preview/',
+  },
+  production: {
+    api: 'https://pulsar-server.swmansion.com',
+    socket: 'wss://pulsar-server.swmansion.com',
+    // The live preview ships as a subpage of Studio (same origin), not on the docs
+    // site — mirrors the Figma plugin's `preview` host.
+    preview: 'https://pulsar.swmansion.com/studio/figma-preview/',
+  },
+};
+
+function resolveEnv(): PulsarEnv {
+  const explicit = process.env.EXPO_PUBLIC_PULSAR_ENV?.trim().toLowerCase();
+  if (explicit === 'local' || explicit === 'staging' || explicit === 'production') {
+    return explicit;
+  }
+  return __DEV__ ? 'local' : 'production';
+}
+
+export const PULSAR_ENV: PulsarEnv = resolveEnv();
+export const PULSAR_HOSTS: PulsarHosts = HOSTS[PULSAR_ENV];


### PR DESCRIPTION
## What

Adds a `local | staging | production` tier resolver to PulsarApp, mirroring how Studio and the Figma plugin already work (`pulsar-private/studio/src/env.ts`, `figma/src/ui/lib/env.ts`).

- **New `constants/env.ts`** — single host map (`api` / `socket` / `preview`) per tier. Resolved via `EXPO_PUBLIC_PULSAR_ENV` override, else `__DEV__ ? 'local' : 'production'` (Expo inlines `EXPO_PUBLIC_*` at build time).
- **`constants/Connection.ts`** — now re-exports `API_SERVER_URL` / `SOCKET_SERVER_URL` / `FIGMA_PREVIEW_URL` from the map instead of hardcoding prod with hand-swapped commented-out localhost lines. Call sites unchanged.
  - Side effect: `FIGMA_PREVIEW_URL` is now tier-aware, replacing the stale `docs.swmansion.com/pulsar/figma-preview/` with the Studio-hosted preview.
- **`.env.example`** — documents the switch (`.env` is gitignored / holds Sentry secrets).

Staging lives on `swmtest.xyz`; the matching server-side/Studio/Figma staging URLs land in a companion pulsar-private PR.

## How to use

In `.env`:
```
EXPO_PUBLIC_PULSAR_ENV=staging   # or local | production
```
Unset → dev build targets local, release build targets production (behavior unchanged).

## Testing

- `npx tsc --noEmit`: no new errors from the changed files.
- With `EXPO_PUBLIC_PULSAR_ENV=staging`, pairing WebSocket targets `wss://pulsar-server.swmtest.xyz` and the Figma preview loads from `pulsar.swmtest.xyz/studio/figma-preview/`.