### PR TITLE
feat(app): keep the screen awake on Home and the Figma preview

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -17,6 +17,7 @@ import Point from '@/components/Point';
 import FigmaLogo from '@/components/FigmaLogo';
 import ConnectionList from '@/components/home/ConnectionList';
 import NowPlayingToast from '@/components/NowPlayingToast';
+import { useKeepAwakeWhileFocused } from '@/hooks/useKeepAwakeWhileFocused';
 import { Margins } from '@/constants/theme';
 
 const defaultEdges = {
@@ -82,6 +83,11 @@ function FigmaPreviewWebView({ token }: { token: string }) {
 
   const webRef = useRef<WebView>(null);
   const playFromHost = usePlayPatternFromHost();
+
+  // Scoped to this component rather than FigmaScreen, so the lock is only held
+  // while a preview is actually open - not on the explainer with no token.
+  useKeepAwakeWhileFocused('figma-preview');
+
   const navigation = useNavigation();
   const router = useRouter();
   const { lastPreviewUpdate } = useConnections();

--- a/PulsarApp/app/(tabs)/index.tsx
+++ b/PulsarApp/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import HapticsSupportBanner from '@/components/home/HapticsSupportBanner';
 import NowPlayingToast from '@/components/NowPlayingToast';
 import { useConnections } from '@/contexts/ConnectionsContext';
 import { useMediaSession } from '@/contexts/MediaSessionContext';
+import { useKeepAwakeWhileFocused } from '@/hooks/useKeepAwakeWhileFocused';
 
 const logo = require('@/assets/images/logo.png');
 
@@ -23,6 +24,10 @@ export default function HomeScreen() {
   const { connections, addByCode, remove, reconnect } = useConnections();
   const { openConnection } = useMediaSession();
   const router = useRouter();
+
+  // Patterns are usually played from a paired Studio/plugin while the phone
+  // sits untouched on the desk - don't let it lock mid-session.
+  useKeepAwakeWhileFocused('home');
 
   const [connectingCode, setConnectingCode] = useState('');
   const [scannerOpen, setScannerOpen] = useState(false);

--- a/PulsarApp/hooks/useKeepAwakeWhileFocused.ts
+++ b/PulsarApp/hooks/useKeepAwakeWhileFocused.ts
@@ -1,0 +1,27 @@
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
+import { useIsFocused } from 'expo-router';
+import { useEffect } from 'react';
+
+// Keep the screen from auto-locking while the owning screen is focused.
+//
+// expo-keep-awake's own `useKeepAwake` is mount-scoped, which is wrong for tab
+// screens: the tabs stay mounted in the background, so the lock would survive
+// switching away. Gating on focus releases it as soon as the user leaves.
+//
+// Each call site passes its own `tag` - locks are reference-counted per tag, so
+// a shared tag would let one screen's cleanup release another screen's lock.
+export function useKeepAwakeWhileFocused(tag: string) {
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (!isFocused) return;
+
+    // Swallow failures: on an unsupported platform (web without the Wake Lock
+    // API) this is a no-op we don't want surfacing as an unhandled rejection.
+    activateKeepAwakeAsync(tag).catch(() => {});
+
+    return () => {
+      deactivateKeepAwake(tag).catch(() => {});
+    };
+  }, [isFocused, tag]);
+}

--- a/PulsarApp/package-lock.json
+++ b/PulsarApp/package-lock.json
@@ -23,6 +23,7 @@
         "expo-font": "~57.0.1",
         "expo-haptics": "~57.0.1",
         "expo-image": "~57.0.2",
+        "expo-keep-awake": "~57.0.1",
         "expo-linking": "~57.0.5",
         "expo-localization": "~57.0.1",
         "expo-router": "~57.0.11",
@@ -41,6 +42,7 @@
         "react-native-gesture-handler": "~2.32.0",
         "react-native-nano-icons": "^0.1.8",
         "react-native-pulsar": "file:../react-native/react-native-pulsar",
+        "react-native-pulsar-lottie": "file:../react-native/PulsarLottie",
         "react-native-reanimated": "4.5.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "~4.26.0",
@@ -57,9 +59,38 @@
         "typescript": "~6.0.3"
       }
     },
