### PR TITLE
Add JSON-LD and llms.txt for AI search

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,6 +47,19 @@ jobs:
         working-directory: docs
         run: npm run build
 
+      - name: Check docs llms.txt
+        run: |
+          file=docs/dist/llms.txt
+          if [ ! -s "$file" ]; then
+            echo "::error::$file is missing or empty"
+            exit 1
+          fi
+          count=$(grep -cE '^- \[[^]]+\]\(https://docs\.swmansion\.com/pulsar/[^)]+\)' "$file" || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::$file lists no pages"
+            exit 1
+          fi
+          echo "llms.txt lists $count pages"
       - name: Configure Pages
         uses: actions/configure-pages@v5
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import swmGeo, { structuredData } from './swm-geo.mjs';
 import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
@@ -29,6 +30,7 @@ export default defineConfig({
     },
   },
   integrations: [
+    swmGeo({ name: 'Pulsar', description: 'Haptic feedback library for Swift, Kotlin and React Native', repository: 'pulsar' }),
     starlight({
       title: 'Pulsar',
       customCss: [
@@ -42,6 +44,7 @@ export default defineConfig({
       // declarations and are then ignored by the browser (falling back to a
       // system font). A head <link> is order-independent and always applies.
       head: [
+        { tag: 'script', attrs: { type: 'application/ld+json' }, content: JSON.stringify(structuredData({ name: 'Pulsar', description: 'Haptic feedback library for Swift, Kotlin and React Native', repository: 'pulsar' })) },
         { tag: 'link', attrs: { rel: 'preconnect', href: 'https://fonts.googleapis.com' } },
         {
           tag: 'link',

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://docs.swmansion.com/pulsar/sitemap-index.xml

--- a/docs/swm-geo.mjs
+++ b/docs/swm-geo.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ORGANIZATION_ID = "https://swmansion.com/#organization";
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const decode = (value) =>
+  value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+export function structuredData({ description, name, repository }) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": ORGANIZATION_ID,
+        name: "Software Mansion",
+        url: "https://swmansion.com",
+        sameAs: [
+          "https://github.com/software-mansion",
+          "https://www.linkedin.com/company/software-mansion/",
+          "https://twitter.com/swmansion",
+          "https://www.youtube.com/c/SoftwareMansion",
+        ],
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        name,
+        ...(description ? { description } : {}),
+        ...(repository
+          ? { codeRepository: `https://github.com/software-mansion/${repository}` }
+          : {}),
+        author: { "@id": ORGANIZATION_ID },
+        maintainer: { "@id": ORGANIZATION_ID },
+      },
+    ],
+  };
+}
+
+function collect(dir, root = dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, root, found);
+    else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+      found.push(path.relative(root, full));
+  }
+  return found;
+}
+
+export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
+  const entries = [];
+
+  for (const file of files) {
+    const html = readFile(file);
+    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+    const title = decode(raw).replace(
+      new RegExp(`\\s*[|·]\\s*${escapeRegExp(name)}$`),
+      "",
+    );
+    if (!title) continue;
+
+    const detail = decode(
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? "",
+    );
+    const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
+    entries.push(`- [${title}](${prefix}${route})${detail ? `: ${detail}` : ""}`);
+  }
+
+  const lines = [`# ${name}`];
+  if (description) lines.push("", `> ${description}`);
+  if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+  lines.push(
+    "",
+    "## About",
+    "",
+    `- [Software Mansion](https://swmansion.com): maintainer of ${name}`,
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+export default function swmGeo({ description, name, repository } = {}) {
+  let site = "https://docs.swmansion.com";
+  let base = "/";
+
+  return {
+    name: "swm-geo",
+    hooks: {
+      "astro:config:done": ({ config }) => {
+        if (config.site) site = String(config.site).replace(/\/$/, "");
+        base = `/${String(config.base ?? "/").replace(/^\/|\/$/g, "")}/`.replace("//", "/");
+      },
+      "astro:build:done": ({ dir }) => {
+        const outDir = fileURLToPath(dir);
+        fs.writeFileSync(
+          path.join(outDir, "llms.txt"),
+          buildLlmsTxt({
+            description,
+            files: collect(outDir),
+            name,
+            prefix: `${site}${base}`,
+            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+          }),
+          "utf8",
+        );
+      },
+    },
+  };
+}

--- a/docs/swm-geo.mjs
+++ b/docs/swm-geo.mjs
@@ -94,7 +94,7 @@ export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
   return lines.join("\n");
 }
 
-export default function swmGeo({ description, name, repository } = {}) {
+export default function swmGeo({ description, name } = {}) {
   let site = "https://docs.swmansion.com";
   let base = "/";
 

--- a/docs/swm-geo.mjs
+++ b/docs/swm-geo.mjs
@@ -37,7 +37,9 @@ export function structuredData({ description, name, repository }) {
         name,
         ...(description ? { description } : {}),
         ...(repository
-          ? { codeRepository: `https://github.com/software-mansion/${repository}` }
+          ? {
+              codeRepository: `https://github.com/software-mansion/${repository}`,
+            }
           : {}),
         author: { "@id": ORGANIZATION_ID },
         maintainer: { "@id": ORGANIZATION_ID },
@@ -69,10 +71,13 @@ export function buildLlmsTxt({ description, files, name, prefix, readFile }) {
     if (!title) continue;
 
     const detail = decode(
-      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? "",
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ??
+        "",
     );
     const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
-    entries.push(`- [${title}](${prefix}${route})${detail ? `: ${detail}` : ""}`);
+    entries.push(
+      `- [${title}](${prefix}${route})${detail ? `: ${detail}` : ""}`,
+    );
   }
 
   const lines = [`# ${name}`];
@@ -98,7 +103,11 @@ export default function swmGeo({ description, name, repository } = {}) {
     hooks: {
       "astro:config:done": ({ config }) => {
         if (config.site) site = String(config.site).replace(/\/$/, "");
-        base = `/${String(config.base ?? "/").replace(/^\/|\/$/g, "")}/`.replace("//", "/");
+        base =
+          `/${String(config.base ?? "/").replace(/^\/|\/$/g, "")}/`.replace(
+            "//",
+            "/",
+          );
       },
       "astro:build:done": ({ dir }) => {
         const outDir = fileURLToPath(dir);
@@ -109,7 +118,8 @@ export default function swmGeo({ description, name, repository } = {}) {
             files: collect(outDir),
             name,
             prefix: `${site}${base}`,
-            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+            readFile: (file) =>
+              fs.readFileSync(path.join(outDir, file), "utf8"),
           }),
           "utf8",
         );


### PR DESCRIPTION
Two SEO changes for the docs site. Nothing changes the rendered page.

- **JSON-LD**: `Organization` with the same `@id` as swmansion.com, plus `SoftwareSourceCode`. The identical `@id` is what makes engines read this site and swmansion.com as one entity instead of two unrelated ones.
- **`llms.txt`**, written by an Astro integration on `astro:build:done` — no new dependency. The workflow fails if the file is missing or lists nothing.

Both come from `swm-geo.mjs` next to the Astro config. The same change is going out across the docs repos; reference: software-mansion/react-native-reanimated#10332.

**Check:** the deploy workflow does not run on pull requests, so the new step could not run here. It sits before the publish step, so a broken `llms.txt` blocks the deploy rather than shipping silently. The equivalent step is green in the Docusaurus repos, listing 25 to 90 pages.