### PR TITLE
fix(flutter): give the Android plugin its own namespace

### DIFF
--- a/flutter/pulsar/android/build.gradle.kts
+++ b/flutter/pulsar/android/build.gradle.kts
@@ -49,7 +49,7 @@ if (useLocalPulsarAndroid) {
 }
 
 android {
-    namespace = "com.swmansion.pulsar"
+    namespace = "com.swmansion.pulsar.flutter"
 
     compileSdk = 36
 
@@ -71,6 +71,7 @@ android {
             java.srcDirs("src/main/kotlin")
             if (useLocalPulsarAndroid) {
                 java.srcDir(localPulsarAndroidSourceDir)
+                java.srcDir("src/localPulsar/java")
             }
         }
         getByName("test") {

--- a/flutter/pulsar/android/src/localPulsar/java/com/swmansion/pulsar/BuildConfig.java
+++ b/flutter/pulsar/android/src/localPulsar/java/com/swmansion/pulsar/BuildConfig.java
@@ -1,0 +1,13 @@
+package com.swmansion.pulsar;
+
+// Shim. Only compiled when USE_LOCAL_PULSAR_ANDROID=1, where the borrowed
+// Android/Pulsar sources reference com.swmansion.pulsar.BuildConfig but this
+// module's namespace (com.swmansion.pulsar.flutter) means AGP generates the
+// real BuildConfig at a different package. Forwarding keeps DEBUG tracking
+// the actual build type. In published mode this file is excluded — the real
+// BuildConfig comes from the com.swmansion:pulsar Maven artifact.
+public final class BuildConfig {
+  public static final boolean DEBUG = com.swmansion.pulsar.flutter.BuildConfig.DEBUG;
+
+  private BuildConfig() {}
+}

--- a/flutter/pulsar/android/src/main/AndroidManifest.xml
+++ b/flutter/pulsar/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.swmansion.pulsar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
@@ -1,4 +1,4 @@
-package com.swmansion.pulsar
+package com.swmansion.pulsar.flutter
 
 import android.app.Activity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -8,6 +8,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import com.swmansion.pulsar.Pulsar
 import com.swmansion.pulsar.bundle.LoadedBundle
 import com.swmansion.pulsar.composers.PatternComposer
 import com.swmansion.pulsar.types.CompatibilityMode

--- a/flutter/pulsar/pubspec.yaml
+++ b/flutter/pulsar/pubspec.yaml
@@ -44,7 +44,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.swmansion.pulsar
+        package: com.swmansion.pulsar.flutter
         pluginClass: PulsarPlugin
       ios:
         pluginClass: PulsarPlugin


### PR DESCRIPTION
Fixes #216

## Problem

The Flutter plugin's Android module declared `namespace = "com.swmansion.pulsar"` — the exact namespace of the `com.swmansion:pulsar` artifact it depends on. AGP rejects that:

```
Namespace 'com.swmansion.pulsar' is used in multiple modules and/or libraries:
:pulsar_haptics, com.swmansion:pulsar:1.3.0. Please ensure that all modules and
libraries have a unique namespace.
```

AGP gates this behind `android.uniquePackageNames`. Older versions only warn, which is why the collision shipped unnoticed; newer ones (as bundled with recent Flutter stable — the reporter is on 3.47.0) make it an error, so `flutter build apk` fails outright for anyone adding `pulsar_haptics` to an app.

## Fix

Move the plugin to `com.swmansion.pulsar.flutter` — namespace, Kotlin package, and the pubspec `package:` entry together. The namespace is the part AGP validates; the source package moves with it so the plugin no longer shares a package with the SDK it depends on, matching the other bindings:

| Binding | namespace | source package |
|---|---|---|
| react-native-pulsar | `…pulsar.reactnative` | `…pulsar.reactnative` |
| kmp | `…pulsar.kmp` | `…pulsar.kmp` |
| flutter (this PR) | `…pulsar.flutter` | `…pulsar.flutter` |

Also:

- Add a `BuildConfig` shim under `src/localPulsar/java`, compiled only when `USE_LOCAL_PULSAR_ANDROID=1`, because the borrowed `Android/Pulsar` sources `import com.swmansion.pulsar.BuildConfig` while AGP now generates it at the `.flutter` package. It forwards to the module's real `BuildConfig`, so `DEBUG` keeps tracking the actual build type (`AudioSimulator` gates debug sound on it). Same approach as `react-native-pulsar`. Verified load-bearing: deleting it fails the local-sources build with `Unresolved reference 'BuildConfig'` in `AudioSimulator.kt`.
- Drop the deprecated `package` attribute from the plugin manifest — ignored since AGP 8, and stale once the namespace moves.

## Blast radius

The namespace governs only the generated `BuildConfig` and `R`. Neither the plugin nor `Android/Pulsar` declares any resources or references `R` at all (checked), and the single `BuildConfig` reference is the one the shim covers.

The class FQN change (`com.swmansion.pulsar.PulsarPlugin` → `com.swmansion.pulsar.flutter.PulsarPlugin`) is invisible to normal apps: `GeneratedPluginRegistrant` is regenerated from pubspec on every build, and I confirmed it emits the new FQN. It would affect a hand-written registrant or a `-keep class com.swmansion.pulsar.PulsarPlugin` rule; there are no such rules in this repo, and the installed base at 0.1.0 is small.

## Verification

Reproduced against the **published** `pulsar_haptics: 0.1.0` from pub.dev, following the issue's repro steps (fresh `flutter create` app + `flutter build apk`), with `android.uniquePackageNames=true` to match the reporter's AGP:

| Plugin source | debug | release |
|---|---|---|
| published 0.1.0, unmodified | ❌ the issue's error, verbatim | ❌ same error |
| Kotlin package moved, namespace left alone | ❌ identical error | — |
| namespace moved (this PR's shape) | ✅ builds | ✅ builds (clean) |

The middle row is worth noting: moving the package without the namespace changes nothing, since AGP compares `android.namespace` against resolved library namespaces and never looks at source packages. The namespace edit is what fixes the bug; the package move is for consistency with the other bindings.

Regression checks:

- `flutter/PulsarApp` with `USE_LOCAL_PULSAR_ANDROID=1` (what CI builds): clean debug **and** release APK. Verified the merged plugin manifest reads `com.swmansion.pulsar.flutter`, the local `Android/Pulsar` sources still compile, and — in bytecode — that the shim's `DEBUG` reads through to the module's generated `BuildConfig` rather than being hardcoded.
- `flutter/pulsar/example` with local sources: builds.
- Runtime on a Pixel 9 emulator, after the package move: app launches, the native capability query returns `advancedSupport` (so the registrant resolves the new FQN and the method channel reaches the plugin), and system impact / named preset / custom pattern / stop all execute — no `MissingPluginException`, empty crash buffer, vibrate op reaching the system vibrator service.
- Grepped the repo for stale references to the old FQN or `package: com.swmansion.pulsar`: none.
- The two pre-existing Dart test failures in `flutter/pulsar` (`pulsar_test.dart` analyzer error, and a `preloadPresets` expectation) also fail on unmodified `main` — untouched by this change, which is Android-side only.

## Considered and rejected

Setting `android.uniquePackageNames=true` in the example apps so CI would fail on a future collision rather than warn. It breaks `flutter/pulsar/example`: its `integration_test` dependency pulls `androidx.test.espresso:espresso-core:3.2.0`, which collides with `espresso-idling-resource:3.2.0` upstream — not something we can fix. It passes in `flutter/PulsarApp` today only because that app has no integration tests, so enabling it there alone would be a trap for whoever adds them. Dropped; the comment on the `namespace` line carries the reasoning instead.

## Not included

- `flutter/pulsar/android/src/test/.../PulsarPluginTest.kt` is dead `flutter create` scaffolding: it never imported `PulsarPlugin` and asserts on a `getPlatformVersion` method the plugin doesn't implement, so it cannot compile and has never run. Left as-is rather than expanding this PR — worth deleting separately.
- No CHANGELOG entry or version bump: the plugin version is tracked in `sdk-versions.json` via the sync tooling, and changelog entries land in separate release PRs.