+    "../react-native/PulsarLottie": {
+      "name": "react-native-pulsar-lottie",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^19.1.0",
+        "del-cli": "^6.0.0",
+        "lottie-react-native": "~7.3.8",
+        "prettier": "^3.6.2",
+        "react": "19.1.0",
+        "react-native": "0.81.1",
+        "react-native-builder-bob": "^0.40.13",
+        "react-native-pulsar": "^1.6.1",
+        "react-native-reanimated": "^4.0.0",
+        "react-native-worklets": "*",
+        "typescript": "^5.9.2"
+      },
+      "peerDependencies": {
+        "lottie-react-native": ">=7.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-pulsar": ">=1.6.0",
+        "react-native-reanimated": ">=4.0.0",
+        "react-native-worklets": "*"
+      }
+    },
     "../react-native/react-native-pulsar": {
       "version": "1.7.0",
       "license": "MIT",
+      "bin": {
+        "pulsar-gen-rn": "scripts/pulsar-gen-rn.mjs"
+      },
       "devDependencies": {
         "@commitlint/config-conventional": "^19.8.1",
         "@eslint/compat": "^1.3.2",
@@ -12041,6 +12072,10 @@
     },
     "node_modules/react-native-pulsar": {
       "resolved": "../react-native/react-native-pulsar",
+      "link": true
+    },
+    "node_modules/react-native-pulsar-lottie": {
+      "resolved": "../react-native/PulsarLottie",
       "link": true
     },
     "node_modules/react-native-reanimated": {

--- a/PulsarApp/package.json
+++ b/PulsarApp/package.json
@@ -28,6 +28,7 @@
     "expo-font": "~57.0.1",
     "expo-haptics": "~57.0.1",
     "expo-image": "~57.0.2",
+    "expo-keep-awake": "~57.0.1",
     "expo-linking": "~57.0.5",
     "expo-localization": "~57.0.1",
     "expo-router": "~57.0.11",


### PR DESCRIPTION
## What

Prevents the phone from auto-locking while the **Home** tab or the **Figma live preview** is focused.

Adds `PulsarApp/hooks/useKeepAwakeWhileFocused.ts`, a thin wrapper around `expo-keep-awake`:

```ts
export function useKeepAwakeWhileFocused(tag: string) {
  const isFocused = useIsFocused();

  useEffect(() => {
    if (!isFocused) return;
    activateKeepAwakeAsync(tag).catch(() => {});
    return () => {
      deactivateKeepAwake(tag).catch(() => {});
    };
  }, [isFocused, tag]);
}
```

Call sites:
- `app/(tabs)/index.tsx` → `useKeepAwakeWhileFocused('home')`
- `app/(tabs)/figma.tsx` → `useKeepAwakeWhileFocused('figma-preview')`

## Why

Both screens are typically watched hands-off — the phone sits on the desk while patterns are played from a paired Studio or the Figma plugin — so the idle timer would lock the device mid-session.

## Notes for the reviewer

- **Focus-gated, not mount-gated.** `expo-keep-awake`'s own `useKeepAwake` is mount-scoped, which is wrong here: Expo Router keeps tab screens mounted in the background, so the lock would survive switching to another tab. The hook follows the `useIsFocused` pattern already used by `hooks/useHapticsScreenActivity.ts`.
- **Distinct tags per call site.** Locks are reference-counted per tag; a shared tag would let one screen's cleanup release the other's lock.
- **Placement on the Figma tab.** The hook sits in `FigmaPreviewWebView`, not `FigmaScreen`, so the lock is only held while a preview is actually open — the explainer state (no token) still lets the phone sleep.
- **No native rebuild needed.** `expo-keep-awake` was already installed and autolinked as a dependency of the `expo` package (`ExpoKeepAwake (57.0.1)` is in `ios/Podfile.lock`). It is now declared explicitly in `package.json` since we import it directly.
- **Unrelated lockfile churn.** Refreshing `package-lock.json` also reconciled pre-existing drift — the `react-native-pulsar-lottie` link entry and a `pulsar-gen-rn` bin entry were missing from it. Happy to strip those back out if you'd rather keep the diff minimal.
- This only defeats the auto-lock timer; a manual power-button press still locks the device, and iOS may ignore it under low-power conditions.

## Testing

⚠️ **Not compiled or run.** The changes were made in a worktree without `node_modules`, so there was no way to type-check or launch the app. The individual pieces were verified against the installed packages (`activateKeepAwakeAsync` / `deactivateKeepAwake` in `expo-keep-awake`'s `.d.ts`, `useIsFocused` exported from `expo-router`, the `@/*` tsconfig alias), but the change itself is unexercised — worth a manual pass before merge:

- [ ] Home tab stays lit past the auto-lock interval
- [ ] Open a Figma preview → stays lit; close it (clear the token) → locks normally
- [ ] Switch from Home to another tab → locks normally