### PR TITLE
docs: add web haptics article and a "Good to read" page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -106,6 +106,7 @@ export default defineConfig({
           label: 'Articles',
           items: [
             { label: 'Overview', slug: 'articles' },
+            { label: 'Good to read', slug: 'articles/good-to-read' },
             ...articles.map((article) => ({
               label: article.shortTitle,
               link: article.url,

--- a/docs/src/content/docs/articles/good-to-read.mdx
+++ b/docs/src/content/docs/articles/good-to-read.mdx
@@ -1,0 +1,34 @@
+---
+title: Good to read
+description: A curated list of talks, platform guidelines, and other external resources that explain haptics well.
+pagination: false
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Haptics is a small field with a lot of scattered knowledge. These are external
+resources we keep coming back to — worth your time if you want to understand how
+haptics work and how each platform expects you to use them.
+
+## Talks
+
+<LinkCard
+  title="Haptics: Untapped Potential — Kacper Kapuściak, Chain React 2026"
+  href="https://www.youtube.com/watch?v=GYQ85O7H_PQ"
+  description="A tour of how haptics work under the hood and what it takes to make an ordinary mobile interaction something users can actually feel."
+/>
+
+## Platform guidelines
+
+<CardGrid>
+  <LinkCard
+    title="Playing haptics — Apple Human Interface Guidelines"
+    href="https://developer.apple.com/design/human-interface-guidelines/playing-haptics"
+    description="Apple's design guidance on when haptics help, the standard iOS feedback patterns, and how to keep custom haptics consistent with the system."
+  />
+  <LinkCard
+    title="Implement haptics on Android — Android Developers"
+    href="https://developer.android.com/develop/ui/views/haptics"
+    description="How Android's vibration actuators, primitives, and constants work, plus how to design rich feedback that degrades gracefully across devices."
+  />
+</CardGrid>

--- a/docs/src/content/docs/articles/index.mdx
+++ b/docs/src/content/docs/articles/index.mdx
@@ -5,7 +5,11 @@ pagination: false
 ---
 
 import { ArticlesGrid } from '../../../components/landing/Articles/Articles';
+import { BASE_PATH } from '../../../../config';
 
 These articles go deeper into the fundamentals of haptics and how to design tactile experiences that feel intentional in real products.
 
 <ArticlesGrid />
+
+Looking for more? <a href={`${BASE_PATH}/articles/good-to-read/`}>Good to read</a> collects talks and
+platform guidelines from outside Software Mansion that explain haptics well.

--- a/docs/src/data/articles.ts
+++ b/docs/src/data/articles.ts
@@ -10,6 +10,15 @@ export type Article = {
 
 export const articles: Article[] = [
   {
+    title: 'Haptic Feedback on the Web: Why the Web Deliberately Refuses to Be as Tactile as Native Apps?',
+    shortTitle: 'Haptic Feedback on the Web',
+    url: 'https://swmansion.com/blog/haptic-feedback-on-the-web-why-the-web-deliberately-refuses-to-be-as-tactile-as-native-apps/',
+    source: 'Software Mansion Blog',
+    publishedAt: 'Aug 18, 2026',
+    imageUrl: 'https://strapi-production-5f3f.up.railway.app/uploads/BLOGPOST_Web_Haptics_5b56b0e1bf.png',
+    imageAlt: 'Banner for the article Haptic Feedback on the Web',
+  },
+  {
     title: 'What Is the Difference Between iOS and Android Haptics',
     shortTitle: 'iOS vs Android Haptics',
     url: 'https://swmansion.com/blog/what-is-the-difference-between-i-os-and-android-haptics/',


### PR DESCRIPTION
## What

Two docs additions:

**1. New article entry** — [Haptic Feedback on the Web: Why the Web Deliberately Refuses to Be as Tactile as Native Apps?](https://swmansion.com/blog/haptic-feedback-on-the-web-why-the-web-deliberately-refuses-to-be-as-tactile-as-native-apps/) added to `src/data/articles.ts`. It's the newest post (Aug 18, 2026), so it goes first — which puts it at the top of the articles grid (docs + landing page) and first in the sidebar's Articles group.

**2. New "Good to read" page** (`/pulsar/articles/good-to-read/`) collecting external resources that explain haptics well:

- **Talks** — [Haptics: Untapped Potential — Kacper Kapuściak, Chain React 2026](https://www.youtube.com/watch?v=GYQ85O7H_PQ)
- **Platform guidelines** — [Playing haptics (Apple HIG)](https://developer.apple.com/design/human-interface-guidelines/playing-haptics) and [Implement haptics on Android](https://developer.android.com/develop/ui/views/haptics)

The page is registered in the sidebar under Articles → Good to read, and linked from the Articles overview page.

## Notes

- Built with Starlight's `LinkCard` / `CardGrid`, matching `getting-started.mdx`.
- Article title, publish date, and banner image were taken from the post's own OG metadata.
- The overview-page link uses `BASE_PATH` rather than a hardcoded `/pulsar` prefix.

## Testing

- `npm run build` in `docs/` passes; all 3 resource links and the new article entry are present in the built HTML.
- Verified both pages in a browser (sidebar entry, card rendering, banner image loads, overview → Good to read link resolves).