### PR TITLE
fix(flutter): Android namespace fix for the 0.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ pulsar.getPresets().play("Hammer")
 > **Note:** Published on pub.dev as **`pulsar_haptics`**, not `pulsar`. The shorter `pulsar` name was reserved by an unrelated author before this project was published and is not maintained by Software Mansion.
 
 <!-- GENERATED:FLUTTER_VERSION_START -->
-Latest available version: `0.1.0`
+Latest available version: `0.1.1`
 <!-- GENERATED:FLUTTER_VERSION_END -->
 
 Add Pulsar to your `pubspec.yaml`:
@@ -144,7 +144,7 @@ Add Pulsar to your `pubspec.yaml`:
 <!-- GENERATED:FLUTTER_INSTALL_SNIPPET_START -->
 ```yaml
 dependencies:
-  pulsar_haptics: ^0.1.0
+  pulsar_haptics: ^0.1.1
 ```
 <!-- GENERATED:FLUTTER_INSTALL_SNIPPET_END -->
 

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -58,7 +58,7 @@ The Pulsar Flutter SDK exposes the same building blocks as the native SDKs — `
 </Aside>
 
 {/* GENERATED:FLUTTER_VERSION_START */}
-Latest available version: `0.1.0`
+Latest available version: `0.1.1`
 {/* GENERATED:FLUTTER_VERSION_END */}
 
 Add Pulsar to your `pubspec.yaml`:
@@ -66,7 +66,7 @@ Add Pulsar to your `pubspec.yaml`:
 {/* GENERATED:FLUTTER_INSTALL_SNIPPET_START */}
 ```yaml
 dependencies:
-  pulsar_haptics: ^0.1.0
+  pulsar_haptics: ^0.1.1
 ```
 {/* GENERATED:FLUTTER_INSTALL_SNIPPET_END */}
 

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -14,7 +14,7 @@ This page covers concepts that apply across all Pulsar SDKs: types of haptics, p
 | Android | `com.swmansion:pulsar` (Maven) | `1.3.0` |
 | React Native | `react-native-pulsar` (npm) | `1.7.0` |
 | Kotlin Multiplatform | `com.swmansion:pulsar-kmp` (Maven) | `0.1.0` |
-| Flutter | `pulsar_haptics` (pub.dev) | `0.1.0` |
+| Flutter | `pulsar_haptics` (pub.dev) | `0.1.1` |
 | Web | `pulsar-haptics` (npm) | `0.2.0` |
 {/* GENERATED:SDK_OVERVIEW_VERSIONS_END */}
 

--- a/flutter/pulsar/CHANGELOG.md
+++ b/flutter/pulsar/CHANGELOG.md
@@ -11,3 +11,18 @@
 ## 0.0.3
 
 * Fix SwiftPM support for iOS platform.
+
+## 0.1.0
+
+* Rename the iOS podspec to `pulsar_haptics.podspec` so CocoaPods resolves the plugin under its pub package name.
+* Depend on the renamed `PulsarHaptics` CocoaPod, which builds under every CocoaPods linkage mode — including `use_frameworks!` with both `:static` and `:dynamic` linkage.
+* Declare the `pulsar-ios` Swift package dependency in the SPM manifest so the plugin builds with Flutter's Swift Package Manager support.
+* Bump the native cores to pulsar-ios `1.4.0` and pulsar-android `1.3.0`.
+
+  No Dart API changes — this release is packaging and native dependency work only.
+
+## 0.1.1
+
+* Fix the Android build failing with `Namespace 'com.swmansion.pulsar' is used in multiple modules and/or libraries`. The plugin shared its Android namespace with the `com.swmansion:pulsar` artifact it depends on, which newer Android Gradle Plugin versions reject; it now uses `com.swmansion.pulsar.flutter`.
+
+  No Dart API changes.

--- a/flutter/pulsar/README.md
+++ b/flutter/pulsar/README.md
@@ -18,13 +18,13 @@ A haptic feedback SDK for Flutter. Pulsar gives you 150+ ready-to-play presets, 
 > **Note:** This package is published as **`pulsar_haptics`**, not `pulsar`. The shorter `pulsar` name on pub.dev was reserved by an unrelated author before this project was published and is not maintained by Software Mansion. Always depend on `pulsar_haptics`.
 
 <!-- GENERATED:FLUTTER_VERSION_START -->
-Latest available version: `0.1.0`
+Latest available version: `0.1.1`
 <!-- GENERATED:FLUTTER_VERSION_END -->
 
 <!-- GENERATED:FLUTTER_INSTALL_SNIPPET_START -->
 ```yaml
 dependencies:
