### PR TITLE
feat(docs): add copyright notice and privacy policy

### DIFF
--- a/docs/src/components/PageFrame.astro
+++ b/docs/src/components/PageFrame.astro
@@ -1,6 +1,7 @@
 ---
 import Default from '@astrojs/starlight/components/PageFrame.astro';
 import GTMBody from './gtm-body.astro';
+const currentYear = new Date().getFullYear();
 ---
 
 <GTMBody />
@@ -9,3 +10,35 @@ import GTMBody from './gtm-body.astro';
   <slot name="sidebar" slot="sidebar" />
   <slot />
 </Default>
+
+<footer class="docs-footer">
+  <p>
+    &copy; {currentYear}
+    <a href="https://swmansion.com/" target="_blank" rel="noopener">Software Mansion</a>.
+    Read about our
+    <a href="https://swmansion.com/privacy/policy/" target="_blank" rel="noopener"
+      >Privacy Policy</a
+    >.
+  </p>
+</footer>
+
+<style>
+  .docs-footer {
+    border-top: 1px solid var(--sl-color-gray-5);
+    padding: 1.25rem 1rem 2rem;
+    text-align: center;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--sl-color-gray-2);
+  }
+
+  .docs-footer p {
+    margin: 0 auto;
+    max-width: 48rem;
+  }
+
+  .docs-footer a {
+    color: inherit;
+    text-underline-offset: 2px;
+  }
+ </style>

--- a/docs/src/components/landing/SwmSection/SwmSection.module.scss
+++ b/docs/src/components/landing/SwmSection/SwmSection.module.scss
@@ -7,7 +7,7 @@
   background-size: 85%;
   text-align: center;
   padding-top: 75px;
-  padding-bottom: 125px;
+  padding-bottom: 100px;
   width: 100%;
   box-sizing: border-box;
 
@@ -80,6 +80,43 @@
         max-width: 100%;
       }
     }
+  }
+
+  .footer {
+    margin-top: 75px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    font-size: 14px;
+    line-height: 20px;
+    color: var(--color-blue-100);
+
+    @media (max-width: 768px) {
+      flex-wrap: wrap;
+      text-align: center;
+      gap: 8px;
+    }
+  }
+
+  .footerLogo {
+    width: auto;
+    height: 34px;
+    flex-shrink: 0;
+  }
+
+  .footerText {
+    margin: 0;
+  }
+
+  .footerText a {
+    color: inherit;
+    text-decoration: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .footerText a:hover {
+    opacity: 0.8;
   }
 }
 

--- a/docs/src/components/landing/SwmSection/SwmSection.tsx
+++ b/docs/src/components/landing/SwmSection/SwmSection.tsx
@@ -1,5 +1,4 @@
 import styles from './SwmSection.module.scss';
-import commonStyle from '../common.module.scss';
 import { BasicLayout } from '../Layouts/BasicLayout';
 import { SectionHeader } from '../SectionHeader/SectionHeader';
 import { Button } from '../Button/Button';
@@ -8,6 +7,8 @@ import swm_logo from '../../../assets/swm-logo.svg';
 import arrow from '../../../assets/landing-page/footer_arrow.svg';
 
 export function SwmSection({ className }: { className?: string }) {
+  const currentYear = new Date().getFullYear();
+
   return (
     <div className={`${styles.section} ${className || ''}`}>
       <img className={styles.logo} src={swm_logo.src} />
@@ -30,6 +31,21 @@ export function SwmSection({ className }: { className?: string }) {
             <Button label="Learn more about us" url="https://swmansion.com/" />
           </div>
         </Card>
+      </BasicLayout>
+      <BasicLayout>
+        <div className={styles.footer}>
+          <p className={styles.footerText}>
+            &copy; {currentYear}{' '}
+            <a href="https://swmansion.com/" target="_blank" rel="noopener">
+              Software Mansion
+            </a>
+            . Read about our{' '}
+            <a href="https://swmansion.com/privacy/policy/ " target="_blank" rel="noopener">
+              Privacy Policy
+            </a>
+            .
+          </p>
+        </div>
       </BasicLayout>
     </div>
   );


### PR DESCRIPTION
## Summary

Add to landing page footer copyright notice and privacy policy link.

## Screenshots

<img width="983" height="595" alt="Screenshot 2026-08-18 at 13 57 29" src="https://github.com/user-attachments/assets/e957bcc3-e6c4-46cb-b0c3-d5f2de8857e4" />

<img width="1194" height="595" alt="Screenshot 2026-08-18 at 13 50 42" src="https://github.com/user-attachments/assets/2bdb57f4-098c-44eb-843a-af8fc1e86306" />
