### PR TITLE
feat(docs): conditionally load GTM scripts based on production enviroment

### DIFF
--- a/docs/src/components/gtm-body.astro
+++ b/docs/src/components/gtm-body.astro
@@ -1,12 +1,17 @@
 ---
 import { GTM_CONFIG } from '../../config';
+const isProduction = import.meta.env.PROD;
 ---
 
-<noscript>
-  <iframe
-    src={`https://www.googletagmanager.com/ns.html?id=${GTM_CONFIG.id}`}
-    height="0"
-    width="0"
-    style="display:none;visibility:hidden"
-  ></iframe>
-</noscript>
+{
+  isProduction && (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${GTM_CONFIG.id}`}
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+      ></iframe>
+    </noscript>
+  )
+}

--- a/docs/src/components/gtm-head.astro
+++ b/docs/src/components/gtm-head.astro
@@ -1,16 +1,21 @@
 ---
 import { GTM_CONFIG } from '../../config';
+const isProduction = import.meta.env.PROD;
 ---
 
-<script is:inline define:vars={{ gtmId: GTM_CONFIG.id }}>
-  (function (w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != 'dataLayer' ? '&l=' + l : '';
-    j.async = true;
-    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, 'script', 'dataLayer', gtmId);
-</script>
+{
+  isProduction && (
+    <script is:inline define:vars={{ gtmId: GTM_CONFIG.id }}>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', gtmId);
+    </script>
+  )
+}


### PR DESCRIPTION
## What

Load gtm only in production builds.

## Why

GTM should not run in local dev or preview. This keeps analytics clean and avoids noise from non-prod traffic.

## Changes

- gate `docs/src/components/gtm-head.astro` with `import.meta.env.PROD`
- gate `docs/src/components/gtm-body.astro` with `import.meta.env.PROD`

## Verification

- Confirmed gtm snippets render only when `import.meta.env.PROD` is true
- Checked edited files for lint issues