-  pulsar_haptics: ^0.1.0
+  pulsar_haptics: ^0.1.1
 ```
 <!-- GENERATED:FLUTTER_INSTALL_SNIPPET_END -->
 

--- a/flutter/pulsar/android/build.gradle.kts
+++ b/flutter/pulsar/android/build.gradle.kts
@@ -49,7 +49,7 @@ if (useLocalPulsarAndroid) {
 }
 
 android {
-    namespace = "com.swmansion.pulsar"
+    namespace = "com.swmansion.pulsar.flutter"
 
     compileSdk = 36
 
@@ -71,6 +71,7 @@ android {
             java.srcDirs("src/main/kotlin")
             if (useLocalPulsarAndroid) {
                 java.srcDir(localPulsarAndroidSourceDir)
+                java.srcDir("src/localPulsar/java")
             }
         }
         getByName("test") {

--- a/flutter/pulsar/android/src/localPulsar/java/com/swmansion/pulsar/BuildConfig.java
+++ b/flutter/pulsar/android/src/localPulsar/java/com/swmansion/pulsar/BuildConfig.java
@@ -1,0 +1,13 @@
+package com.swmansion.pulsar;
+
+// Shim. Only compiled when USE_LOCAL_PULSAR_ANDROID=1, where the borrowed
+// Android/Pulsar sources reference com.swmansion.pulsar.BuildConfig but this
+// module's namespace (com.swmansion.pulsar.flutter) means AGP generates the
+// real BuildConfig at a different package. Forwarding keeps DEBUG tracking
+// the actual build type. In published mode this file is excluded — the real
+// BuildConfig comes from the com.swmansion:pulsar Maven artifact.
+public final class BuildConfig {
+  public static final boolean DEBUG = com.swmansion.pulsar.flutter.BuildConfig.DEBUG;
+
+  private BuildConfig() {}
+}

--- a/flutter/pulsar/android/src/main/AndroidManifest.xml
+++ b/flutter/pulsar/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.swmansion.pulsar">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
@@ -1,4 +1,4 @@
-package com.swmansion.pulsar
+package com.swmansion.pulsar.flutter
 
 import android.app.Activity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -8,6 +8,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import com.swmansion.pulsar.Pulsar
 import com.swmansion.pulsar.composers.PatternComposer
 import com.swmansion.pulsar.types.CompatibilityMode
 import com.swmansion.pulsar.types.ConfigPoint

--- a/flutter/pulsar/ios/pulsar_haptics.podspec
+++ b/flutter/pulsar/ios/pulsar_haptics.podspec
@@ -9,7 +9,7 @@ pulsar_ios_pod_version = '1.4.0' # pulsar-sync:flutter-pulsar-ios
 
 Pod::Spec.new do |s|
   s.name             = 'pulsar_haptics'
-  s.version          = '0.1.0' # pulsar-sync:flutter-version
+  s.version          = '0.1.1' # pulsar-sync:flutter-version
   s.summary          = 'Rich haptic feedback for Flutter with presets, pattern playback, and realtime control.'
   s.description      = <<-DESC
 Pulsar gives you 150+ ready-to-play haptic presets, a pattern composer for fully custom

--- a/flutter/pulsar/pubspec.yaml
+++ b/flutter/pulsar/pubspec.yaml
@@ -44,7 +44,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.swmansion.pulsar
+        package: com.swmansion.pulsar.flutter
         pluginClass: PulsarPlugin
       ios:
         pluginClass: PulsarPlugin

--- a/flutter/pulsar/pubspec.yaml
+++ b/flutter/pulsar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pulsar_haptics
 description: Rich haptic feedback for Flutter with presets, pattern playback, and realtime control.
-version: 0.1.0 # pulsar-sync:flutter-version
+version: 0.1.1 # pulsar-sync:flutter-version
 homepage: https://github.com/software-mansion/pulsar
 repository: https://github.com/software-mansion/pulsar
 issue_tracker: https://github.com/software-mansion/pulsar/issues

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -23,7 +23,7 @@
     }
   },
   "flutter": {
-    "version": "0.1.0",
+    "version": "0.1.1",
     "packageName": "pulsar_haptics",
     "pulsarCore": {
       "iosPodVersion": "1.4.0",


### PR DESCRIPTION
Backport of #217 onto the 0.1.0 release line, so the Android namespace fix can ship as `pulsar_haptics` 0.1.1 without pulling in everything that has landed on `main` since the 0.1.0 tag.

Base branch `release/pulsar_haptics-flutter-0.1.x` is cut from the [`pulsar_haptics-flutter-0.1.0`](https://github.com/software-mansion/pulsar/releases/tag/pulsar_haptics-flutter-0.1.0) tag (`4bb77ed`), unmodified.

Fixes #216 on the release line — see #217 for the full problem analysis and main-line verification.

## Commits

**1. `fix(flutter): give the Android plugin its own namespace`** — cherry-pick of #217

The plugin's Android namespace was `com.swmansion.pulsar`, identical to the `com.swmansion:pulsar` artifact it depends on. Newer AGP versions reject that outright, so `flutter build apk` fails for anyone depending on `pulsar_haptics`. Moves namespace, Kotlin package, and the pubspec `package:` entry to `com.swmansion.pulsar.flutter`.

One conflict during the cherry-pick, resolved: `main` imports `com.swmansion.pulsar.bundle.LoadedBundle`, which does not exist on this line (the bundle APIs landed after the tag). Kept only the `import com.swmansion.pulsar.Pulsar` the move requires. The resulting diff against the tag is the same five files as #217.

**2. `chore(flutter): release 0.1.1`**

Bumps `sdk-versions.json` to 0.1.1 and propagates it through `scripts/sync-sdk-versions.mjs` (pubspec, podspec, READMEs, docs), plus the changelog entry.

It also carries over the **0.1.0 changelog entry**, which landed on `main` in #192 *after* this tag was cut and is therefore missing here — without it, pub.dev would render 0.1.1 as following 0.0.3.

## Verification

Verified in the configuration this release actually ships: a consumer app depending on this branch's plugin, resolving the published `com.swmansion:pulsar:1.3.0` artifact, with `android.uniquePackageNames=true` set to match the AGP behaviour the reporter hit.

- Debug APK: builds.
- Release APK (clean): builds.
- `GeneratedPluginRegistrant` emits `com.swmansion.pulsar.flutter.PulsarPlugin`, so registration resolves the moved class.
- `flutter pub publish --dry-run`: package validates, **0 warnings**.

Runtime behaviour was verified on a Pixel 9 emulator in #217 (plugin registers, capability query returns `advancedSupport`, impacts/presets/patterns/stop all fire with no exceptions). The plugin code is identical apart from the conflict resolution noted above.

## After merge

Tag `pulsar_haptics-flutter-0.1.1` on this branch — `publish-flutter-pub.yml` fires on that tag pattern and publishes from `flutter/pulsar`.

## Note

The `flutter/pulsar/example` app cannot be built with `android.uniquePackageNames=true` on this line either: its `integration_test` dependency pulls `androidx.test.espresso:espresso-core:3.2.0`, which collides with `espresso-idling-resource:3.2.0` upstream. That is unrelated to this fix and unfixable on our side — hence the verification above uses a standalone consumer app.
