### PR TITLE
feat(docs): add Candy Cascade, a haptics-driven match-3, to the web app Games tab

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -20,13 +20,16 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "sharp": "^0.34.2"
+        "sharp": "^0.34.2",
+        "typegpu": "^0.12.3"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.1.0",
+        "@webgpu/types": "^0.1.72",
         "prettier": "^3.8.1",
         "sass-embedded": "^1.97.3",
         "typed-css-modules": "^0.9.1",
+        "unplugin-typegpu": "^0.12.2",
         "vite": "^6.4.1"
       }
     },
@@ -2610,6 +2613,13 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.72.tgz",
+      "integrity": "sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2759,6 +2769,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ast-kit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+      "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/astring": {
@@ -5258,9 +5285,9 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6725,6 +6752,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6732,9 +6766,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8186,6 +8220,28 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinyest": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyest/-/tinyest-0.3.2.tgz",
+      "integrity": "sha512-1wqSt97RLezWzeogLSVXHr+E3jpYO8jxyaK2AIdJeGoZZTCubwNxQ9IqU5gbQpJVcxlbPugPAsII+m9/gqpPSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/tinyest-for-wgsl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tinyest-for-wgsl/-/tinyest-for-wgsl-0.4.0.tgz",
+      "integrity": "sha512-3vkeNf74HrJ1C6QJUiL92ArsaigD8ra52JBMTeyDfqEz6SawyCO1aiF+XCKiMt3MBaL5QIsKOHG5gl/v21MqKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyest": "~0.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -8273,6 +8329,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsover-runtime": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/tsover-runtime/-/tsover-runtime-0.0.7.tgz",
+      "integrity": "sha512-FHHwMJzZbnP23+fU1PxXljy7j0RRRosL2r1/CRUNTqfW+l7m35JsUkM615x/cAzw4GqRdXPIl3axKMj9qzpZtQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/twoslash": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.2.12.tgz",
@@ -8303,6 +8365,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typed-binary": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/typed-binary/-/typed-binary-4.3.3.tgz",
+      "integrity": "sha512-W2hLsSzt3k/tg38gDE4Fn/QiwcoqGuUHBc2cb3mXuH7KcYxe/GM57vzW14s2/bawB4R5knGgGq8Xb57vsaJ4Sg==",
+      "license": "MIT"
     },
     "node_modules/typed-css-modules": {
       "version": "0.9.1",
@@ -8440,6 +8508,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/typegpu": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/typegpu/-/typegpu-0.12.3.tgz",
+      "integrity": "sha512-zYwQEhnPPwhq5vQKmollXRK1LCVjStOnL+2B0PiebqvAzYPr25rPNR4r3olLoow5sKKjyj3kzHKEcpD5SyDzGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyest": "~0.3.2",
+        "tsover-runtime": "^0.0.7",
+        "typed-binary": "^4.3.3"
+      },
+      "bin": {
+        "typegpu": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/typescript": {
@@ -8664,6 +8749,84 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-typegpu": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/unplugin-typegpu/-/unplugin-typegpu-0.12.2.tgz",
+      "integrity": "sha512-qwDybuJ4CVsDQs9BPoBVgNWdwSlPgT0HcCMDXKYcCYN+IJCJD9/s0QyEuGfnuJ+Ng30tEoRK+s4SIdCHpu1hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "ast-kit": "^2.2.0",
+        "defu": "^6.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4",
+        "tinyest": "~0.3.2",
+        "tinyest-for-wgsl": "~0.4.0",
+        "unplugin": "^3.0.0"
+      },
+      "peerDependencies": {
+        "typegpu": "^0.12.1"
       }
     },
     "node_modules/unstorage": {
@@ -8955,6 +9118,13 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,13 +28,16 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "typegpu": "^0.12.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.1.0",
+    "@webgpu/types": "^0.1.72",
     "prettier": "^3.8.1",
     "sass-embedded": "^1.97.3",
     "typed-css-modules": "^0.9.1",
+    "unplugin-typegpu": "^0.12.2",
     "vite": "^6.4.1"
   }
 }

--- a/docs/vite.web-app.config.ts
+++ b/docs/vite.web-app.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import typegpu from 'unplugin-typegpu/vite';
 import { BASE_PATH } from './config.ts';
 
 /**
@@ -14,7 +15,10 @@ import { BASE_PATH } from './config.ts';
 export default defineConfig({
   root: 'web-app',
   base: `${BASE_PATH}/web-app/`,
-  plugins: [react()],
+  // `typegpu()` compiles the game's `'use gpu'` particle shaders to WGSL at
+  // build time. Without it TypeGPU has no AST for those function bodies and
+  // throws "Missing metadata for tgpu.fn function body" at runtime.
+  plugins: [react(), typegpu()],
   server: {
     fs: {
       // Presets (JSON + waveform PNGs) live in the Astro asset tree and are

--- a/docs/web-app/README.md
+++ b/docs/web-app/README.md
@@ -2,8 +2,8 @@
 
 A web clone of the Pulsar mobile app (`/PulsarApp`), shipped alongside the docs
 at **/pulsar/web-app/**. It mirrors four of the app's screens — Presets,
-Playground, Demos and Games (a placeholder for now) — and drives them all with
-the real [`pulsar-haptics`](../../web/Pulsar) web SDK.
+Playground, Demos and Games — and drives them all with the real
+[`pulsar-haptics`](../../web/Pulsar) web SDK.
 
 ## Why it is a separate bundle
 
@@ -44,3 +44,84 @@ Web haptics only exist behind the Vibration API, which desktop browsers and iOS
 Safari do not expose. On those, `Preset` renders each pattern to audio instead,
 so the rhythm is still perceivable — the app surfaces that as an "audio
 fallback" toggle. Android Chrome gets the real thing.
+
+## Games
+
+`src/screens/games/` holds playable demos. Add one by appending to the `GAMES`
+array in `screens/games/index.tsx`; routing, the list screen and the back button
+follow from there.
+
+### Candy Cascade (`screens/games/candy/`)
+
+A match-3 built to show haptics doing real work — every match, drop, special and
+combo is a distinct Pulsar pattern.
+
+A line of three is only the _trigger_: `sweepConnected` then flood-fills the
+whole touching blob of that colour, so an L with a stray tail clears as one
+lump instead of leaving orphans. Only the cleared set grows — which special a
+match earns is still measured on the straight runs, so a sprawling blob cannot
+accidentally mint a colour bomb.
+
+| File               | Role                                                                    |
+| ------------------ | ----------------------------------------------------------------------- |
+| `engine.ts`        | Pure rules: matching, specials, cascades, gravity. No React, no DOM.    |
+| `haptics.ts`       | The haptic vocabulary, plus the priority arbiter described below.       |
+| `audio.ts`         | Procedural Web Audio synth — every sound is generated, no samples.      |
+| `effects.ts`       | Binds haptic + sound + particles together, one function per game event. |
+| `particles/`       | TypeGPU/WebGPU particle field, with a Canvas 2D fallback.               |
+| `CandyCascade.tsx` | Playback only: walks the steps the engine returned and fires effects.   |
+
+Three decisions are worth knowing before changing anything here.
+
+**Resolution happens before animation.** `resolveMove` plays a whole move out —
+every cascade, every chain reaction — and returns an ordered list of steps. The
+component then animates them. That is what lets the celebration know a chain is
+five deep _before_ the first candy pops, so the finale can be scheduled instead
+of discovered.
+
+**Haptics are arbitrated, not queued.** The Web Vibration API has one global
+timeline: starting a pattern cancels whatever was playing. A cascade fires a
+dozen events per second, so `playHaptic` takes a priority and refuses to let a
+tile-landing tick interrupt a combo finale.
+
+**Banners are typed, not uniform.** `BannerKind` (`bonus` / `cascade` /
+`combo` / `super` / `info`) picks the tint, the rim's colour and spin speed, the
+title size, how long it stays up, its own entry-and-exit keyframes, and the
+sparks `bannerEffect` throws around it — a bonus tip should not arrive like a
+wipeout. The shared shell lives on `.candy-banner`; each kind overrides only the
+parts that carry meaning. `--banner-top` in the stylesheet must stay in step
+with `BANNER_TOP` in `effects.ts`, which is where those sparks are aimed.
+
+**Anything driven by `requestAnimationFrame` needs a backstop.** Browsers stop
+rAF for a hidden or throttled page, and this game leans on it in two places: the
+particle field (which drops bursts when its loop has gone quiet, rather than
+banking a wall of confetti for the first frame back) and the HUD counters (whose
+count-up tween is snapped to its target by a timer if the frames never arrive).
+Note that embedded and preview surfaces report `document.hidden` while plainly
+on screen, so ask the render loop whether it is running — never that flag.
+
+**Sound is synthesised so it can share the haptics' numbers.** Match pitch walks
+a pentatonic scale with cascade depth, the same value that raises the pulse
+frequency; the finale's riser is built against `FINALE_MS`, the constant the
+finale haptic uses. Sound and vibration rise and land together by construction.
+
+### Particles
+
+`particles/index.ts` picks a backend. WebGPU is tried first and TypeGPU is
+imported lazily, so browsers without it never download the ~310 kB chunk;
+anything that fails — no adapter, a shader a driver rejects — falls back to
+Canvas 2D with matching motion constants.
+
+The canvas is portalled into `.shell`, not the board: the board must keep
+`overflow: hidden` for the candies' drop-in, which would slice every spark off
+at its border. Effects are still written in board coordinates and the backend
+shifts them by `setOrigin`, re-read each frame so scrolling and resizing need no
+listeners. `resize` is a no-op when the size is unchanged — it is called from
+the frame loop, and assigning `canvas.width` reallocates the backing store.
+
+The WebGPU path keeps both spawning and integration on the GPU. The CPU appends
+a _description_ of each burst to a small storage array and dispatches one thread
+per particle to be born, so a nine-tile cascade costs one buffer write and one
+dispatch. `'use gpu'` function bodies are compiled to WGSL at build time by
+`unplugin-typegpu`, wired up in `../vite.web-app.config.ts` — without that
+plugin TypeGPU has no AST for them and throws at runtime.

--- a/docs/web-app/src/App.tsx
+++ b/docs/web-app/src/App.tsx
@@ -7,6 +7,7 @@ import { PlaygroundScreen } from './screens/PlaygroundScreen';
 import { DemosScreen } from './screens/DemosScreen';
 import { GamesScreen } from './screens/GamesScreen';
 import { DemoScreen, isDemoSlug } from './screens/demos';
+import { GameScreen, isGameSlug } from './screens/games';
 
 const TAB_IDS: TabId[] = ['presets', 'playground', 'demos', 'games'];
 
@@ -29,7 +30,13 @@ export function App() {
 
   function renderScreen() {
     if (tab === 'playground') return <PlaygroundScreen />;
-    if (tab === 'games') return <GamesScreen />;
+    if (tab === 'games') {
+      return isGameSlug(sub) ? (
+        <GameScreen slug={sub} onBack={() => navigate('games')} />
+      ) : (
+        <GamesScreen onOpen={(slug) => navigate(`games/${slug}`)} />
+      );
+    }
     if (tab === 'demos') {
       return isDemoSlug(sub) ? (
         <DemoScreen slug={sub} onBack={() => navigate('demos')} />

--- a/docs/web-app/src/screens/GamesScreen.tsx
+++ b/docs/web-app/src/screens/GamesScreen.tsx
@@ -1,18 +1,34 @@
-import { GamepadIcon } from '../components/Icons';
+import { ChevronRightIcon } from '../components/Icons';
+import { GAMES, type GameSlug } from './games';
 
-export function GamesScreen() {
+type Props = {
+  onOpen: (slug: GameSlug) => void;
+};
+
+export function GamesScreen({ onOpen }: Props) {
   return (
     <div className="screen">
       <h1 className="title">Games</h1>
-      <p className="lead">Haptics make games feel physical. This is where they will live.</p>
+      <p className="lead">
+        Haptics make games feel physical. Every hit, drop and combo below is a Pulsar pattern.
+      </p>
 
-      <div className="card placeholder">
-        <GamepadIcon size={44} />
-        <h2 className="subtitle">Coming soon</h2>
-        <p className="lead" style={{ marginTop: 0 }}>
-          We are building a set of small games that lean on haptics for feedback — hits, misses,
-          near-misses and the rest. Nothing to play just yet.
-        </p>
+      <div className="stack">
+        {GAMES.map((game) => (
+          <button
+            key={game.slug}
+            type="button"
+            className="row-card"
+            onClick={() => onOpen(game.slug)}
+          >
+            <span>
+              <span className="row-card__label">{game.title}</span>
+              <br />
+              <span className="muted">{game.tagline}</span>
+            </span>
+            <ChevronRightIcon size={20} />
+          </button>
+        ))}
       </div>
 
       <a className="footer-link" href="../">

--- a/docs/web-app/src/screens/games/candy/CandyCascade.tsx
+++ b/docs/web-app/src/screens/games/candy/CandyCascade.tsx
@@ -1,0 +1,914 @@
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  COLS,
+  ROWS,
+  areAdjacent,
+  colOf,
+  createBoard,
+  createRng,
+  findBestMove,
+  hasValidMove,
+  idx,
+  resolveMove,
+  rowOf,
+  shuffleBoard,
+  type Board,
+  type CascadeStep,
+  type ComboKind,
+  type Move,
+  type Rng,
+  type Tile as TileData,
+} from './engine';
+import { CandySprite } from './CandySprite';
+import { Counter } from './Counter';
+import { gameAudio } from './audio';
+import { hapticsAvailable, resetHaptics } from './haptics';
+import { createParticleField, type ParticleField } from './particles';
+import {
+  bannerEffect,
+  blastEffect,
+  comboEffect,
+  bornEffect,
+  clearShake,
+  finaleEffect,
+  landingEffect,
+  matchEffect,
+  rejectEffect,
+  selectEffect,
+  shuffleEffect,
+  swapEffect,
+  type BannerKind,
+  type Effects,
+} from './effects';
+
+/**
+ * Playback, not logic.
+ *
+ * `resolveMove` has already decided everything by the time this component runs:
+ * it hands back an ordered list of cascade steps, and this file walks them,
+ * pausing for each animation and firing the matching effects. Splitting it that
+ * way is what lets the celebration know how deep a chain is *before* the first
+ * candy pops, so the finale can be scheduled rather than discovered.
+ */
+
+const STARTING_MOVES = 25;
+
+/**
+ * How the game keeps itself lively.
+ *
+ * Played honestly, a striped candy turns up about once every two moves for
+ * someone who spots the best swap — but the worst dry spell measured over 500
+ * moves was fourteen, which is a long time to see nothing happen. So the rules
+ * loosen in two situations: for the opening moves, where a new player needs to
+ * see what a special *does* before they can learn to aim for one, and again
+ * whenever anyone has gone several moves without one. Left on permanently the
+ * same dial produces more than one special per move and the board turns to
+ * soup, so it is deliberately temporary in both cases.
+ */
+const WARMUP_MOVES = 8;
+const PITY_MOVES = 4;
+const GENEROUS_AT = 4;
+
+/**
+ * Chance that a refilled candy copies a neighbour's colour — see
+ * `MoveOptions.cascadeBias`.
+ *
+ * Measured over 500 played-out moves: at 0 a chain of any length happens on 43%
+ * of moves and only 24% are worth celebrating. At 0.20 that becomes 69% and
+ * 49%, which roughly doubles how often a combo turns up. Past about 0.3 it runs
+ * away — 88% of moves chain and each takes nearly six cascade steps, which at
+ * 550ms a step means the player spends most of the game watching rather than
+ * playing. The opening is nudged higher because a first impression should sparkle.
+ */
+const CASCADE_BIAS = 0.2;
+const CASCADE_BIAS_WARMUP = 0.28;
+
+/** Idle time before the board points out a move it can see. */
+const HINT_AFTER_MS = 4200;
+
+/** Animation budget for each phase, in ms. Effects are timed against these. */
+const SWAP_MS = 175;
+const CLEAR_MS = 285;
+const FALL_MS = 265;
+
+const wait = (ms: number) => new Promise<void>((resolve) => window.setTimeout(resolve, ms));
+
+/**
+ * How far, as a fraction of a cell, a candy must be pushed before the swap
+ * commits. Low enough to feel eager, high enough that a tap with a shaky finger
+ * stays a tap.
+ */
+const COMMIT_AT = 0.42;
+
+/** The grabbed candy never slides further than this, so it reads as a nudge. */
+const MAX_NUDGE = 0.62;
+
+/**
+ * The illegal-move refusal. `REJECT_LEAN` is only needed for a tap-then-tap
+ * swap, which has no drag offset to inherit; a dragged swap keeps whatever the
+ * player already pushed. `REJECT_HOLD_MS` is the beat the candy visibly resists
+ * before sliding home.
+ */
+const REJECT_LEAN = 0.34;
+const REJECT_HOLD_MS = 90;
+
+/**
+ * The recoil, as fractions of however far the player actually pushed.
+ *
+ * Expressing the bounce relative to the push (rather than as an overshooting
+ * easing curve) is what keeps it safe: a hard shove and a gentle nudge both
+ * recoil by the same *proportion*, so the candy never swings out of its own
+ * cell and into its neighbours however hard the illegal swap was attempted.
+ */
+const REJECT_SPRING: { at: number; ms: number }[] = [
+  { at: -0.26, ms: 150 },
+  { at: 0.1, ms: 110 },
+  { at: 0, ms: 90 },
+];
+
+const REJECT_SETTLE_MS = REJECT_SPRING.reduce((total, stage) => total + stage.ms, 0);
+
+/**
+ * A live pixel offset applied to two neighbouring candies.
+ *
+ * Both the drag and the illegal-move wiggle use it, which is the point: a
+ * rejected swap must never touch the board. Moving candies by *offset* leaves
+ * the grid untouched, so nothing has to be swapped and un-swapped, and the
+ * springy grid transition — which overshoots a third of a cell into the
+ * neighbouring candies — never gets interrupted and reversed mid-flight.
+ */
+type Nudge = {
+  from: number;
+  to: number;
+  dx: number;
+  dy: number;
+  kind: 'drag' | 'reject';
+  /** The offset at the moment the push ended — the spring scales off it. */
+  pushedX: number;
+  pushedY: number;
+  /** Duration for this leg of the spring; the CSS reads it as `--settle-ms`. */
+  settleMs?: number;
+};
+
+/**
+ * One candy. Memoised because a drag re-renders the board on every pointermove
+ * and only the two candies being pushed actually change — without this, all 64
+ * SVGs would re-render at pointer rate.
+ */
+const Tile = memo(function Tile({
+  tile,
+  index,
+  clearing,
+  selected,
+  hinted,
+  grabbed,
+  displaced,
+  rejecting,
+  settleMs,
+  dx,
+  dy,
+}: {
+  tile: TileData;
+  index: number;
+  clearing: boolean;
+  selected: boolean;
+  /** Part of the move the board is suggesting after an idle spell. */
+  hinted: boolean;
+  /** The candy under the finger — it lifts and rides above the board. */
+  grabbed: boolean;
+  /** The neighbour it is pushing against — it slides, but does not lift. */
+  displaced: boolean;
+  /** Part of an illegal-move spring: a tight ease, staged from JS. */
+  rejecting: boolean;
+  settleMs?: number;
+  dx: number;
+  dy: number;
+}) {
+  const col = colOf(index);
+  const row = rowOf(index);
+  const transform =
+    dx !== 0 || dy !== 0
+      ? `translate(calc(${col * 100}% + ${dx}px), calc(${row * 100}% + ${dy}px))`
+      : `translate(${col * 100}%, ${row * 100}%)`;
+
+  return (
+    <div
+      className={[
+        'candy',
+        clearing ? 'candy--clearing' : '',
+        selected ? 'candy--selected' : '',
+        hinted ? 'candy--hint' : '',
+        grabbed ? 'candy--grabbed' : '',
+        displaced ? 'candy--displaced' : '',
+        rejecting ? 'candy--rejecting' : '',
+        tile.special !== 'none' ? 'candy--special' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={
+        settleMs === undefined
+          ? { transform }
+          : ({ transform, '--settle-ms': `${settleMs}ms` } as CSSProperties)
+      }
+    >
+      <CandySprite color={tile.color} special={tile.special} />
+    </div>
+  );
+});
+
+/** What a cascade earns as a banner. Index by depth, clamped. */
+const CASCADE_TITLES = ['Sweet!', 'Tasty!', 'Delicious!', 'Divine!', 'Unstoppable!'];
+
+/**
+ * The combos that earn a screen kick. Deliberately narrow: shaking the whole app
+ * is the loudest thing the game can do, so it is saved for a wipeout or a chain
+ * five deep rather than spent on every special.
+ */
+const SUPER_COMBOS: ReadonlySet<ComboKind> = new Set<ComboKind>([
+  'bombBomb',
+  'bombStriped',
+  'bombColor',
+  'wrappedWrapped',
+]);
+
+const SUPER_CASCADE = 5;
+
+const COMBO_TITLES: Record<Exclude<ComboKind, 'none'>, string> = {
+  bombColor: 'Colour bomb!',
+  bombBomb: 'Total wipeout!',
+  bombStriped: 'Charged bomb!',
+  stripedStriped: 'Double stripe!',
+  stripedWrapped: 'Striped wrap!',
+  wrappedWrapped: 'Mega wrap!',
+};
+
+type Banner = { id: number; title: string; detail: string; kind: BannerKind };
+
+/**
+ * How long each kind stays up. A bonus banner is instructional and has to be
+ * read; a cascade label is pure punctuation and outstays its welcome if it
+ * lingers; a super combo has earned the extra beat.
+ */
+const BANNER_MS: Record<BannerKind, number> = {
+  bonus: 1700,
+  cascade: 1300,
+  combo: 1500,
+  super: 1900,
+  info: 1500,
+};
+
+export function CandyCascade() {
+  const rngRef = useRef<Rng>(createRng(Date.now() >>> 0));
+  const [board, setBoard] = useState<Board>(() => createBoard(rngRef.current));
+  const [clearing, setClearing] = useState<ReadonlySet<number>>(() => new Set());
+  const [selected, setSelected] = useState<number | null>(null);
+  const [score, setScore] = useState(0);
+  const [moves, setMoves] = useState(STARTING_MOVES);
+  const [busy, setBusy] = useState(false);
+  const [banner, setBanner] = useState<Banner | null>(null);
+  const [dryStreak, setDryStreak] = useState(0);
+  const [hint, setHint] = useState<{ from: number; to: number } | null>(null);
+  /** The live chain counter. `exiting` keeps it mounted long enough to leave. */
+  const [combo, setCombo] = useState<{ level: number; exiting: boolean } | null>(null);
+  const [backend, setBackend] = useState<ParticleField['backend'] | null>(null);
+
+  const boardRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  /**
+   * The particle canvas is rendered into the app shell rather than the board,
+   * because the board must keep `overflow: hidden` for the candies' drop-in and
+   * that clips sparks at its border. Spanning the shell lets a blast throw
+   * confetti across the whole app, and the shell's own clipping keeps it inside
+   * the frame.
+   */
+  const [shell, setShell] = useState<HTMLElement | null>(null);
+  const effectsRef = useRef<Effects>({ field: null });
+  const sizeRef = useRef({ width: 1, height: 1 });
+  const [nudge, setNudge] = useState<Nudge | null>(null);
+  /** Guards the delayed clear in `settleNudge` against a newer settle. */
+  const nudgeGenRef = useRef(0);
+  const dragRef = useRef<{ from: number; originX: number; originY: number; done: boolean } | null>(
+    null,
+  );
+  /** Bumped on restart/unmount so an in-flight cascade stops touching state. */
+  const runRef = useRef(0);
+  const bannerIdRef = useRef(0);
+
+  useLayoutEffect(() => {
+    setShell(document.querySelector<HTMLElement>('.shell'));
+  }, []);
+
+  // --------------------------------------------------------- particles --
+
+  // Depends on `shell` because the canvas lives in a portal into it: on the
+  // first commit that portal has not rendered, so `canvasRef` is still empty
+  // and there is nothing to attach a GPU context to. Re-running once the shell
+  // is known is what gives this effect a canvas to work with.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    let field: ParticleField | null = null;
+    let raf = 0;
+    let last = performance.now();
+    let cancelled = false;
+
+    void createParticleField(canvas).then((created) => {
+      if (cancelled) {
+        created.destroy();
+        return;
+      }
+      field = created;
+      effectsRef.current.field = created;
+      setBackend(created.backend);
+
+      const loop = (now: number) => {
+        // Clamped so a backgrounded tab does not resume with a huge timestep
+        // that teleports every particle off screen.
+        const dt = Math.min(0.05, (now - last) / 1000);
+        last = now;
+
+        // Re-read each frame so the origin survives scrolling and resizing
+        // without needing listeners for either; two rect reads are far cheaper
+        // than getting this subtly wrong.
+        const boardElement = boardRef.current;
+        const shellElement = canvas.parentElement;
+        if (boardElement && shellElement) {
+          const boardRect = boardElement.getBoundingClientRect();
+          const shellRect = shellElement.getBoundingClientRect();
+          created.resize(shellRect.width, shellRect.height);
+          created.setOrigin(boardRect.left - shellRect.left, boardRect.top - shellRect.top);
+        }
+
+        created.frame(dt);
+        raf = requestAnimationFrame(loop);
+      };
+      raf = requestAnimationFrame(loop);
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      effectsRef.current.field = null;
+      field?.destroy();
+    };
+  }, [shell]);
+
+  // Keep the particle canvas locked to the board's pixel size.
+  useLayoutEffect(() => {
+    const element = boardRef.current;
+    if (!element) return;
+
+    // Board size only: it is what effect positions are expressed in. The canvas
+    // is sized to the shell instead, inside the frame loop.
+    const apply = (width: number, height: number) => {
+      if (width <= 0 || height <= 0) return;
+      sizeRef.current = { width, height };
+    };
+
+    // Measure synchronously first. The particle field is built asynchronously,
+    // so if the observer's only callback lands before the field exists, its
+    // measurement goes nowhere and the canvas is left at its 1x1 default —
+    // taking every burst position and the drag's commit distance down with it.
+    // This effect is layout-phase, so it always runs before that creation.
+    const rect = element.getBoundingClientRect();
+    apply(rect.width, rect.height);
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      apply(width, height);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      runRef.current++;
+      resetHaptics();
+      clearShake();
+      gameAudio.close();
+    };
+  }, []);
+
+  const showBanner = useCallback((title: string, detail: string, kind: BannerKind) => {
+    bannerIdRef.current += 1;
+    const id = bannerIdRef.current;
+    setBanner({ id, title, detail, kind });
+    bannerEffect(effectsRef.current, kind, sizeRef.current);
+    window.setTimeout(() => {
+      setBanner((current) => (current?.id === id ? null : current));
+    }, BANNER_MS[kind]);
+  }, []);
+
+  /**
+   * The generosity dial for this move — see `WARMUP_MOVES`. Derived rather than
+   * stored so it can never drift out of step with the counters it reads.
+   */
+  const movesPlayed = STARTING_MOVES - moves;
+  const warmingUp = movesPlayed < WARMUP_MOVES;
+  const generousAt = warmingUp || dryStreak >= PITY_MOVES ? GENEROUS_AT : undefined;
+  const cascadeBias = warmingUp ? CASCADE_BIAS_WARMUP : CASCADE_BIAS;
+
+  /** Centre of a cell in canvas pixels — where a burst should originate. */
+  const pointOf = useCallback((index: number, source: Board) => {
+    const { width, height } = sizeRef.current;
+    return {
+      x: ((colOf(index) + 0.5) / COLS) * width,
+      y: ((rowOf(index) + 0.5) / ROWS) * height,
+      color: source[index]?.color ?? 0,
+    };
+  }, []);
+
+  /**
+   * Eases any live offset home on the no-overshoot curve, then clears it.
+   *
+   * Offsets are never dropped to zero in one step: doing that hands the candy
+   * to the springy grid transition, which overshoots a third of a cell into its
+   * neighbours — the jolt that made a refused swap look like the row moving.
+   */
+  const settleNudge = useCallback(() => {
+    const generation = ++nudgeGenRef.current;
+    let elapsed = 0;
+
+    for (const stage of REJECT_SPRING) {
+      const at = stage.at;
+      const ms = stage.ms;
+      window.setTimeout(() => {
+        if (nudgeGenRef.current !== generation) return;
+        setNudge((current) =>
+          current
+            ? {
+                ...current,
+                // Each stage is a fraction of the offset the player pushed, so
+                // the recoil is proportional and always lands back on zero.
+                dx: current.pushedX * at,
+                dy: current.pushedY * at,
+                kind: 'reject',
+                settleMs: ms,
+              }
+            : null,
+        );
+      }, elapsed);
+      elapsed += ms;
+    }
+
+    window.setTimeout(() => {
+      if (nudgeGenRef.current === generation) setNudge(null);
+    }, elapsed + 40);
+  }, []);
+
+  // ---------------------------------------------------------- playback --
+
+  const playStep = useCallback(
+    async (step: CascadeStep, before: Board, run: number) => {
+      const boardSize = sizeRef.current;
+
+      // Mark the doomed candies so CSS can pop them, then fire their effects.
+      setClearing(new Set(step.clear.cleared.map((index) => before[index]?.id ?? -1)));
+
+      const points = step.clear.cleared
+        .filter((index) => before[index])
+        .map((index) => pointOf(index, before));
+      const tiles = step.clear.cleared.length;
+
+      matchEffect(effectsRef.current, points, tiles, step.clear.cascade);
+
+      if (step.clear.cascade >= 2) {
+        setCombo({ level: step.clear.cascade, exiting: false });
+        comboEffect(effectsRef.current, step.clear.cascade, boardSize);
+      }
+
+      // Specials fire slightly after the pop so the two are distinguishable.
+      step.clear.blasts.forEach((blast, order) => {
+        window.setTimeout(
+          () => {
+            if (runRef.current !== run) return;
+            blastEffect(
+              effectsRef.current,
+              blast.kind,
+              { ...pointOf(blast.index, before), color: blast.color },
+              boardSize,
+            );
+          },
+          60 + order * 55,
+        );
+      });
+
+      step.clear.created.forEach((entry) => {
+        window.setTimeout(() => {
+          if (runRef.current !== run) return;
+          bornEffect(effectsRef.current, entry.special, {
+            ...pointOf(entry.index, before),
+            color: entry.color,
+          });
+          // Say so when one was granted rather than earned, and say what it
+          // does — a striped candy is useless to a player who has not worked
+          // out that swapping it fires the line.
+          if (entry.bonus) showBanner('Bonus stripe!', 'Swap it to blast the line', 'bonus');
+        }, 120);
+      });
+
+      setScore((current) => current + step.clear.points);
+      await wait(CLEAR_MS);
+      if (runRef.current !== run) return;
+
+      setBoard(step.fall.board);
+      setClearing(new Set());
+      landingEffect(step.fall.moved, step.fall.distance);
+
+      await wait(FALL_MS);
+    },
+    [pointOf, showBanner],
+  );
+
+  const playMove = useCallback(
+    async (from: number, to: number) => {
+      const run = runRef.current;
+      setBusy(true);
+      setSelected(null);
+
+      const result: Move | null = resolveMove(board, from, to, rngRef.current, {
+        generousAt,
+        cascadeBias,
+      });
+
+      // An illegal swap leans the two candies into each other and lets them
+      // settle. Crucially the board is never changed, so there is no swap to
+      // undo and the springy grid transition is never interrupted halfway
+      // through its overshoot — that reversal is what used to shove the
+      // surrounding row.
+      if (!result) {
+        rejectEffect();
+
+        const horizontal = colOf(from) !== colOf(to);
+        const direction = horizontal
+          ? Math.sign(colOf(to) - colOf(from))
+          : Math.sign(rowOf(to) - rowOf(from));
+        const lean = cellSize() * REJECT_LEAN * direction;
+
+        // Inherit the offset the drag already built and just hold it: the candy
+        // is seen to push, refuse, and slide back in one continuous motion. A
+        // tap-then-tap swap has no offset to inherit, so it leans from rest.
+        setNudge((current) =>
+          current
+            ? { ...current, kind: 'reject' }
+            : {
+                from,
+                to,
+                dx: horizontal ? lean : 0,
+                dy: horizontal ? 0 : lean,
+                pushedX: horizontal ? lean : 0,
+                pushedY: horizontal ? 0 : lean,
+                kind: 'reject',
+              },
+        );
+        await wait(REJECT_HOLD_MS);
+        if (runRef.current !== run) return;
+
+        settleNudge();
+        await wait(REJECT_SETTLE_MS + 60);
+        if (runRef.current !== run) return;
+
+        setBusy(false);
+        return;
+      }
+
+      const swapped: Board = [...board];
+      swapped[from] = board[to];
+      swapped[to] = board[from];
+
+      swapEffect();
+      // Cleared together with the board change: the candy is already part-way
+      // to its new cell, so dropping the offset as the grid updates lets it
+      // finish the journey instead of springing back first.
+      setNudge(null);
+      setBoard(swapped);
+      await wait(SWAP_MS);
+      if (runRef.current !== run) return;
+
+      setMoves((current) => Math.max(0, current - 1));
+
+      const madeSpecial = result.steps.some((step) => step.clear.created.length > 0);
+      setDryStreak((current) => (madeSpecial ? 0 : current + 1));
+
+      // A special-on-special swap is the whole event, so it is crowned up
+      // front; a long chain earns its celebration only once it has played out.
+      const comboTitle = result.combo === 'none' ? null : COMBO_TITLES[result.combo];
+      if (comboTitle) {
+        const superCombo = SUPER_COMBOS.has(result.combo) || result.cascade >= SUPER_CASCADE;
+        showBanner(comboTitle, 'Special combo', superCombo ? 'super' : 'combo');
+        finaleEffect(effectsRef.current, Math.max(3, result.cascade), sizeRef.current, {
+          superCombo,
+        });
+      }
+
+      let previous = swapped;
+      for (const step of result.steps) {
+        await playStep(step, previous, run);
+        if (runRef.current !== run) return;
+        previous = step.fall.board;
+      }
+
+      // Let the counter play its exit rather than vanishing with the last step.
+      setCombo((current) => (current ? { ...current, exiting: true } : null));
+      window.setTimeout(() => setCombo(null), 420);
+
+      if (!comboTitle && result.cascade >= 3) {
+        const title = CASCADE_TITLES[Math.min(CASCADE_TITLES.length - 1, result.cascade - 3)];
+        const superCascade = result.cascade >= SUPER_CASCADE;
+        showBanner(title, `${result.cascade}x cascade`, superCascade ? 'super' : 'cascade');
+        finaleEffect(effectsRef.current, result.cascade, sizeRef.current, {
+          superCombo: superCascade,
+        });
+        await wait(320);
+      }
+
+      // A board with no legal swap left would soft-lock the game.
+      if (!hasValidMove(previous)) {
+        showBanner('No moves left', 'Reshuffling the board', 'info');
+        shuffleEffect();
+        await wait(360);
+        if (runRef.current !== run) return;
+        setBoard(shuffleBoard(previous, rngRef.current));
+        await wait(FALL_MS);
+      }
+
+      if (runRef.current === run) setBusy(false);
+    },
+    [board, playStep, settleNudge, generousAt, cascadeBias, showBanner],
+  );
+
+  /**
+   * After a few idle seconds, point at the best swap the board has.
+   *
+   * Reading a match-3 grid is a learned skill, and a player who cannot find a
+   * move learns nothing from staring at one. `findBestMove` costs a fraction of
+   * a millisecond, so this can simply run whenever the board settles.
+   */
+  useEffect(() => {
+    if (busy || moves === 0) {
+      setHint(null);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const best = findBestMove(board, { generousAt });
+      if (best) setHint({ from: best.from, to: best.to });
+    }, HINT_AFTER_MS);
+    return () => window.clearTimeout(timer);
+  }, [board, busy, moves, generousAt]);
+
+  // ------------------------------------------------------------- input --
+
+  const cellAt = useCallback((clientX: number, clientY: number): number | null => {
+    const element = boardRef.current;
+    if (!element) return null;
+    const rect = element.getBoundingClientRect();
+    const col = Math.floor(((clientX - rect.left) / rect.width) * COLS);
+    const row = Math.floor(((clientY - rect.top) / rect.height) * ROWS);
+    if (col < 0 || col >= COLS || row < 0 || row >= ROWS) return null;
+    return idx(col, row);
+  }, []);
+
+  /**
+   * Cell size straight from layout rather than the cached board size — the
+   * gesture's commit distance is measured in cells, so it must never be able
+   * to inherit a stale measurement.
+   */
+  const cellSize = useCallback(() => {
+    const element = boardRef.current;
+    return element ? element.getBoundingClientRect().width / COLS : 0;
+  }, []);
+
+  /** The cell one step from `from` in a direction, or null at the board edge. */
+  const neighbour = useCallback((from: number, stepCol: number, stepRow: number) => {
+    const col = colOf(from) + stepCol;
+    const row = rowOf(from) + stepRow;
+    if (col < 0 || col >= COLS || row < 0 || row >= ROWS) return null;
+    return idx(col, row);
+  }, []);
+
+  const canPlay = !busy && moves > 0;
+
+  const endDrag = useCallback(() => {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    // A committed gesture has handed its offset to `playMove`, which owns it
+    // from there. Only an abandoned drag settles itself.
+    if (drag && !drag.done) settleNudge();
+  }, [settleNudge]);
+
+  function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    // The AudioContext can only start inside a gesture, so unlock on any touch.
+    gameAudio.unlock();
+    setHint(null);
+    if (!canPlay) return;
+
+    const index = cellAt(event.clientX, event.clientY);
+    if (index === null) return;
+
+    // Stops the browser from starting its own drag or text selection on top of
+    // the gesture — that is what turns a candy grab into a smeared highlight.
+    event.preventDefault();
+
+    // Capture keeps a drag alive when the finger leaves the board, but it
+    // throws on a pointer id the browser no longer considers active. That must
+    // not take the move down with it.
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Non-fatal: without capture the drag simply ends at the board edge.
+    }
+
+    if (selected !== null && areAdjacent(selected, index)) {
+      endDrag();
+      void playMove(selected, index);
+      return;
+    }
+
+    dragRef.current = { from: index, originX: event.clientX, originY: event.clientY, done: false };
+    setSelected(index);
+    selectEffect();
+  }
+
+  /**
+   * A gesture pushes one candy against one neighbour.
+   *
+   * The direction comes from the drag *vector* measured against where the
+   * finger went down — never from whichever cell the pointer happens to be
+   * over. That distinction is what keeps a long swipe to a single swap instead
+   * of letting the candy walk along the row under the cursor.
+   */
+  function onPointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    const drag = dragRef.current;
+    if (!drag || drag.done) return;
+
+    // A mouse that is no longer held must not keep driving the board. Without
+    // this, one missed pointerup leaves the gesture armed and plain hovering
+    // starts swapping candies.
+    if (event.pointerType === 'mouse' && event.buttons === 0) {
+      endDrag();
+      return;
+    }
+    if (!canPlay) return;
+
+    const cell = cellSize();
+    if (cell <= 0) return;
+
+    const dx = event.clientX - drag.originX;
+    const dy = event.clientY - drag.originY;
+
+    // Lock to the dominant axis: a diagonal drag is still one swap, not two.
+    const horizontal = Math.abs(dx) >= Math.abs(dy);
+    const travel = horizontal ? dx : dy;
+    const direction = Math.sign(travel);
+    if (direction === 0) return;
+
+    const target = neighbour(drag.from, horizontal ? direction : 0, horizontal ? 0 : direction);
+    if (target === null) return;
+
+    const distance = Math.abs(travel);
+    const offset = Math.min(distance, cell * MAX_NUDGE) * direction;
+    setNudge({
+      from: drag.from,
+      to: target,
+      dx: horizontal ? offset : 0,
+      dy: horizontal ? 0 : offset,
+      pushedX: horizontal ? offset : 0,
+      pushedY: horizontal ? 0 : offset,
+      kind: 'drag',
+    });
+
+    if (distance >= cell * COMMIT_AT) {
+      // The offset stays exactly where the player put it; `playMove` decides
+      // whether it carries on into the swap or slides back.
+      drag.done = true;
+      void playMove(drag.from, target);
+    }
+  }
+
+  function onPointerUp() {
+    // A gesture that never reached the commit distance stays a tap, so the
+    // candy remains selected and tap-then-tap still works.
+    endDrag();
+  }
+
+  function restart() {
+    runRef.current++;
+    dragRef.current = null;
+    nudgeGenRef.current++;
+    setNudge(null);
+    resetHaptics();
+    clearShake();
+    effectsRef.current.field?.clear();
+    rngRef.current = createRng((Date.now() ^ (Math.random() * 1e9)) >>> 0);
+    setBoard(createBoard(rngRef.current));
+    setClearing(new Set());
+    setSelected(null);
+    setScore(0);
+    setMoves(STARTING_MOVES);
+    setBanner(null);
+    setHint(null);
+    setDryStreak(0);
+    setCombo(null);
+    setBusy(false);
+  }
+
+  const over = moves === 0 && !busy;
+
+  return (
+    <>
+      <div className="candy-hud">
+        <Counter value={score} label="Score" tone="score" />
+        <Counter value={moves} label="Moves" tone="moves" align="right" warn={moves <= 5} />
+      </div>
+
+      <div
+        ref={boardRef}
+        className="candy-board"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        role="application"
+        aria-label="Candy board"
+      >
+        {board.map((tile, index) => {
+          if (!tile) return null;
+
+          // The grabbed candy follows the finger; the one it is pushing against
+          // slides the opposite way by the same amount.
+          const pushed = nudge?.from === index;
+          const displaced = nudge?.to === index;
+          const dx = pushed ? nudge.dx : displaced ? -nudge.dx : 0;
+          const dy = pushed ? nudge.dy : displaced ? -nudge.dy : 0;
+          const dragging = nudge?.kind === 'drag';
+          const hinted = hint !== null && (hint.from === index || hint.to === index);
+
+          return (
+            <Tile
+              key={tile.id}
+              tile={tile}
+              index={index}
+              clearing={clearing.has(tile.id)}
+              selected={selected === index}
+              hinted={hinted}
+              grabbed={pushed && dragging}
+              displaced={displaced && dragging}
+              rejecting={(pushed || displaced) && !dragging}
+              settleMs={nudge?.settleMs}
+              dx={dx}
+              dy={dy}
+            />
+          );
+        })}
+
+        {combo && combo.level >= 2 && (
+          <div
+            // Keyed on the level so each tick remounts and replays the pop.
+            key={combo.level}
+            className={`candy-combo${combo.exiting ? ' candy-combo--out' : ''}`}
+            style={{ '--heat': `${Math.min(1, (combo.level - 2) / 6)}` } as CSSProperties}
+            aria-live="polite"
+          >
+            <span className="candy-combo__value">&times;{combo.level}</span>
+            <span className="candy-combo__label">combo</span>
+          </div>
+        )}
+
+        {banner && (
+          <div className={`candy-banner candy-banner--${banner.kind}`} key={banner.id}>
+            {banner.kind === 'super' && <span className="candy-banner__wave" aria-hidden="true" />}
+            <span className="candy-banner__title">{banner.title}</span>
+            <span className="candy-banner__detail">{banner.detail}</span>
+          </div>
+        )}
+
+        {over && (
+          <div className="candy-over">
+            <span className="candy-over__title">Out of moves</span>
+            <span className="candy-over__score">{score.toLocaleString()} points</span>
+            <button type="button" className="btn" onClick={restart}>
+              Play again
+            </button>
+          </div>
+        )}
+      </div>
+
+      {shell && createPortal(<canvas ref={canvasRef} className="candy-particles" />, shell)}
+
+      <p className="hint candy-footnote">
+        {hapticsAvailable()
+          ? 'Every match, drop and combo is a different Pulsar pattern — cascades climb, specials sweep, combos land with the confetti.'
+          : 'This browser has no Vibration API, so the haptics are playing as sound instead. Open it on an Android phone to feel them.'}
+        {backend === 'webgpu'
+          ? ' Particles are running on WebGPU via TypeGPU.'
+          : backend === 'canvas'
+            ? ' WebGPU is unavailable here, so particles fall back to Canvas 2D.'
+            : ''}
+      </p>
+    </>
+  );
+}

--- a/docs/web-app/src/screens/games/candy/CandySprite.tsx
+++ b/docs/web-app/src/screens/games/candy/CandySprite.tsx
@@ -1,0 +1,91 @@
+import { CANDIES, type CandyShape } from './palette';
+import type { SpecialKind } from './engine';
+
+/**
+ * One candy, drawn as SVG.
+ *
+ * Shape carries the same information as colour so the board stays playable
+ * without colour vision, and specials are drawn as overlays on top of the base
+ * silhouette — a striped lemon is still recognisably a lemon.
+ */
+
+const SHAPES: Record<CandyShape, string> = {
+  circle: 'M50 10a40 40 0 1 0 0 80a40 40 0 1 0 0-80Z',
+  square:
+    'M30 12h40a18 18 0 0 1 18 18v40a18 18 0 0 1-18 18H30a18 18 0 0 1-18-18V30a18 18 0 0 1 18-18Z',
+  diamond: 'M50 6 94 50 50 94 6 50Z',
+  hex: 'M50 7 89 28.5v43L50 93 11 71.5v-43Z',
+  drop: 'M50 7c22 21 38 37 38 52a38 38 0 0 1-76 0c0-15 16-31 38-52Z',
+  star: 'M50 6 61.2 34.6 91.9 36.4 68.1 55.9 75.9 85.6 50 69 24.1 85.6 31.9 55.9 8.1 36.4 38.8 34.6Z',
+};
+
+type Props = {
+  color: number;
+  special: SpecialKind;
+};
+
+export function CandySprite({ color, special }: Props) {
+  const candy = CANDIES[color] ?? CANDIES[0];
+  const bomb = special === 'bomb';
+
+  return (
+    <svg className="candy__art" viewBox="0 0 100 100" aria-hidden="true">
+      {bomb ? (
+        // A colour bomb belongs to no colour: a dark sphere speckled with every
+        // candy hue, so it reads as "all of them at once".
+        <>
+          <circle cx="50" cy="50" r="40" fill="#1b1b3a" />
+          {CANDIES.map((entry, index) => {
+            const angle = (index / CANDIES.length) * Math.PI * 2 - Math.PI / 2;
+            return (
+              <circle
+                key={entry.name}
+                cx={50 + Math.cos(angle) * 22}
+                cy={50 + Math.sin(angle) * 22}
+                r="8.5"
+                fill={entry.color}
+              />
+            );
+          })}
+          <circle cx="38" cy="34" r="7" fill="#ffffff" opacity="0.5" />
+        </>
+      ) : (
+        <>
+          <path d={SHAPES[candy.shape]} fill={candy.color} />
+          <path d={SHAPES[candy.shape]} fill="none" stroke="rgba(0,26,114,0.22)" strokeWidth="3" />
+          <ellipse cx="38" cy="31" rx="13" ry="9" fill={candy.sheen} opacity="0.75" />
+
+          {(special === 'stripedH' || special === 'stripedV') && (
+            <g opacity="0.92" transform={special === 'stripedV' ? 'rotate(90 50 50)' : undefined}>
+              {[-14, 0, 14].map((offset) => (
+                <rect
+                  key={offset}
+                  x="12"
+                  y={46 + offset}
+                  width="76"
+                  height="7"
+                  rx="3.5"
+                  fill="#ffffff"
+                />
+              ))}
+            </g>
+          )}
+
+          {special === 'wrapped' && (
+            <>
+              <path
+                d={SHAPES[candy.shape]}
+                fill="none"
+                stroke="#ffffff"
+                strokeWidth="7"
+                opacity="0.9"
+                transform="scale(0.62) translate(31 31)"
+              />
+              <path d="M8 50h84M50 8v84" stroke="#ffffff" strokeWidth="6" opacity="0.75" />
+            </>
+          )}
+        </>
+      )}
+    </svg>
+  );
+}

--- a/docs/web-app/src/screens/games/candy/Counter.tsx
+++ b/docs/web-app/src/screens/games/candy/Counter.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * A number that counts up to its new value, pops when it changes, and throws a
+ * floating delta chip.
+ *
+ * The tween runs on `requestAnimationFrame`, which browsers stop entirely for a
+ * hidden or throttled page — so a timer always snaps the counter to its target
+ * as a backstop. Without it a score bumped while the tab was in the background
+ * would come back frozen part-way there and stay wrong for the rest of the run.
+ */
+
+const TWEEN_MS = 420;
+const DELTA_MS = 900;
+
+type Delta = { id: number; text: string };
+
+type Props = {
+  value: number;
+  label: string;
+  /** Drives the colour of the pop and the delta chip. */
+  tone: 'score' | 'moves';
+  align?: 'left' | 'right';
+  /** Renders the value in the warning colour (used when moves run low). */
+  warn?: boolean;
+};
+
+export function Counter({ value, label, tone, align = 'left', warn = false }: Props) {
+  const [display, setDisplay] = useState(value);
+  const [deltas, setDeltas] = useState<Delta[]>([]);
+  /**
+   * Bumped once per real change — never per tween frame — so remounting the
+   * value span replays the pop animation without restarting it 60 times a
+   * second. (A CSS animation only re-runs when its name changes or the element
+   * is recreated; remounting is the reliable trigger here.)
+   */
+  const [popId, setPopId] = useState(0);
+
+  const displayRef = useRef(value);
+  const previousRef = useRef(value);
+  const deltaIdRef = useRef(0);
+
+  useEffect(() => {
+    const from = displayRef.current;
+    const previous = previousRef.current;
+    previousRef.current = value;
+    if (from === value) return;
+
+    const difference = value - previous;
+    if (difference !== 0) {
+      setPopId((current) => current + 1);
+
+      const id = ++deltaIdRef.current;
+      const text = difference > 0 ? `+${difference.toLocaleString()}` : `${difference}`;
+      setDeltas((current) => [...current, { id, text }]);
+      window.setTimeout(
+        () => setDeltas((current) => current.filter((entry) => entry.id !== id)),
+        DELTA_MS,
+      );
+    }
+
+    const start = performance.now();
+    let raf = 0;
+
+    const step = (now: number) => {
+      const progress = Math.min(1, (now - start) / TWEEN_MS);
+      // Ease-out cubic: quick off the mark, settling gently onto the number.
+      const eased = 1 - (1 - progress) ** 3;
+      const next = Math.round(from + (value - from) * eased);
+      displayRef.current = next;
+      setDisplay(next);
+      if (progress < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+
+    // Backstop for a paused rAF — see the note at the top of this file.
+    const snap = window.setTimeout(() => {
+      if (displayRef.current !== value) {
+        displayRef.current = value;
+        setDisplay(value);
+      }
+    }, TWEEN_MS + 250);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(snap);
+    };
+  }, [value]);
+
+  return (
+    <div className={`counter${align === 'right' ? ' counter--right' : ''} counter--${tone}`}>
+      <span className="counter__label">{label}</span>
+
+      <span className="counter__slot">
+        <span
+          key={popId}
+          className={`counter__value${warn ? ' counter__value--warn' : ''}`}
+          // Announce the settled value, not every frame of the tween.
+          aria-label={`${label}: ${value}`}
+        >
+          {display.toLocaleString()}
+        </span>
+
+        {deltas.map((delta) => (
+          <span key={delta.id} className="counter__delta" aria-hidden="true">
+            {delta.text}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}

--- a/docs/web-app/src/screens/games/candy/audio.ts
+++ b/docs/web-app/src/screens/games/candy/audio.ts
@@ -1,0 +1,307 @@
+import { isSoundEnabled } from '../../../haptics';
+
+/**
+ * Every sound in the game is synthesised on the spot — there are no samples to
+ * download, license or keep in sync with the repo.
+ *
+ * That is not only a packaging convenience. Because the voices are generated,
+ * they can be driven by the *same* numbers as the haptics: a match's tile count
+ * picks the pitch as well as the pulse width, and the finale's riser is built
+ * against `FINALE_MS`, the constant the finale haptic uses. Sound and vibration
+ * therefore rise and land together instead of merely happening at once.
+ *
+ * Everything is consonant by construction: pitches are chosen from a C major
+ * pentatonic scale, so a nine-deep cascade climbing the scale still sounds like
+ * music rather than an alarm.
+ */
+
+/** C major pentatonic, in semitones — no interval in here can clash. */
+const PENTATONIC = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24, 26, 28];
+const BASE_HZ = 523.25; // C5
+
+const step = (degree: number) =>
+  BASE_HZ * 2 ** ((PENTATONIC[Math.min(degree, PENTATONIC.length - 1)] ?? 0) / 12);
+
+class GameAudio {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private noise: AudioBuffer | null = null;
+
+  /**
+   * Browsers refuse to start an AudioContext outside a user gesture, so the
+   * board calls this from its first pointerdown. Safe to call repeatedly.
+   */
+  unlock() {
+    const ctx = this.context();
+    if (ctx && ctx.state === 'suspended') void ctx.resume();
+  }
+
+  close() {
+    void this.ctx?.close();
+    this.ctx = null;
+    this.master = null;
+    this.noise = null;
+  }
+
+  private context(): AudioContext | null {
+    if (this.ctx) return this.ctx;
+    const Ctor =
+      window.AudioContext ??
+      (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+
+    const ctx = new Ctor();
+    const master = ctx.createGain();
+    master.gain.value = 0.5;
+
+    // A dozen voices can land inside one cascade frame; without this the sum
+    // clips into a crackle rather than getting louder.
+    const limiter = ctx.createDynamicsCompressor();
+    limiter.threshold.value = -14;
+    limiter.ratio.value = 12;
+    limiter.attack.value = 0.002;
+    limiter.release.value = 0.15;
+
+    master.connect(limiter).connect(ctx.destination);
+    this.ctx = ctx;
+    this.master = master;
+    return ctx;
+  }
+
+  /** Null whenever audio is unavailable or the user muted the app. */
+  private live(): { ctx: AudioContext; out: GainNode; t: number } | null {
+    if (!isSoundEnabled()) return null;
+    const ctx = this.context();
+    if (!ctx || !this.master) return null;
+    if (ctx.state === 'suspended') void ctx.resume();
+    return { ctx, out: this.master, t: ctx.currentTime };
+  }
+
+  private noiseBuffer(ctx: AudioContext): AudioBuffer {
+    if (this.noise) return this.noise;
+    const buffer = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+    this.noise = buffer;
+    return buffer;
+  }
+
+  // ------------------------------------------------------------- voices --
+
+  /** A plucked tone with an exponential tail — the workhorse "blip". */
+  private tone(
+    at: number,
+    opts: {
+      freq: number;
+      to?: number;
+      duration: number;
+      gain: number;
+      type?: OscillatorType;
+      delay?: number;
+    },
+  ) {
+    const live = this.live();
+    if (!live) return;
+    const { ctx, out } = live;
+    const start = at + (opts.delay ?? 0);
+
+    const osc = ctx.createOscillator();
+    osc.type = opts.type ?? 'triangle';
+    osc.frequency.setValueAtTime(opts.freq, start);
+    if (opts.to !== undefined) {
+      osc.frequency.exponentialRampToValueAtTime(Math.max(20, opts.to), start + opts.duration);
+    }
+
+    const env = ctx.createGain();
+    env.gain.setValueAtTime(0.0001, start);
+    env.gain.exponentialRampToValueAtTime(opts.gain, start + 0.006);
+    env.gain.exponentialRampToValueAtTime(0.0001, start + opts.duration);
+
+    osc.connect(env).connect(out);
+    osc.start(start);
+    osc.stop(start + opts.duration + 0.02);
+  }
+
+  /** Filtered noise — the body of whooshes, blasts and landings. */
+  private burst(
+    at: number,
+    opts: {
+      duration: number;
+      gain: number;
+      from: number;
+      to?: number;
+      q?: number;
+      type?: BiquadFilterType;
+      delay?: number;
+    },
+  ) {
+    const live = this.live();
+    if (!live) return;
+    const { ctx, out } = live;
+    const start = at + (opts.delay ?? 0);
+
+    const src = ctx.createBufferSource();
+    src.buffer = this.noiseBuffer(ctx);
+    src.loop = true;
+
+    const filter = ctx.createBiquadFilter();
+    filter.type = opts.type ?? 'bandpass';
+    filter.frequency.setValueAtTime(opts.from, start);
+    if (opts.to !== undefined) {
+      filter.frequency.exponentialRampToValueAtTime(Math.max(40, opts.to), start + opts.duration);
+    }
+    filter.Q.value = opts.q ?? 1.2;
+
+    const env = ctx.createGain();
+    env.gain.setValueAtTime(0.0001, start);
+    env.gain.exponentialRampToValueAtTime(opts.gain, start + 0.008);
+    env.gain.exponentialRampToValueAtTime(0.0001, start + opts.duration);
+
+    src.connect(filter).connect(env).connect(out);
+    src.start(start);
+    src.stop(start + opts.duration + 0.02);
+  }
+
+  private now(): number | null {
+    return this.live()?.t ?? null;
+  }
+
+  // -------------------------------------------------------------- events --
+
+  select() {
+    const t = this.now();
+    if (t === null) return;
+    this.tone(t, { freq: step(4), duration: 0.06, gain: 0.1, type: 'sine' });
+  }
+
+  swap() {
+    const t = this.now();
+    if (t === null) return;
+    this.burst(t, { duration: 0.14, gain: 0.11, from: 900, to: 2600, q: 0.9 });
+    this.tone(t, { freq: step(2), to: step(5), duration: 0.11, gain: 0.09, type: 'sine' });
+  }
+
+  reject() {
+    const t = this.now();
+    if (t === null) return;
+    this.tone(t, { freq: 190, to: 130, duration: 0.13, gain: 0.16, type: 'square' });
+    this.tone(t, { freq: 150, to: 96, duration: 0.16, gain: 0.16, type: 'square', delay: 0.11 });
+  }
+
+  /**
+   * The candy pop. Cascade level walks up the pentatonic scale, so a chain
+   * reaction plays as a rising phrase — the audible twin of the haptic climb.
+   */
+  match(tiles: number, cascade: number) {
+    const t = this.now();
+    if (t === null) return;
+    const degree = Math.min(PENTATONIC.length - 1, cascade - 1 + Math.max(0, tiles - 3));
+    const freq = step(degree);
+
+    this.tone(t, { freq, to: freq * 1.9, duration: 0.16, gain: 0.16 });
+    this.tone(t, { freq: freq * 2, duration: 0.1, gain: 0.06, type: 'sine', delay: 0.01 });
+    this.burst(t, { duration: 0.07, gain: 0.09, from: 1800, to: 700, q: 0.8 });
+  }
+
+  /** Candies hitting the bottom: a handful of dry wood-block clicks. */
+  land(tiles: number, distance: number) {
+    const t = this.now();
+    if (t === null) return;
+    const hits = Math.min(5, Math.max(2, Math.round(tiles / 5)));
+    for (let i = 0; i < hits; i++) {
+      const delay = (i / hits) * Math.min(0.3, 0.07 + distance * 0.03) + Math.random() * 0.02;
+      this.burst(t, { duration: 0.05, gain: 0.07, from: 420 + Math.random() * 260, q: 3, delay });
+    }
+  }
+
+  /** A striped candy's beam crossing the board. */
+  sweep() {
+    const t = this.now();
+    if (t === null) return;
+    this.burst(t, { duration: 0.26, gain: 0.15, from: 500, to: 5200, q: 1.6 });
+    this.tone(t, { freq: step(3), to: step(9), duration: 0.24, gain: 0.09, type: 'sawtooth' });
+  }
+
+  /** Wrapped and colour-bomb detonations — `power` 0..1 sets the weight. */
+  blast(power: number) {
+    const t = this.now();
+    if (t === null) return;
+    this.burst(t, {
+      duration: 0.34 + power * 0.3,
+      gain: 0.2,
+      from: 1600,
+      to: 120,
+      q: 0.7,
+      type: 'lowpass',
+    });
+    this.tone(t, { freq: 150, to: 40, duration: 0.4 + power * 0.25, gain: 0.24, type: 'sine' });
+    this.tone(t, { freq: 90, to: 32, duration: 0.5, gain: 0.14, type: 'triangle', delay: 0.02 });
+  }
+
+  /** A special candy being created — a bright upward arpeggio. */
+  born(steps: number) {
+    const t = this.now();
+    if (t === null) return;
+    for (let i = 0; i < steps; i++) {
+      this.tone(t, { freq: step(4 + i * 2), duration: 0.12, gain: 0.1, delay: i * 0.05 });
+    }
+  }
+
+  /**
+   * The finale. Built against the same millisecond budget as the finale haptic
+   * (`FINALE_MS`): riser, hit, then a shower of bells under the confetti.
+   */
+  finale(level: number, totalMs: number) {
+    const t = this.now();
+    if (t === null) return;
+    const total = totalMs / 1000;
+    const hit = total * 0.53;
+    const power = Math.min(1, (level - 2) / 5);
+
+    // Riser — noise climbing into the hit.
+    this.burst(t, { duration: hit, gain: 0.14, from: 300, to: 6000, q: 1.1 });
+    this.tone(t, { freq: step(0), to: step(7), duration: hit, gain: 0.07, type: 'sawtooth' });
+
+    // The hit itself.
+    this.blast(power);
+    const chordAt = hit;
+    [0, 2, 4, 7].forEach((offset, i) => {
+      this.tone(t, {
+        freq: step(offset),
+        duration: 0.5,
+        gain: 0.11,
+        type: 'triangle',
+        delay: chordAt + i * 0.012,
+      });
+    });
+
+    // Confetti sparkle, thinning out exactly as the haptic's ticks do.
+    const tail = total - hit - 0.08;
+    for (let i = 0; i < 14; i++) {
+      const progress = i / 14;
+      this.tone(t, {
+        freq: step(6 + Math.floor(Math.random() * 6)),
+        duration: 0.22,
+        gain: 0.075 * (1 - progress * 0.75),
+        type: 'sine',
+        delay: chordAt + 0.1 + progress * tail + Math.random() * 0.03,
+      });
+    }
+  }
+
+  shuffle() {
+    const t = this.now();
+    if (t === null) return;
+    for (let i = 0; i < 8; i++) {
+      this.burst(t, {
+        duration: 0.07,
+        gain: 0.06,
+        from: 700 + Math.random() * 1400,
+        q: 2.5,
+        delay: i * 0.045,
+      });
+    }
+  }
+}
+
+export const gameAudio = new GameAudio();

--- a/docs/web-app/src/screens/games/candy/effects.ts
+++ b/docs/web-app/src/screens/games/candy/effects.ts
@@ -1,0 +1,406 @@
+import { gameAudio } from './audio';
+import {
+  FINALE_MS,
+  Priority,
+  bombBlastPattern,
+  bombBornPattern,
+  finalePattern,
+  landingPattern,
+  matchPattern,
+  playHaptic,
+  rejectPattern,
+  selectPattern,
+  stripeSweepPattern,
+  stripedBornPattern,
+  swapPattern,
+  wrappedBlastPattern,
+  wrappedBornPattern,
+} from './haptics';
+import { BurstKind, type ParticleField } from './particles';
+import { NEUTRAL_RGB, candyRgb } from './palette';
+import type { SpecialKind } from './engine';
+
+/**
+ * One event, one function — and each function fires the haptic, the sound and
+ * the particles together.
+ *
+ * Keeping the three in the same place is what makes "the combo haptic matches
+ * the combo visual" true by construction rather than by coincidence: the
+ * finale's crescendo, its riser and its confetti are all built against the same
+ * `FINALE_MS` budget, and a stripe's sweep haptic is fired with the same
+ * direction vector as the particles that follow the beam.
+ */
+
+export type Effects = { field: ParticleField | null };
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+/** How long `.shell--shaking` runs; kept in step with the keyframe in CSS. */
+export const SHAKE_MS = 520;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Kicks the whole app shell, not just the board — a wipeout should feel like it
+ * happened *to* the player, and stopping the shake at the board's edge reads as
+ * a panel wobbling rather than an impact.
+ *
+ * The class is removed and re-added around a forced reflow because a CSS
+ * animation only starts when its name changes; re-adding a class that is still
+ * present would leave a second super combo silent.
+ */
+export function shakeScreen(strength: number) {
+  if (prefersReducedMotion()) return;
+  const shell = document.querySelector<HTMLElement>('.shell');
+  if (!shell) return;
+
+  shell.classList.remove('shell--shaking');
+  void shell.offsetWidth;
+  shell.style.setProperty('--shake', `${strength.toFixed(1)}px`);
+  shell.classList.add('shell--shaking');
+
+  window.setTimeout(() => shell.classList.remove('shell--shaking'), SHAKE_MS);
+}
+
+/** Drops any shake in progress — the screen must not be left mid-kick. */
+export function clearShake() {
+  const shell = document.querySelector<HTMLElement>('.shell');
+  shell?.classList.remove('shell--shaking');
+}
+
+/**
+ * A ring of beams fired out from a point. Reuses the striped candy's `streak`
+ * particles, which spawn strung out along their direction rather than in a
+ * cloud, so each one reads as a single lance of light.
+ */
+function laserRing(
+  field: ParticleField | null,
+  x: number,
+  y: number,
+  beams: number,
+  energy: number,
+  spin: number,
+) {
+  for (let i = 0; i < beams; i++) {
+    // `spin` offsets the whole ring so repeat combos never fire the same star.
+    const angle = (i / beams) * Math.PI * 2 + spin;
+    field?.emit({
+      kind: BurstKind.streak,
+      x,
+      y,
+      color: candyRgb[i % candyRgb.length] ?? NEUTRAL_RGB,
+      count: 26,
+      energy,
+      dirX: Math.cos(angle),
+      dirY: Math.sin(angle),
+    });
+  }
+}
+
+export function selectEffect() {
+  playHaptic(selectPattern, Priority.tick);
+  gameAudio.select();
+}
+
+export function swapEffect() {
+  playHaptic(swapPattern, Priority.move);
+  gameAudio.swap();
+}
+
+export function rejectEffect() {
+  playHaptic(rejectPattern, Priority.move);
+  gameAudio.reject();
+}
+
+/** A colour match clearing. `points` are the screen positions of the tiles. */
+export function matchEffect(
+  { field }: Effects,
+  points: { x: number; y: number; color: number }[],
+  tiles: number,
+  cascade: number,
+) {
+  playHaptic(matchPattern(tiles, cascade), Priority.match);
+  gameAudio.match(tiles, cascade);
+
+  const energy = clamp01(0.25 + (cascade - 1) * 0.18 + (tiles - 3) * 0.06);
+  for (const point of points) {
+    field?.emit({
+      kind: BurstKind.pop,
+      x: point.x,
+      y: point.y,
+      color: candyRgb[point.color] ?? NEUTRAL_RGB,
+      count: 12 + Math.round(energy * 14),
+      energy,
+    });
+  }
+}
+
+/** Candies settling into their new places. */
+export function landingEffect(tiles: number, distance: number) {
+  playHaptic(landingPattern(tiles, distance), Priority.tick);
+  gameAudio.land(tiles, distance);
+}
+
+/** A special candy appearing. */
+export function bornEffect(
+  { field }: Effects,
+  special: SpecialKind,
+  point: { x: number; y: number; color: number },
+) {
+  if (special === 'none') return;
+
+  const pattern =
+    special === 'bomb'
+      ? bombBornPattern
+      : special === 'wrapped'
+        ? wrappedBornPattern
+        : stripedBornPattern;
+
+  playHaptic(pattern, Priority.special);
+  gameAudio.born(special === 'bomb' ? 4 : special === 'wrapped' ? 3 : 2);
+
+  field?.emit({
+    kind: BurstKind.spark,
+    x: point.x,
+    y: point.y,
+    color: special === 'bomb' ? NEUTRAL_RGB : (candyRgb[point.color] ?? NEUTRAL_RGB),
+    count: special === 'bomb' ? 46 : 26,
+    energy: special === 'bomb' ? 0.9 : 0.5,
+  });
+}
+
+/**
+ * A special going off. Striped candies fire particles *along their beam* and
+ * get the sweeping haptic; wrapped and bomb get radial blasts and the two
+ * detonation patterns.
+ */
+export function blastEffect(
+  { field }: Effects,
+  special: Exclude<SpecialKind, 'none'>,
+  point: { x: number; y: number; color: number },
+  board: { width: number; height: number },
+) {
+  const color = candyRgb[point.color] ?? NEUTRAL_RGB;
+
+  if (special === 'stripedH' || special === 'stripedV') {
+    playHaptic(stripeSweepPattern, Priority.special);
+    gameAudio.sweep();
+
+    const horizontal = special === 'stripedH';
+    // Two beams, one each way, so the burst reads as a line crossing the board.
+    for (const sign of [-1, 1]) {
+      field?.emit({
+        kind: BurstKind.streak,
+        x: point.x,
+        y: point.y,
+        color,
+        count: 40,
+        energy: 0.85,
+        dirX: horizontal ? sign : 0,
+        dirY: horizontal ? 0 : sign,
+      });
+    }
+    return;
+  }
+
+  const bomb = special === 'bomb';
+  playHaptic(bomb ? bombBlastPattern : wrappedBlastPattern, Priority.special);
+  gameAudio.blast(bomb ? 1 : 0.45);
+
+  field?.emit({
+    kind: BurstKind.explosion,
+    x: point.x,
+    y: point.y,
+    color: bomb ? NEUTRAL_RGB : color,
+    count: bomb ? 150 : 80,
+    energy: bomb ? 1 : 0.6,
+  });
+
+  // A colour bomb takes the whole board, so it throws a second, wider ring.
+  if (bomb) {
+    field?.emit({
+      kind: BurstKind.explosion,
+      x: board.width / 2,
+      y: board.height / 2,
+      color: NEUTRAL_RGB,
+      count: 120,
+      energy: 1,
+    });
+  }
+}
+
+/**
+ * The combo celebration. The riser, the crescendo and the confetti all run on
+ * `FINALE_MS`, and the confetti is emitted at the moment the haptic lands its
+ * hit, so the burst is felt and seen on the same beat.
+ */
+export function finaleEffect(
+  { field }: Effects,
+  level: number,
+  board: { width: number; height: number },
+  options: { superCombo?: boolean } = {},
+): number {
+  playHaptic(finalePattern(level), Priority.finale);
+  gameAudio.finale(level, FINALE_MS);
+
+  const power = clamp01((level - 2) / 5);
+  const hitAt = FINALE_MS * 0.53;
+  const centreX = board.width / 2;
+  const centreY = board.height * 0.42;
+
+  // A first, tighter ring launches slightly ahead of the hit, so the beams are
+  // already racing outward when the explosion and the haptic's peak land.
+  window.setTimeout(
+    () => laserRing(field, centreX, centreY, 6 + Math.round(power * 4), 0.75, 0),
+    hitAt - 90,
+  );
+
+  window.setTimeout(() => {
+    field?.emit({
+      kind: BurstKind.explosion,
+      x: centreX,
+      y: centreY,
+      color: NEUTRAL_RGB,
+      count: 110 + Math.round(power * 90),
+      energy: 1,
+    });
+
+    // The main starburst — more beams the deeper the chain went.
+    laserRing(field, centreX, centreY, 10 + Math.round(power * 8), 1, Math.PI / 12);
+
+    if (options.superCombo) {
+      // A wipeout throws the screen as well, timed to the same instant the
+      // finale haptic lands its hit.
+      shakeScreen(7 + power * 6);
+    }
+
+    // Confetti rains from across the top edge rather than one point.
+    const columns = 7;
+    for (let i = 0; i < columns; i++) {
+      field?.emit({
+        kind: BurstKind.confetti,
+        x: (board.width * (i + 0.5)) / columns,
+        y: board.height * 0.12,
+        color: NEUTRAL_RGB,
+        count: 26 + Math.round(power * 18),
+        energy: 0.8,
+      });
+    }
+  }, hitAt);
+
+  // A third ring on the way out keeps a super combo alive past the flash.
+  if (options.superCombo) {
+    window.setTimeout(() => laserRing(field, centreX, centreY, 14, 0.85, Math.PI / 7), hitAt + 150);
+  }
+
+  return FINALE_MS;
+}
+
+export function shuffleEffect() {
+  gameAudio.shuffle();
+}
+
+/**
+ * How far down the board a banner sits, as a fraction of its height.
+ *
+ * Duplicated as `--banner-top` in the stylesheet. The two have to agree: this
+ * value is where the sparks are thrown, that one is where the pill is drawn,
+ * and a mismatch shows up immediately as a banner with its own confetti
+ * hovering somewhere else.
+ */
+export const BANNER_TOP = 0.38;
+
+/** Where the combo counter sits, as a fraction of board height. Matches CSS. */
+export const COMBO_TOP = 0.13;
+
+/**
+ * A puff under the combo counter each time it ticks up. Small and hot — the
+ * chain itself is already throwing candy debris all over the board, so this
+ * only has to draw the eye to the number.
+ */
+export function comboEffect(
+  { field }: Effects,
+  level: number,
+  board: { width: number; height: number },
+) {
+  if (!field || level < 2) return;
+  const heat = clamp01((level - 2) / 6);
+  field.emit({
+    kind: BurstKind.spark,
+    x: board.width / 2,
+    y: board.height * COMBO_TOP,
+    color: heat > 0.5 ? (candyRgb[0] ?? NEUTRAL_RGB) : (candyRgb[4] ?? NEUTRAL_RGB),
+    count: 12 + Math.round(heat * 22),
+    energy: 0.35 + heat * 0.55,
+  });
+}
+
+export type BannerKind = 'bonus' | 'cascade' | 'combo' | 'super' | 'info';
+
+/**
+ * Sparks thrown around a banner as it lands, scaled to what it is announcing.
+ *
+ * Deliberately modest next to `finaleEffect` — this decorates the label, it is
+ * not the celebration itself, and a super combo is already firing a full
+ * starburst behind it.
+ */
+export function bannerEffect(
+  { field }: Effects,
+  kind: BannerKind,
+  board: { width: number; height: number },
+) {
+  // A shuffle notice is housekeeping, not an achievement.
+  if (kind === 'info' || !field) return;
+
+  const x = board.width / 2;
+  const y = board.height * BANNER_TOP;
+
+  if (kind === 'bonus') {
+    field.emit({
+      kind: BurstKind.spark,
+      x,
+      y,
+      color: candyRgb[4] ?? NEUTRAL_RGB,
+      count: 20,
+      energy: 0.3,
+    });
+    return;
+  }
+
+  if (kind === 'cascade') {
+    // Two puffs off the ends, so the sparks frame the label rather than hiding it.
+    for (const offset of [-0.22, 0.22]) {
+      field.emit({
+        kind: BurstKind.spark,
+        x: x + board.width * offset,
+        y,
+        color: candyRgb[2] ?? NEUTRAL_RGB,
+        count: 22,
+        energy: 0.5,
+      });
+    }
+    return;
+  }
+
+  const beams = kind === 'super' ? 10 : 6;
+  laserRing(field, x, y, beams, kind === 'super' ? 0.9 : 0.6, Math.PI / 9);
+  field.emit({
+    kind: BurstKind.spark,
+    x,
+    y,
+    color: NEUTRAL_RGB,
+    count: kind === 'super' ? 54 : 32,
+    energy: kind === 'super' ? 0.85 : 0.55,
+  });
+
+  if (kind === 'super') {
+    // A second puff a beat later, under the shockwave ring the banner draws.
+    window.setTimeout(
+      () => field.emit({ kind: BurstKind.spark, x, y, color: NEUTRAL_RGB, count: 34, energy: 0.7 }),
+      190,
+    );
+  }
+}

--- a/docs/web-app/src/screens/games/candy/engine.ts
+++ b/docs/web-app/src/screens/games/candy/engine.ts
@@ -1,0 +1,745 @@
+/**
+ * Match-3 board rules, kept as pure functions so the React layer never has
+ * to reason about matching — it only plays back the steps this module returns.
+ *
+ * A move is resolved *up front*: `resolveMove` walks every cascade to
+ * completion and hands back an ordered list of `CascadeStep`s. The screen then
+ * animates one step at a time, firing the haptics, audio and particles that
+ * each step describes. Keeping resolution and playback apart is what lets the
+ * haptic for a cascade know how big the cascade is *before* it starts playing.
+ */
+
+export const COLS = 8;
+export const ROWS = 8;
+export const COLORS = 6;
+
+export type SpecialKind = 'none' | 'stripedH' | 'stripedV' | 'wrapped' | 'bomb';
+
+export type Tile = {
+  /** Stable across gravity so React can key on it and CSS can animate the fall. */
+  id: number;
+  /** Index into the palette. A `bomb` matches every colour, so its own is unused. */
+  color: number;
+  special: SpecialKind;
+};
+
+/** Row-major, `null` only ever appears mid-resolution (between clear and gravity). */
+export type Board = (Tile | null)[];
+
+export type Rng = () => number;
+
+export const idx = (col: number, row: number) => row * COLS + col;
+export const colOf = (i: number) => i % COLS;
+export const rowOf = (i: number) => Math.floor(i / COLS);
+const inBounds = (col: number, row: number) => col >= 0 && col < COLS && row >= 0 && row < ROWS;
+
+/** Deterministic PRNG — a fixed seed makes a board reproducible for debugging. */
+export function createRng(seed: number): Rng {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+let nextId = 1;
+const makeTile = (color: number, special: SpecialKind = 'none'): Tile => ({
+  id: nextId++,
+  color,
+  special,
+});
+
+/** A bomb is colourless, so it must never take part in a colour run. */
+const matchable = (tile: Tile | null): tile is Tile => tile !== null && tile.special !== 'bomb';
+
+// ------------------------------------------------------------------ runs --
+
+type Axis = 'h' | 'v';
+type Run = { indices: number[]; axis: Axis };
+
+function findRuns(board: Board): Run[] {
+  const runs: Run[] = [];
+
+  const scan = (axis: Axis, outer: number, inner: number, at: (a: number, b: number) => number) => {
+    for (let a = 0; a < outer; a++) {
+      let start = 0;
+      while (start < inner) {
+        const first = board[at(a, start)];
+        let end = start + 1;
+        if (matchable(first)) {
+          while (end < inner) {
+            const next = board[at(a, end)];
+            if (!matchable(next) || next.color !== first.color) break;
+            end++;
+          }
+        }
+        if (matchable(first) && end - start >= 3) {
+          const indices: number[] = [];
+          for (let b = start; b < end; b++) indices.push(at(a, b));
+          runs.push({ indices, axis });
+        }
+        start = end;
+      }
+    }
+  };
+
+  scan('h', ROWS, COLS, (row, col) => idx(col, row));
+  scan('v', COLS, ROWS, (col, row) => idx(col, row));
+  return runs;
+}
+
+export type MatchGroup = {
+  indices: number[];
+  color: number;
+  /** Longest single line inside the group — 4 earns a stripe, 5+ a colour bomb. */
+  longest: number;
+  /** An L or T shape (a horizontal and a vertical run crossing) earns a wrap. */
+  crossed: boolean;
+};
+
+/** Merges runs that share a cell, so an L-shape counts as one match, not two. */
+function groupRuns(board: Board, runs: Run[]): MatchGroup[] {
+  const groups: { runs: Run[]; cells: Set<number> }[] = [];
+
+  for (const run of runs) {
+    const touching = groups.filter((group) => run.indices.some((i) => group.cells.has(i)));
+    if (touching.length === 0) {
+      groups.push({ runs: [run], cells: new Set(run.indices) });
+      continue;
+    }
+    const [target, ...rest] = touching;
+    target.runs.push(run);
+    run.indices.forEach((i) => target.cells.add(i));
+    for (const other of rest) {
+      target.runs.push(...other.runs);
+      other.cells.forEach((i) => target.cells.add(i));
+      groups.splice(groups.indexOf(other), 1);
+    }
+  }
+
+  return groups.map((group) => {
+    const first = board[group.runs[0].indices[0]]!;
+    return {
+      indices: [...group.cells],
+      color: first.color,
+      longest: Math.max(...group.runs.map((run) => run.indices.length)),
+      crossed:
+        group.runs.some((run) => run.axis === 'h') && group.runs.some((run) => run.axis === 'v'),
+    };
+  });
+}
+
+export function findMatches(board: Board): MatchGroup[] {
+  return groupRuns(board, findRuns(board));
+}
+
+const NEIGHBOURS: readonly (readonly [number, number])[] = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+/**
+ * Grows a match to every same-coloured candy orthogonally connected to it.
+ *
+ * A line of three is only ever the *trigger*: the whole touching blob of that
+ * colour goes with it, so an L with a stray tail, or a clump hanging off the
+ * end of a run, clears as one satisfying lump instead of leaving orphans that
+ * were visibly part of the same shape.
+ *
+ * Only the cleared set grows — the run metrics that decide which special is
+ * earned stay measured on the straight lines, so a sprawling blob cannot
+ * accidentally mint a colour bomb.
+ */
+export function sweepConnected(board: Board, seeds: number[], color: number): number[] {
+  const found = new Set<number>(seeds);
+  const queue = [...seeds];
+
+  while (queue.length > 0) {
+    const index = queue.shift()!;
+    const col = colOf(index);
+    const row = rowOf(index);
+
+    for (const [stepCol, stepRow] of NEIGHBOURS) {
+      const nextCol = col + stepCol;
+      const nextRow = row + stepRow;
+      if (!inBounds(nextCol, nextRow)) continue;
+
+      const next = idx(nextCol, nextRow);
+      if (found.has(next)) continue;
+
+      const tile = board[next];
+      if (!matchable(tile) || tile.color !== color) continue;
+
+      found.add(next);
+      queue.push(next);
+    }
+  }
+
+  return [...found];
+}
+
+/** A stripe sweeps along the axis the run itself lay on. */
+function stripeAxis(group: MatchGroup): 'stripedH' | 'stripedV' {
+  return new Set(group.indices.map(rowOf)).size === 1 ? 'stripedH' : 'stripedV';
+}
+
+/** Which special a group earns. Crossed shapes beat length. */
+export function rewardFor(group: MatchGroup): SpecialKind {
+  if (group.longest >= 5) return 'bomb';
+  if (group.crossed) return 'wrapped';
+  if (group.longest === 4) return stripeAxis(group);
+  return 'none';
+}
+
+export type MoveOptions = {
+  /**
+   * When set, a swept blob of at least this many candies earns a striped candy
+   * even though its longest straight run was only three.
+   *
+   * This is the game's generosity dial. Specials are what make a board feel
+   * alive, but the honest rules produce roughly one every nine moves — far too
+   * sparse for someone still learning to read the board. The screen turns this
+   * on for the opening moves and again whenever a player has gone a while
+   * without one, so line blasts stay a regular event instead of a rarity.
+   */
+  generousAt?: number;
+
+  /**
+   * Chance, per refilled candy, of copying a neighbour's colour instead of
+   * rolling a fresh one.
+   *
+   * A uniformly random refill is the reason chain reactions feel rare: every
+   * new candy is independent, so a follow-on match is pure luck. Nudging
+   * refills to clump makes cascades a regular event without touching the
+   * matching rules, and because it only ever affects candies falling in from
+   * off-screen, the player can never tell it happened.
+   */
+  cascadeBias?: number;
+};
+
+/**
+ * A hard ceiling on chain length.
+ *
+ * `cascadeBias` makes each refill more likely to match, which in principle can
+ * keep a board resolving for a very long time. This bounds the worst case so a
+ * single swap can never lock the screen up mid-animation.
+ */
+const MAX_CASCADE = 14;
+
+// ------------------------------------------------------- special blasts --
+
+/** One special going off. The screen turns each of these into its own effect. */
+export type Blast = { kind: Exclude<SpecialKind, 'none'>; index: number; color: number };
+
+const rowIndices = (row: number) => Array.from({ length: COLS }, (_, col) => idx(col, row));
+const colIndices = (col: number) => Array.from({ length: ROWS }, (_, row) => idx(col, row));
+
+function areaIndices(center: number, radius: number): number[] {
+  const out: number[] = [];
+  const c = colOf(center);
+  const r = rowOf(center);
+  for (let dc = -radius; dc <= radius; dc++) {
+    for (let dr = -radius; dr <= radius; dr++) {
+      if (inBounds(c + dc, r + dr)) out.push(idx(c + dc, r + dr));
+    }
+  }
+  return out;
+}
+
+function blastRadius(board: Board, index: number, kind: Exclude<SpecialKind, 'none'>): number[] {
+  switch (kind) {
+    case 'stripedH':
+      return rowIndices(rowOf(index));
+    case 'stripedV':
+      return colIndices(colOf(index));
+    case 'wrapped':
+      return areaIndices(index, 1);
+    case 'bomb': {
+      // A bomb detonated by the cascade (rather than swapped) takes the colour
+      // it is sitting next to; on its own it just clears its immediate area.
+      const tile = board[index];
+      return tile ? areaIndices(index, 1) : [];
+    }
+  }
+}
+
+/**
+ * Grows a set of doomed cells until no special inside it is left unfired —
+ * this is what makes one striped candy set off the wrapped candy it hits, and
+ * that one set off the next. Returns the blasts in detonation order so the
+ * screen can stagger their particles and haptics.
+ */
+function detonate(board: Board, seeds: Iterable<number>, forced: Blast[] = []) {
+  const cleared = new Set<number>(seeds);
+  const blasts: Blast[] = [];
+  const fired = new Set<number>();
+  const queue: number[] = [...cleared];
+
+  for (const blast of forced) {
+    fired.add(blast.index);
+    blasts.push(blast);
+    for (const i of blastRadius(board, blast.index, blast.kind)) {
+      if (!cleared.has(i)) {
+        cleared.add(i);
+        queue.push(i);
+      }
+    }
+  }
+
+  while (queue.length > 0) {
+    const index = queue.shift()!;
+    const tile = board[index];
+    if (!tile || tile.special === 'none' || fired.has(index)) continue;
+
+    fired.add(index);
+    blasts.push({ kind: tile.special, index, color: tile.color });
+    for (const i of blastRadius(board, index, tile.special)) {
+      if (!cleared.has(i)) {
+        cleared.add(i);
+        queue.push(i);
+      }
+    }
+  }
+
+  return { cleared, blasts };
+}
+
+/** Every cell holding a given colour — the colour bomb's payload. */
+function indicesOfColor(board: Board, color: number): number[] {
+  const out: number[] = [];
+  board.forEach((tile, i) => {
+    if (tile && tile.special !== 'bomb' && tile.color === color) out.push(i);
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------- steps --
+
+export type ClearPhase = {
+  /** 1 for the swap itself, 2+ for each cascade it sets off. */
+  cascade: number;
+  cleared: number[];
+  blasts: Blast[];
+  created: {
+    index: number;
+    special: Exclude<SpecialKind, 'none'>;
+    color: number;
+    /** Granted by the generosity rule rather than earned by a run. */
+    bonus: boolean;
+  }[];
+  /** Size of each colour match, largest first — drives the match haptic. */
+  groupSizes: number[];
+  points: number;
+};
+
+export type FallPhase = {
+  board: Board;
+  /** How many tiles actually moved — the drop haptic scales with this. */
+  moved: number;
+  /** Longest fall in cells, so the animation and its haptic can last longer. */
+  distance: number;
+};
+
+export type CascadeStep = { clear: ClearPhase; boardAfterClear: Board; fall: FallPhase };
+
+export type MoveResult = {
+  steps: CascadeStep[];
+  board: Board;
+  points: number;
+  /** Deepest cascade reached — 1 is a plain match, 4+ is worth celebrating. */
+  cascade: number;
+};
+
+const POINTS_PER_TILE = 60;
+/** Each extra cascade level is worth half again as much as the last. */
+const cascadeMultiplier = (level: number) => 1 + (level - 1) * 0.5;
+
+/**
+ * Colour for a candy falling in from off-screen. See `cascadeBias`: most of the
+ * time this is a fresh roll, but some of the time it copies a settled
+ * neighbour so the incoming candies arrive already clumped.
+ */
+function refillColor(board: Board, col: number, row: number, rng: Rng, bias: number): number {
+  if (bias > 0 && rng() < bias) {
+    const below = row + 1 < ROWS ? board[idx(col, row + 1)] : null;
+    const left = col > 0 ? board[idx(col - 1, row)] : null;
+    // Specials are excluded: copying a colour bomb's nominal colour would be
+    // meaningless, and copying a stripe's would quietly seed more of them.
+    const source = [below, left].find((tile) => tile && tile.special === 'none');
+    if (source) return source.color;
+  }
+  return Math.floor(rng() * COLORS);
+}
+
+function applyGravity(board: Board, rng: Rng, bias = 0): FallPhase {
+  const next: Board = [...board];
+  let moved = 0;
+  let distance = 0;
+
+  for (let col = 0; col < COLS; col++) {
+    let write = ROWS - 1;
+    for (let row = ROWS - 1; row >= 0; row--) {
+      const tile = next[idx(col, row)];
+      if (!tile) continue;
+      if (write !== row) {
+        next[idx(col, write)] = tile;
+        next[idx(col, row)] = null;
+        moved++;
+        distance = Math.max(distance, write - row);
+      }
+      write--;
+    }
+    // Everything above `write` is empty and refills from off the top. Filled
+    // bottom-up so `refillColor` can see the candy that landed below it.
+    for (let row = write; row >= 0; row--) {
+      next[idx(col, row)] = makeTile(refillColor(next, col, row, rng, bias));
+      moved++;
+      distance = Math.max(distance, row + 1);
+    }
+  }
+
+  return { board: next, moved, distance };
+}
+
+/**
+ * Runs the board to a standstill: match, blow up whatever the match touched,
+ * drop, refill, repeat. `forced` carries the blast a special-on-special swap
+ * produces, which fires before any colour matching happens.
+ */
+function settle(
+  board: Board,
+  rng: Rng,
+  forced: Blast[],
+  seeds: number[] = [],
+  options: MoveOptions = {},
+): MoveResult {
+  const steps: CascadeStep[] = [];
+  let working = board;
+  let points = 0;
+  let cascade = 0;
+  let pendingForced = forced;
+  let pendingSeeds = seeds;
+
+  for (;;) {
+    const groups = pendingForced.length > 0 || pendingSeeds.length > 0 ? [] : findMatches(working);
+    if (groups.length === 0 && pendingForced.length === 0 && pendingSeeds.length === 0) break;
+
+    cascade++;
+    const multiplier = cascadeMultiplier(cascade);
+
+    // Specials are placed after the clear, at the cell that earned them.
+    const created: ClearPhase['created'] = [];
+    const seedSet = new Set<number>(pendingSeeds);
+    const sweptSizes: number[] = [];
+    for (const group of groups) {
+      const swept = sweepConnected(working, group.indices, group.color);
+      swept.forEach((i) => seedSet.add(i));
+      sweptSizes.push(swept.length);
+
+      // Measured on the runs, not the swept blob — see `sweepConnected`.
+      let reward = rewardFor(group);
+      let bonus = false;
+      if (
+        reward === 'none' &&
+        options.generousAt !== undefined &&
+        swept.length >= options.generousAt
+      ) {
+        reward = stripeAxis(group);
+        bonus = true;
+      }
+      if (reward !== 'none') {
+        created.push({ index: pickRewardCell(group), special: reward, color: group.color, bonus });
+      }
+    }
+
+    const { cleared, blasts } = detonate(working, seedSet, pendingForced);
+    pendingForced = [];
+    pendingSeeds = [];
+
+    // A cell that earned a special keeps it instead of being emptied.
+    const survivors = new Map(created.map((entry) => [entry.index, entry]));
+    const afterClear: Board = working.map((tile, i) => {
+      const reward = survivors.get(i);
+      if (reward) return makeTile(reward.color, reward.special);
+      return cleared.has(i) ? null : tile;
+    });
+
+    const groupSizes = sweptSizes.sort((a, b) => b - a);
+    const stepPoints = Math.round(cleared.size * POINTS_PER_TILE * multiplier);
+    points += stepPoints;
+
+    const fall = applyGravity(afterClear, rng, options.cascadeBias ?? 0);
+    steps.push({
+      clear: {
+        cascade,
+        cleared: [...cleared],
+        blasts,
+        created,
+        groupSizes,
+        points: stepPoints,
+      },
+      boardAfterClear: afterClear,
+      fall,
+    });
+
+    working = fall.board;
+    if (cascade >= MAX_CASCADE) break;
+  }
+
+  return { steps, board: working, points, cascade };
+}
+
+/** Where a special lands: the crossing of an L, otherwise the middle of the run. */
+function pickRewardCell(group: MatchGroup): number {
+  if (group.crossed) {
+    const counts = new Map<number, number>();
+    for (const i of group.indices) {
+      const sameRow = group.indices.filter((j) => rowOf(j) === rowOf(i)).length;
+      const sameCol = group.indices.filter((j) => colOf(j) === colOf(i)).length;
+      counts.set(i, sameRow + sameCol);
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1])[0][0];
+  }
+  return group.indices[Math.floor(group.indices.length / 2)];
+}
+
+// ----------------------------------------------------------------- moves --
+
+export const areAdjacent = (a: number, b: number) =>
+  Math.abs(colOf(a) - colOf(b)) + Math.abs(rowOf(a) - rowOf(b)) === 1;
+
+/** How two swapped specials combine — named so the UI can pick a matching effect. */
+export type ComboKind =
+  | 'none'
+  | 'bombColor'
+  | 'bombBomb'
+  | 'bombStriped'
+  | 'stripedStriped'
+  | 'stripedWrapped'
+  | 'wrappedWrapped';
+
+export type Move = MoveResult & { combo: ComboKind };
+
+/**
+ * Attempts a swap. Returns `null` when the swap is illegal — the screen plays
+ * its "reject" haptic and springs the tiles back.
+ */
+export function resolveMove(
+  board: Board,
+  a: number,
+  b: number,
+  rng: Rng,
+  options: MoveOptions = {},
+): Move | null {
+  if (!areAdjacent(a, b)) return null;
+  const first = board[a];
+  const second = board[b];
+  if (!first || !second) return null;
+
+  const swapped: Board = [...board];
+  swapped[a] = second;
+  swapped[b] = first;
+
+  const combo = comboOf(first, second);
+  if (combo !== 'none') {
+    const { forced, seeds } = comboPayload(swapped, a, b, first, second, combo);
+    return { ...settle(swapped, rng, forced, seeds, options), combo };
+  }
+
+  // A plain swap only stands if it actually makes a match.
+  if (findMatches(swapped).length === 0) return null;
+  return { ...settle(swapped, rng, [], [], options), combo: 'none' };
+}
+
+function comboOf(first: Tile, second: Tile): ComboKind {
+  const kinds = [first.special, second.special];
+  const has = (kind: SpecialKind) => kinds.includes(kind);
+  const striped = kinds.filter((k) => k === 'stripedH' || k === 'stripedV').length;
+
+  if (first.special === 'bomb' && second.special === 'bomb') return 'bombBomb';
+  if (has('bomb') && striped === 1) return 'bombStriped';
+  if (has('bomb') && has('wrapped')) return 'bombStriped';
+  if (has('bomb')) return 'bombColor';
+  if (striped === 2) return 'stripedStriped';
+  if (striped === 1 && has('wrapped')) return 'stripedWrapped';
+  if (first.special === 'wrapped' && second.special === 'wrapped') return 'wrappedWrapped';
+  return 'none';
+}
+
+/** Turns a special-on-special swap into the blasts it should set off. */
+function comboPayload(
+  board: Board,
+  a: number,
+  b: number,
+  first: Tile,
+  second: Tile,
+  combo: ComboKind,
+): { forced: Blast[]; seeds: number[] } {
+  // After the swap, `first` sits at b and `second` at a.
+  const bombAt = first.special === 'bomb' ? b : a;
+  const otherAt = bombAt === b ? a : b;
+  const other = bombAt === b ? second : first;
+
+  switch (combo) {
+    case 'bombBomb':
+      // Both bombs go: the whole board clears.
+      return { forced: [], seeds: board.map((_, i) => i) };
+
+    case 'bombColor':
+      return { forced: [], seeds: [bombAt, ...indicesOfColor(board, other.color)] };
+
+    case 'bombStriped': {
+      // Every candy of the partner's colour becomes a special and fires at once.
+      const targets = indicesOfColor(board, other.color);
+      const kind = other.special === 'wrapped' ? 'wrapped' : 'stripedH';
+      return {
+        forced: targets.map((index) => ({ kind, index, color: other.color })),
+        seeds: [bombAt, otherAt],
+      };
+    }
+
+    case 'stripedStriped':
+      // A cross: the full row and the full column through the swap.
+      return {
+        forced: [
+          { kind: 'stripedH', index: a, color: first.color },
+          { kind: 'stripedV', index: a, color: first.color },
+        ],
+        seeds: [a, b],
+      };
+
+    case 'stripedWrapped': {
+      // A three-wide band sweeping both ways.
+      const forced: Blast[] = [];
+      for (let d = -1; d <= 1; d++) {
+        const row = rowOf(a) + d;
+        const col = colOf(a) + d;
+        if (row >= 0 && row < ROWS)
+          forced.push({ kind: 'stripedH', index: idx(colOf(a), row), color: first.color });
+        if (col >= 0 && col < COLS)
+          forced.push({ kind: 'stripedV', index: idx(col, rowOf(a)), color: first.color });
+      }
+      return { forced, seeds: [a, b] };
+    }
+
+    case 'wrappedWrapped':
+      return {
+        forced: [{ kind: 'wrapped', index: a, color: first.color }],
+        seeds: areaIndices(a, 2),
+      };
+
+    default:
+      return { forced: [], seeds: [] };
+  }
+}
+
+// ----------------------------------------------------------------- setup --
+
+/** True when at least one legal swap exists, so the player is never stuck. */
+export function hasValidMove(board: Board): boolean {
+  for (let i = 0; i < board.length; i++) {
+    const tile = board[i];
+    if (tile && tile.special !== 'none') return true;
+    for (const j of [i + 1, i + COLS]) {
+      if (j >= board.length || !areAdjacent(i, j)) continue;
+      const trial: Board = [...board];
+      trial[i] = board[j];
+      trial[j] = board[i];
+      if (findMatches(trial).length > 0) return true;
+    }
+  }
+  return false;
+}
+
+export type MoveHint = { from: number; to: number; score: number };
+
+/**
+ * The most rewarding legal swap on the board, used to nudge a stuck player.
+ *
+ * Scored on the immediate result only — matches, swept size, whether a special
+ * is earned — rather than by simulating the whole cascade. A hint is checked
+ * against every adjacent pair on the board, so it has to be cheap; and pointing
+ * at a move that pays off *visibly* teaches more than pointing at one that
+ * happens to trigger a long chain the player cannot see coming.
+ */
+export function findBestMove(board: Board, options: MoveOptions = {}): MoveHint | null {
+  let best: MoveHint | null = null;
+
+  const consider = (from: number, to: number) => {
+    const first = board[from];
+    const second = board[to];
+    if (!first || !second) return;
+
+    const swapped: Board = [...board];
+    swapped[from] = second;
+    swapped[to] = first;
+
+    // A special-on-special swap is always the most interesting thing available.
+    if (first.special !== 'none' && second.special !== 'none') {
+      const score = 1000;
+      if (!best || score > best.score) best = { from, to, score };
+      return;
+    }
+
+    const groups = findMatches(swapped);
+    if (groups.length === 0) return;
+
+    let score = 0;
+    for (const group of groups) {
+      const swept = sweepConnected(swapped, group.indices, group.color).length;
+      score += swept;
+      if (rewardFor(group) !== 'none') score += 12;
+      else if (options.generousAt !== undefined && swept >= options.generousAt) score += 8;
+    }
+
+    if (!best || score > best.score) best = { from, to, score };
+  };
+
+  for (let i = 0; i < board.length; i++) {
+    if (colOf(i) < COLS - 1) consider(i, i + 1);
+    if (rowOf(i) < ROWS - 1) consider(i, i + COLS);
+  }
+
+  return best;
+}
+
+export function createBoard(rng: Rng): Board {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const board: Board = new Array(COLS * ROWS).fill(null);
+    for (let row = 0; row < ROWS; row++) {
+      for (let col = 0; col < COLS; col++) {
+        // Reject a colour that would complete a line, so the board opens quiet.
+        const banned = new Set<number>();
+        const left = board[idx(col - 1, row)];
+        const left2 = board[idx(col - 2, row)];
+        if (col >= 2 && left && left2 && left.color === left2.color) banned.add(left.color);
+        const up = board[idx(col, row - 1)];
+        const up2 = board[idx(col, row - 2)];
+        if (row >= 2 && up && up2 && up.color === up2.color) banned.add(up.color);
+
+        const choices = Array.from({ length: COLORS }, (_, c) => c).filter((c) => !banned.has(c));
+        board[idx(col, row)] = makeTile(choices[Math.floor(rng() * choices.length)]);
+      }
+    }
+    if (hasValidMove(board)) return board;
+  }
+  throw new Error('Could not generate a solvable board');
+}
+
+/** Reshuffles the colours in place when the player runs out of legal swaps. */
+export function shuffleBoard(board: Board, rng: Rng): Board {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const tiles = board.filter((tile): tile is Tile => tile !== null);
+    for (let i = tiles.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [tiles[i], tiles[j]] = [tiles[j], tiles[i]];
+    }
+    if (findMatches(tiles).length === 0 && hasValidMove(tiles)) return tiles;
+  }
+  return createBoard(rng);
+}

--- a/docs/web-app/src/screens/games/candy/haptics.ts
+++ b/docs/web-app/src/screens/games/candy/haptics.ts
@@ -1,0 +1,262 @@
+import { PatternComposer, Settings } from 'pulsar-haptics';
+import type { HapticPattern } from 'pulsar-haptics';
+
+/**
+ * The game's haptic vocabulary.
+ *
+ * Two things shape every pattern here. First, web haptics are pulse-width
+ * modulated: `intensity` stretches each vibration shot and `frequency` tightens
+ * the gaps between them, so "heavy" reads as long shots and "buzzy" reads as
+ * tight ones. Second, the Vibration API owns a single global timeline — playing
+ * a pattern *cancels* whatever was mid-flight rather than layering on top of
+ * it. A cascade fires a dozen events inside a second, so without arbitration
+ * the finale of a five-chain would be cut off by a stray tile-landing tick.
+ * `playHaptic` therefore takes a priority and refuses to interrupt anything
+ * more important that is still playing.
+ */
+
+/** Higher wins. A landing tick must never talk over a combo finale. */
+export const Priority = {
+  tick: 0,
+  move: 1,
+  match: 2,
+  special: 3,
+  finale: 4,
+} as const;
+
+export type HapticPriority = (typeof Priority)[keyof typeof Priority];
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+let playingUntil = 0;
+let playingPriority = -1;
+
+/** Total wall-clock length of a pattern — how long it will hold the timeline. */
+export function patternDuration(pattern: HapticPattern): number {
+  return pattern.reduce((end, segment) => Math.max(end, segment.timestamp + segment.duration), 0);
+}
+
+export function playHaptic(pattern: HapticPattern, priority: HapticPriority): boolean {
+  if (pattern.length === 0) return false;
+
+  const now = performance.now();
+  if (now < playingUntil && priority < playingPriority) return false;
+
+  const composer = new PatternComposer();
+  composer.parse(pattern);
+  const played = composer.play();
+
+  playingUntil = now + patternDuration(pattern);
+  playingPriority = priority;
+  return played;
+}
+
+/** Silences the motor and clears the arbitration state — call this on unmount. */
+export function resetHaptics() {
+  playingUntil = 0;
+  playingPriority = -1;
+  Settings.stopHaptics();
+}
+
+export const hapticsAvailable = () => Settings.isHapticsAvailable();
+
+// ------------------------------------------------------------- vocabulary --
+
+/** Picking a candy up: the lightest thing the motor can say. */
+export const selectPattern: HapticPattern = [
+  { type: 'pulse', timestamp: 0, duration: 24, intensity: 0.35, frequency: 0.55 },
+];
+
+/**
+ * The swap itself. A rising-then-falling line reads as one candy sliding past
+ * another rather than as two separate taps.
+ */
+export const swapPattern: HapticPattern = [
+  {
+    type: 'line',
+    timestamp: 0,
+    duration: 110,
+    intensity: [
+      { time: 0, value: 0.3 },
+      { time: 55, value: 0.85 },
+      { time: 110, value: 0.35 },
+    ],
+    frequency: [
+      { time: 0, value: 0.45 },
+      { time: 110, value: 0.9 },
+    ],
+  },
+];
+
+/** Illegal swap: two blunt, low knocks — the universal "nope". */
+export const rejectPattern: HapticPattern = [
+  { type: 'pulse', timestamp: 0, duration: 70, intensity: 0.95, frequency: 0.12 },
+  { type: 'pulse', timestamp: 105, duration: 70, intensity: 0.95, frequency: 0.12 },
+];
+
+/**
+ * A colour match. Bigger groups hit harder and last longer; deeper cascades sit
+ * higher, so a five-chain climbs instead of repeating one thump.
+ */
+export function matchPattern(tiles: number, cascade: number): HapticPattern {
+  const weight = clamp01((tiles - 3) / 9);
+  const climb = clamp01((cascade - 1) / 5);
+  const duration = Math.round(64 + weight * 90);
+
+  const pattern: HapticPattern = [
+    {
+      type: 'pulse',
+      timestamp: 0,
+      duration,
+      intensity: clamp01(0.5 + weight * 0.45),
+      frequency: clamp01(0.42 + climb * 0.5),
+    },
+  ];
+
+  // A big group gets a short echo, so "huge" is distinguishable from "loud".
+  if (tiles >= 6) {
+    pattern.push({
+      type: 'pulse',
+      timestamp: duration + 45,
+      duration: 50,
+      intensity: clamp01(0.45 + weight * 0.3),
+      frequency: 0.75,
+    });
+  }
+
+  return pattern;
+}
+
+/**
+ * Candies settling after a clear: a thinning scatter of ticks rather than one
+ * block, so the hand reads "several things landed" instead of "one big event".
+ */
+export function landingPattern(tiles: number, distance: number): HapticPattern {
+  const ticks = Math.min(6, Math.max(2, Math.round(tiles / 5)));
+  const span = Math.min(320, 90 + distance * 34);
+
+  return Array.from({ length: ticks }, (_, i) => {
+    const progress = i / Math.max(1, ticks - 1);
+    return {
+      type: 'pulse' as const,
+      // Slightly uneven spacing — perfectly regular ticks read as a machine.
+      timestamp: Math.round(progress * span + (i % 2) * 12),
+      duration: 26,
+      intensity: clamp01(0.42 - progress * 0.22),
+      frequency: 0.7,
+    };
+  });
+}
+
+/** A striped candy being *made* — a quick two-step, the stripe snapping in. */
+export const stripedBornPattern: HapticPattern = [
+  { type: 'pulse', timestamp: 0, duration: 34, intensity: 0.55, frequency: 0.85 },
+  { type: 'pulse', timestamp: 62, duration: 54, intensity: 0.9, frequency: 0.7 },
+];
+
+export const wrappedBornPattern: HapticPattern = [
+  { type: 'continuous', timestamp: 0, duration: 44 },
+  { type: 'pulse', timestamp: 78, duration: 62, intensity: 0.85, frequency: 0.35 },
+];
+
+export const bombBornPattern: HapticPattern = [
+  {
+    type: 'line',
+    timestamp: 0,
+    duration: 260,
+    intensity: [
+      { time: 0, value: 0.25 },
+      { time: 260, value: 1 },
+    ],
+    frequency: [
+      { time: 0, value: 0.3 },
+      { time: 260, value: 0.95 },
+    ],
+  },
+  { type: 'continuous', timestamp: 275, duration: 55 },
+];
+
+/**
+ * A stripe firing. The beam crosses the board in a straight line, so the haptic
+ * is a single sweep whose gaps tighten as it travels — a zip, not a bang.
+ */
+export const stripeSweepPattern: HapticPattern = [
+  {
+    type: 'line',
+    timestamp: 0,
+    duration: 240,
+    intensity: [
+      { time: 0, value: 0.4 },
+      { time: 70, value: 1 },
+      { time: 240, value: 0.2 },
+    ],
+    frequency: [
+      { time: 0, value: 0.95 },
+      { time: 240, value: 0.35 },
+    ],
+  },
+];
+
+/** A wrapped candy detonating: the classic thump-THUMP double blast. */
+export const wrappedBlastPattern: HapticPattern = [
+  { type: 'continuous', timestamp: 0, duration: 52 },
+  { type: 'pulse', timestamp: 130, duration: 120, intensity: 1, frequency: 0.22 },
+];
+
+/** A colour bomb: hard attack, then a rumble that decays like a shockwave. */
+export const bombBlastPattern: HapticPattern = [
+  { type: 'continuous', timestamp: 0, duration: 70 },
+  {
+    type: 'line',
+    timestamp: 80,
+    duration: 420,
+    intensity: [
+      { time: 0, value: 1 },
+      { time: 420, value: 0.15 },
+    ],
+    frequency: [
+      { time: 0, value: 0.8 },
+      { time: 420, value: 0.2 },
+    ],
+  },
+];
+
+/**
+ * The combo finale, deliberately built to the same clock as the particle burst:
+ * a crescendo while the sparks gather (0-520ms), the hit at the moment the
+ * explosion lands (520ms), then thinning sparkle as the confetti falls away.
+ * `FINALE_MS` is exported so the visual and the pattern cannot drift apart.
+ */
+export const FINALE_MS = 980;
+
+export function finalePattern(level: number): HapticPattern {
+  const power = clamp01((level - 2) / 5);
+  const peak = clamp01(0.7 + power * 0.3);
+
+  const sparkle: HapticPattern = [0, 1, 2, 3].map((i) => ({
+    type: 'pulse' as const,
+    timestamp: 640 + i * 84,
+    duration: 30,
+    intensity: clamp01((0.5 - i * 0.1) * (0.7 + power * 0.5)),
+    frequency: 0.9,
+  }));
+
+  return [
+    {
+      type: 'line',
+      timestamp: 0,
+      duration: 520,
+      intensity: [
+        { time: 0, value: 0.2 },
+        { time: 380, value: peak * 0.75 },
+        { time: 520, value: peak },
+      ],
+      frequency: [
+        { time: 0, value: 0.28 },
+        { time: 520, value: 0.95 },
+      ],
+    },
+    { type: 'continuous', timestamp: 524, duration: 64 + Math.round(power * 40) },
+    ...sparkle,
+  ];
+}

--- a/docs/web-app/src/screens/games/candy/palette.ts
+++ b/docs/web-app/src/screens/games/candy/palette.ts
@@ -1,0 +1,37 @@
+/**
+ * The six candies.
+ *
+ * Each one carries a shape as well as a colour: matching purely on hue is
+ * unplayable for the ~8% of players with a colour-vision deficiency, and the
+ * silhouette also makes a fast cascade readable at a glance.
+ */
+
+export type CandyShape = 'circle' | 'square' | 'diamond' | 'hex' | 'drop' | 'star';
+
+export type Candy = {
+  name: string;
+  color: string;
+  /** Lighter tone used for the inner highlight. */
+  sheen: string;
+  shape: CandyShape;
+};
+
+export const CANDIES: Candy[] = [
+  { name: 'Cherry', color: '#FF5A5F', sheen: '#FFB2B4', shape: 'circle' },
+  { name: 'Orange', color: '#FF9F45', sheen: '#FFD3A6', shape: 'square' },
+  { name: 'Lemon', color: '#FFC93C', sheen: '#FFE9A8', shape: 'diamond' },
+  { name: 'Lime', color: '#3DD68C', sheen: '#AFEFD0', shape: 'hex' },
+  { name: 'Blueberry', color: '#38ACDD', sheen: '#B5E1F1', shape: 'drop' },
+  { name: 'Grape', color: '#A06BE8', sheen: '#D8C2F5', shape: 'star' },
+];
+
+/** `#RRGGBB` to the 0..1 triple the particle backends want. */
+export function toRgb01(hex: string): [number, number, number] {
+  const value = Number.parseInt(hex.slice(1), 16);
+  return [((value >> 16) & 255) / 255, ((value >> 8) & 255) / 255, (value & 255) / 255];
+}
+
+export const candyRgb: [number, number, number][] = CANDIES.map((candy) => toRgb01(candy.color));
+
+/** Confetti and colour-bomb white, used when an effect has no single colour. */
+export const NEUTRAL_RGB: [number, number, number] = [1, 0.95, 0.75];

--- a/docs/web-app/src/screens/games/candy/particles/canvas.ts
+++ b/docs/web-app/src/screens/games/candy/particles/canvas.ts
@@ -1,0 +1,245 @@
+import { BurstKind, LOOP_STALE_MS, MAX_PARTICLES, type Burst, type ParticleField } from './types';
+
+/**
+ * Canvas 2D stand-in for browsers without WebGPU (Safari before 26, Firefox
+ * without the flag). It follows the same rules as the shader — same speeds,
+ * lifetimes, gravity and flutter — so the game looks like itself everywhere,
+ * just with a smaller pool and no additive glow.
+ */
+
+type P = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  spin: number;
+  angle: number;
+  kind: number;
+  drag: number;
+  gravity: number;
+  seed: number;
+  color: string;
+};
+
+/** Half the GPU pool: 2D fill calls, not vertices, are the limit here. */
+const POOL = Math.min(1200, MAX_PARTICLES);
+
+const rgb = (color: readonly [number, number, number], tint: number) =>
+  `rgb(${Math.round(Math.min(255, color[0] * 255 * tint))} ${Math.round(
+    Math.min(255, color[1] * 255 * tint),
+  )} ${Math.round(Math.min(255, color[2] * 255 * tint))})`;
+
+const rainbow = (t: number) =>
+  `hsl(${Math.round(t * 360)} 90% ${58 + Math.round(Math.random() * 12)}%)`;
+
+export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2D context unavailable');
+
+  const pool: P[] = Array.from({ length: POOL }, () => ({
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    life: 0,
+    maxLife: 1,
+    size: 0,
+    spin: 0,
+    angle: 0,
+    kind: 0,
+    drag: 0,
+    gravity: 0,
+    seed: 0,
+    color: '#fff',
+  }));
+
+  let cursor = 0;
+  let width = canvas.clientWidth || 1;
+  let height = canvas.clientHeight || 1;
+  let dpr = 1;
+  let elapsed = 0;
+  let destroyed = false;
+  /** Seeded so bursts emitted before the very first frame are still accepted. */
+  let lastFrameAt = performance.now();
+  let originX = 0;
+  let originY = 0;
+
+  function spawn(burst: Burst) {
+    const count = Math.min(burst.count, POOL);
+    for (let i = 0; i < count; i++) {
+      const p = pool[cursor];
+      cursor = (cursor + 1) % POOL;
+
+      const angle = Math.random() * Math.PI * 2;
+      const spread = (Math.random() - 0.5) * 0.55;
+      const dirX = burst.dirX ?? 0;
+      const dirY = burst.dirY ?? -1;
+      const streak = burst.kind === BurstKind.streak;
+
+      const hx = streak ? dirX + dirY * spread : Math.cos(angle);
+      const hy = streak ? dirY - dirX * spread : Math.sin(angle);
+      const r = Math.random();
+
+      const speed =
+        burst.kind === BurstKind.pop
+          ? (70 + r * 190) * (0.55 + burst.energy)
+          : burst.kind === BurstKind.explosion
+            ? (150 + r * 460) * (0.6 + burst.energy)
+            : burst.kind === BurstKind.confetti
+              ? 90 + r * 320
+              : streak
+                ? (420 + r * 520) * (0.6 + burst.energy)
+                : 50 + r * 130;
+
+      p.size =
+        burst.kind === BurstKind.pop
+          ? 2.6 + Math.random() * 4.2
+          : burst.kind === BurstKind.explosion
+            ? 4 + Math.random() * 9
+            : burst.kind === BurstKind.confetti
+              ? 5 + Math.random() * 5.5
+              : streak
+                ? 3 + Math.random() * 5
+                : 2 + Math.random() * 3.4;
+
+      p.maxLife =
+        burst.kind === BurstKind.pop
+          ? 0.34 + Math.random() * 0.3
+          : burst.kind === BurstKind.explosion
+            ? 0.5 + Math.random() * 0.55
+            : burst.kind === BurstKind.confetti
+              ? 1.25 + Math.random() * 0.9
+              : streak
+                ? 0.28 + Math.random() * 0.3
+                : 0.4 + Math.random() * 0.35;
+
+      p.gravity =
+        burst.kind === BurstKind.pop
+          ? 620
+          : burst.kind === BurstKind.explosion
+            ? 380
+            : burst.kind === BurstKind.confetti
+              ? 240
+              : streak
+                ? 0
+                : 90;
+
+      p.drag =
+        burst.kind === BurstKind.pop
+          ? 2.4
+          : burst.kind === BurstKind.explosion
+            ? 1.5
+            : burst.kind === BurstKind.confetti
+              ? 1.1
+              : streak
+                ? 3.4
+                : 2.2;
+
+      p.x = burst.x + Math.cos(angle) * (streak ? i * 1.5 : Math.random() * 9);
+      p.y = burst.y + Math.sin(angle) * (streak ? 0 : Math.random() * 9);
+      p.vx = hx * speed;
+      p.vy = hy * speed;
+      p.life = p.maxLife;
+      p.kind = burst.kind;
+      p.spin = (Math.random() - 0.5) * 3.2 * (burst.kind === BurstKind.confetti ? 3.5 : 1);
+      p.angle = Math.random() * Math.PI * 2;
+      p.seed = Math.random() * 100;
+      p.color =
+        burst.kind === BurstKind.confetti
+          ? rainbow(Math.random())
+          : rgb(burst.color, 0.78 + Math.random() * 0.44);
+    }
+  }
+
+  return {
+    backend: 'canvas',
+
+    resize(nextWidth, nextHeight) {
+      // Called from the frame loop, so this must be free when nothing changed:
+      // assigning `canvas.width` reallocates the backing store and wipes the
+      // canvas, which at 60fps would erase the particles it is meant to show.
+      const w = Math.max(1, nextWidth);
+      const h = Math.max(1, nextHeight);
+      if (w === width && h === height) return;
+
+      width = w;
+      height = h;
+      dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+    },
+
+    setOrigin(x, y) {
+      originX = x;
+      originY = y;
+    },
+
+    emit(burst) {
+      if (destroyed) return;
+      // See `LOOP_STALE_MS`: only spawn while frames are genuinely running.
+      if (performance.now() - lastFrameAt > LOOP_STALE_MS) return;
+      // Board coordinates in, canvas coordinates out — see `setOrigin`.
+      spawn({ ...burst, x: burst.x + originX, y: burst.y + originY });
+    },
+
+    frame(dt) {
+      if (destroyed) return;
+      lastFrameAt = performance.now();
+      elapsed += dt;
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+
+      for (const p of pool) {
+        if (p.life <= 0) continue;
+
+        const damping = Math.max(0, 1 - p.drag * dt);
+        const flutter =
+          p.kind === BurstKind.confetti ? Math.sin(elapsed * 5.5 + p.seed) * 130 * dt : 0;
+
+        p.vx = p.vx * damping + flutter;
+        p.vy = p.vy * damping + p.gravity * dt;
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.life -= dt;
+        p.angle += p.spin * dt * 5;
+        if (p.life <= 0) continue;
+
+        const age = 1 - p.life / p.maxLife;
+        const fade = 1 - Math.max(0, (age - 0.45) / 0.55);
+        const grow = Math.min(1, age / 0.12) * (1 - Math.max(0, (age - 0.55) / 0.45) * 0.75);
+        const size = p.size * (0.35 + grow);
+
+        ctx.globalAlpha = Math.max(0, Math.min(1, fade));
+        ctx.fillStyle = p.color;
+
+        if (p.kind === BurstKind.confetti) {
+          ctx.save();
+          ctx.translate(p.x, p.y);
+          ctx.rotate(p.angle);
+          ctx.fillRect(-size, -size * 0.42, size * 2, size * 0.84);
+          ctx.restore();
+        } else {
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, size, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+
+      ctx.globalAlpha = 1;
+    },
+
+    clear() {
+      for (const p of pool) p.life = 0;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+    },
+
+    destroy() {
+      destroyed = true;
+    },
+  };
+}

--- a/docs/web-app/src/screens/games/candy/particles/gpu.ts
+++ b/docs/web-app/src/screens/games/candy/particles/gpu.ts
@@ -1,0 +1,422 @@
+import tgpu from 'typegpu';
+import * as d from 'typegpu/data';
+import * as std from 'typegpu/std';
+import {
+  BurstKind,
+  LOOP_STALE_MS,
+  MAX_BURSTS,
+  MAX_PARTICLES,
+  type Burst,
+  type ParticleField,
+} from './types';
+
+/**
+ * The WebGPU particle field, written in TypeGPU.
+ *
+ * Both halves of the simulation live on the GPU. Spawning is a compute pass:
+ * the CPU appends a *description* of each burst (origin, colour, kind, energy)
+ * to a small storage array and dispatches one thread per particle to be born,
+ * so a nine-tile cascade costs one buffer write and one dispatch rather than
+ * thousands of JS object allocations. Integration is a second compute pass over
+ * the whole pool, and drawing is a single instanced draw of `MAX_PARTICLES`
+ * quads. Nothing about a burst ever round-trips back to JavaScript.
+ *
+ * The ring buffer that hands out particle slots is deliberately never allowed
+ * to wrap *inside* a burst — when a burst would straddle the end of the pool,
+ * the cursor resets to zero first. That costs a few prematurely recycled
+ * particles and buys a shader with no modulo and no atomics.
+ */
+
+const Particle = d.struct({
+  pos: d.vec2f,
+  vel: d.vec2f,
+  color: d.vec4f,
+  life: d.f32,
+  maxLife: d.f32,
+  size: d.f32,
+  spin: d.f32,
+  /** Mirrors `BurstKind`, held as f32 so the shaders never mix numeric types. */
+  kind: d.f32,
+  drag: d.f32,
+  gravity: d.f32,
+  seed: d.f32,
+});
+
+const BurstData = d.struct({
+  origin: d.vec2f,
+  dir: d.vec2f,
+  color: d.vec4f,
+  first: d.u32,
+  count: d.u32,
+  kind: d.f32,
+  energy: d.f32,
+  seed: d.f32,
+});
+
+const Frame = d.struct({
+  resolution: d.vec2f,
+  dt: d.f32,
+  time: d.f32,
+});
+
+const TAU = 6.2831855;
+
+/** Cheap hash — plenty for scattering sparks, and stable across drivers. */
+const rand = (seed: number) => {
+  'use gpu';
+  return std.fract(std.sin(seed * 12.9898) * 43758.547);
+};
+
+/** Rainbow ramp for confetti, so a finale is not one flat colour. */
+const rainbow = (t: number) => {
+  'use gpu';
+  const r = 0.5 + 0.5 * std.cos(TAU * (t + 0.0));
+  const g = 0.5 + 0.5 * std.cos(TAU * (t + 0.33));
+  const b = 0.5 + 0.5 * std.cos(TAU * (t + 0.67));
+  return d.vec3f(r, g, b);
+};
+
+/**
+ * 1 when `value` falls inside [lo, hi), else 0 — a branch-free `kind ==` test.
+ * The bounds are written as float literals on purpose: passing whole numbers
+ * makes TypeGPU infer `i32` and emit an implicit-conversion warning on every
+ * call.
+ */
+const inRange = (value: number, lo: number, hi: number) => {
+  'use gpu';
+  return std.step(lo, value) * (1 - std.step(hi, value));
+};
+
+export async function createGpuParticles(canvas: HTMLCanvasElement): Promise<ParticleField> {
+  // Device and shaders are brought up *before* the canvas context is claimed.
+  // `getContext('webgpu')` is irreversible — once it succeeds the same element
+  // can never hand out a 2D context — so anything that might fail (no adapter,
+  // a shader that will not compile on this driver) has to fail while the
+  // canvas is still untouched and the 2D fallback is still reachable.
+  const root = await tgpu.init();
+  const format = navigator.gpu.getPreferredCanvasFormat();
+
+  const particleBuffer = root.createBuffer(d.arrayOf(Particle, MAX_PARTICLES)).$usage('storage');
+  const particlesRW = particleBuffer.as('mutable');
+  const particlesRO = particleBuffer.as('readonly');
+
+  const burstBuffer = root.createBuffer(d.arrayOf(BurstData, MAX_BURSTS)).$usage('storage');
+  const burstsRO = burstBuffer.as('readonly');
+
+  const frameBuffer = root.createBuffer(Frame).$usage('uniform');
+  const frame = frameBuffer.as('uniform');
+
+  // ------------------------------------------------------------- spawn --
+
+  const spawnPipeline = root.createGuardedComputePipeline(
+    (slotInBurst: number, burstIndex: number) => {
+      'use gpu';
+      const burst = burstsRO.$[burstIndex];
+      if (slotInBurst >= burst.count) {
+        return;
+      }
+
+      const index = burst.first + slotInBurst;
+      const n = d.f32(slotInBurst);
+      const seed = burst.seed + n * 7.13;
+
+      const r1 = rand(seed);
+      const r2 = rand(seed + 11.7);
+      const r3 = rand(seed + 23.9);
+      const r4 = rand(seed + 37.1);
+
+      const energy = burst.energy;
+      const kind = burst.kind;
+      const pop = inRange(kind, -0.5, 0.5);
+      const explosion = inRange(kind, 0.5, 1.5);
+      const confetti = inRange(kind, 1.5, 2.5);
+      const streak = inRange(kind, 2.5, 3.5);
+      const spark = inRange(kind, 3.5, 4.5);
+
+      // Direction. Most kinds fly out radially; a streak is squeezed onto the
+      // axis its beam travels, with only a little spread.
+      const angle = r1 * TAU;
+      const radial = d.vec2f(std.cos(angle), std.sin(angle));
+      const spread = (r2 - 0.5) * 0.55;
+      const beam = d.vec2f(burst.dir.x + burst.dir.y * spread, burst.dir.y - burst.dir.x * spread);
+      const heading = std.mix(radial, beam, streak);
+
+      // Speed, size and lifetime per kind, blended rather than branched.
+      const speed =
+        pop * (70 + r3 * 190) * (0.55 + energy) +
+        explosion * (150 + r3 * 460) * (0.6 + energy) +
+        confetti * (90 + r3 * 320) +
+        streak * (420 + r3 * 520) * (0.6 + energy) +
+        spark * (50 + r3 * 130);
+
+      const size =
+        pop * (2.6 + r4 * 4.2) +
+        explosion * (4 + r4 * 9) +
+        confetti * (5 + r4 * 5.5) +
+        streak * (3 + r4 * 5) +
+        spark * (2 + r4 * 3.4);
+
+      const life =
+        pop * (0.34 + r2 * 0.3) +
+        explosion * (0.5 + r2 * 0.55) +
+        confetti * (1.25 + r2 * 0.9) +
+        streak * (0.28 + r2 * 0.3) +
+        spark * (0.4 + r2 * 0.35);
+
+      // Confetti hangs and flutters; sparks and beams are weightless and quick.
+      const gravity = pop * 620 + explosion * 380 + confetti * 240 + streak * 0 + spark * 90;
+      const drag = pop * 2.4 + explosion * 1.5 + confetti * 1.1 + streak * 3.4 + spark * 2.2;
+
+      // Confetti takes a rainbow of its own; everything else keeps the candy's
+      // colour, jittered slightly so a burst does not look like a flat decal.
+      const tint = 0.78 + r4 * 0.44;
+      const own = d.vec3f(burst.color.x * tint, burst.color.y * tint, burst.color.z * tint);
+      const rgb = std.mix(own, rainbow(r1), confetti);
+
+      const start = std.add(
+        burst.origin,
+        std.mul(radial, r4 * 9 * (1 - streak) + streak * n * 1.5),
+      );
+
+      // Storage writes take an explicit constructor: assigning a derived vector
+      // straight across is a reference assignment, which WGSL forbids.
+      particlesRW.$[index].pos = d.vec2f(start);
+      particlesRW.$[index].vel = d.vec2f(std.mul(heading, speed));
+      particlesRW.$[index].color = d.vec4f(rgb.x, rgb.y, rgb.z, burst.color.w);
+      particlesRW.$[index].life = life;
+      particlesRW.$[index].maxLife = life;
+      particlesRW.$[index].size = size;
+      particlesRW.$[index].spin = (r3 - 0.5) * 3.2 * (1 + confetti * 2.5);
+      particlesRW.$[index].kind = kind;
+      particlesRW.$[index].drag = drag;
+      particlesRW.$[index].gravity = gravity;
+      particlesRW.$[index].seed = r1 * 100;
+    },
+  );
+
+  // ---------------------------------------------------------- integrate --
+
+  const simulatePipeline = root.createGuardedComputePipeline((index: number) => {
+    'use gpu';
+    const p = particlesRW.$[index];
+    if (p.life <= 0) {
+      return;
+    }
+
+    const dt = frame.$.dt;
+    const damping = std.max(0, 1 - p.drag * dt);
+
+    // Confetti drifts side to side on the way down; nothing else wobbles.
+    const flutter = inRange(p.kind, 1.5, 2.5) * std.sin(frame.$.time * 5.5 + p.seed) * 130 * dt;
+
+    const vel = d.vec2f(p.vel.x * damping + flutter, p.vel.y * damping + p.gravity * dt);
+
+    particlesRW.$[index].vel = d.vec2f(vel);
+    particlesRW.$[index].pos = d.vec2f(std.add(p.pos, std.mul(vel, dt)));
+    particlesRW.$[index].life = p.life - dt;
+  });
+
+  // ------------------------------------------------------------- render --
+
+  const renderPipeline = root.createRenderPipeline({
+    vertex: (input) => {
+      'use gpu';
+      const p = particlesRO.$[input.$instanceIndex];
+
+      // Four vertices as a strip: (0,0) (1,0) (0,1) (1,1), derived with pure
+      // float maths so the shader never leans on integer bit tricks.
+      const v = d.f32(input.$vertexIndex);
+      const corner = d.vec2f(std.fract(v * 0.5) * 4 - 1, std.floor(v * 0.5) * 2 - 1);
+
+      const alive = std.step(0.00001, p.life);
+      const age = 1 - p.life / std.max(p.maxLife, 0.00001);
+
+      // Confetti is a flattened rectangle; everything else stays square.
+      const confetti = inRange(p.kind, 1.5, 2.5);
+      const shaped = d.vec2f(corner.x, corner.y * (1 - confetti * 0.58));
+
+      const angle = p.spin * age * 5;
+      const ca = std.cos(angle);
+      const sa = std.sin(angle);
+      const spun = d.vec2f(shaped.x * ca - shaped.y * sa, shaped.x * sa + shaped.y * ca);
+
+      // Sparks swell as they are born and shrink as they die.
+      const grow = std.smoothstep(0, 0.12, age) * (1 - std.smoothstep(0.55, 1, age) * 0.75);
+      const world = std.add(p.pos, std.mul(spun, p.size * (0.35 + grow) * alive));
+
+      const res = frame.$.resolution;
+      return {
+        $position: d.vec4f((world.x / res.x) * 2 - 1, 1 - (world.y / res.y) * 2, 0, 1),
+        tint: p.color,
+        uv: corner,
+        age,
+        shape: confetti,
+        alive,
+      };
+    },
+
+    fragment: (input) => {
+      'use gpu';
+      const dist = std.length(input.uv);
+
+      // Round soft sprite, or a solid card for confetti.
+      const disc = 1 - std.smoothstep(0.2, 1, dist);
+      const mask = std.mix(disc, 1 - std.smoothstep(0.92, 1.02, dist), input.shape);
+
+      const fade = 1 - std.smoothstep(0.45, 1, input.age);
+      const alpha = std.clamp(input.tint.w * mask * fade * input.alive, 0, 1);
+
+      // A hot core: the middle of a spark reads brighter than its colour.
+      const glow = 1 + (1 - std.smoothstep(0, 0.7, dist)) * 1.1 * (1 - input.shape);
+      const rgb = std.mul(d.vec3f(input.tint.x, input.tint.y, input.tint.z), alpha * glow);
+
+      return d.vec4f(rgb.x, rgb.y, rgb.z, alpha);
+    },
+
+    primitive: { topology: 'triangle-strip' },
+    targets: {
+      format,
+      blend: {
+        // Premultiplied source, so `glow` above can push a sprite past its own
+        // alpha and read as light without blowing out the pale board behind it.
+        color: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+        alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+      },
+    },
+  });
+
+  // --------------------------------------------------------------- host --
+
+  try {
+    // Compiles all three shaders. A driver-specific WGSL failure surfaces here,
+    // where the caller can still drop to Canvas 2D.
+    await Promise.all([
+      spawnPipeline.initAsync(),
+      simulatePipeline.initAsync(),
+      renderPipeline.initAsync(),
+    ]);
+  } catch (error) {
+    root.destroy();
+    throw error;
+  }
+
+  const context = canvas.getContext('webgpu');
+  if (!context) {
+    root.destroy();
+    throw new Error('WebGPU context unavailable');
+  }
+  context.configure({ device: root.device, format, alphaMode: 'premultiplied' });
+
+  let width = canvas.clientWidth || 1;
+  let height = canvas.clientHeight || 1;
+  let cursor = 0;
+  let elapsed = 0;
+  let destroyed = false;
+  /** Seeded so bursts emitted before the very first frame are still accepted. */
+  let lastFrameAt = performance.now();
+  let originX = 0;
+  let originY = 0;
+  const pending: Burst[] = [];
+
+  const field: ParticleField = {
+    backend: 'webgpu',
+
+    resize(nextWidth, nextHeight) {
+      // Called from the frame loop, so this must be free when nothing changed:
+      // assigning `canvas.width` reallocates the backing store and wipes the
+      // canvas, which at 60fps would erase the particles it is meant to show.
+      const w = Math.max(1, nextWidth);
+      const h = Math.max(1, nextHeight);
+      if (w === width && h === height) return;
+
+      width = w;
+      height = h;
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+    },
+
+    setOrigin(x, y) {
+      originX = x;
+      originY = y;
+    },
+
+    emit(burst) {
+      if (destroyed || pending.length >= MAX_BURSTS) return;
+      // Nothing is drawing, so nothing would be seen — and banking these is
+      // what produces the wall of confetti on the first frame back.
+      if (performance.now() - lastFrameAt > LOOP_STALE_MS) return;
+      // Shifted here rather than at the call site: effects are written in board
+      // coordinates and should stay that way.
+      pending.push({ ...burst, x: burst.x + originX, y: burst.y + originY });
+    },
+
+    frame(dt) {
+      if (destroyed) return;
+      lastFrameAt = performance.now();
+      elapsed += dt;
+      frameBuffer.write({ resolution: d.vec2f(width, height), dt, time: elapsed });
+
+      if (pending.length > 0) {
+        let widest = 0;
+        const packed = pending.map((burst) => {
+          const count = Math.min(burst.count, MAX_PARTICLES);
+          // Never let one burst straddle the end of the ring.
+          if (cursor + count > MAX_PARTICLES) cursor = 0;
+          const first = cursor;
+          cursor += count;
+          widest = Math.max(widest, count);
+
+          return {
+            origin: d.vec2f(burst.x, burst.y),
+            dir: d.vec2f(burst.dirX ?? 0, burst.dirY ?? -1),
+            color: d.vec4f(burst.color[0], burst.color[1], burst.color[2], 1),
+            first,
+            count,
+            kind: burst.kind,
+            energy: burst.energy,
+            seed: Math.random() * 500,
+          };
+        });
+
+        burstBuffer.write(packed, { startOffset: 0 });
+        spawnPipeline.dispatchThreads(widest, packed.length);
+        pending.length = 0;
+      }
+
+      simulatePipeline.dispatchThreads(MAX_PARTICLES);
+
+      renderPipeline
+        .withColorAttachment({
+          view: context,
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        })
+        .draw(4, MAX_PARTICLES);
+    },
+
+    clear() {
+      pending.length = 0;
+      cursor = 0;
+      particleBuffer.clear();
+    },
+
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      pending.length = 0;
+      root.destroy();
+    },
+  };
+
+  // `width`/`height` start at the canvas's own client size, so nudge the cached
+  // values first or the guard above would treat the initial sizing as a no-op.
+  width = 0;
+  height = 0;
+  field.resize(canvas.clientWidth || 1, canvas.clientHeight || 1);
+  particleBuffer.clear();
+  return field;
+}
+
+export { BurstKind };

--- a/docs/web-app/src/screens/games/candy/particles/index.ts
+++ b/docs/web-app/src/screens/games/candy/particles/index.ts
@@ -1,0 +1,23 @@
+import { createCanvasParticles } from './canvas';
+import type { ParticleField } from './types';
+
+export * from './types';
+
+/**
+ * Picks the best available particle backend. WebGPU is tried first; anything
+ * that goes wrong (no `navigator.gpu`, no adapter, a shader that fails to
+ * compile on an odd driver) falls back to Canvas 2D rather than taking the
+ * game down with it.
+ */
+export async function createParticleField(canvas: HTMLCanvasElement): Promise<ParticleField> {
+  if (typeof navigator !== 'undefined' && navigator.gpu) {
+    try {
+      // Loaded lazily so browsers without WebGPU never download TypeGPU.
+      const { createGpuParticles } = await import('./gpu');
+      return await createGpuParticles(canvas);
+    } catch (error) {
+      console.warn('[candy] WebGPU particles unavailable, using Canvas 2D:', error);
+    }
+  }
+  return createCanvasParticles(canvas);
+}

--- a/docs/web-app/src/screens/games/candy/particles/types.ts
+++ b/docs/web-app/src/screens/games/candy/particles/types.ts
@@ -1,0 +1,73 @@
+/**
+ * The particle layer's public shape. Both backends — the TypeGPU/WebGPU one and
+ * the Canvas 2D fallback — implement this, so the game never branches on which
+ * is running.
+ */
+
+/** Kinds are numbered because the WebGPU backend passes them to a shader. */
+export const BurstKind = {
+  /** A candy vanishing: a tight puff of sparks in its own colour. */
+  pop: 0,
+  /** A wrapped candy or colour bomb: a heavy radial blast with smoke. */
+  explosion: 1,
+  /** The combo finale: rainbow rectangles that spin and flutter down. */
+  confetti: 2,
+  /** A striped candy's beam: particles fired along one axis. */
+  streak: 3,
+  /** A special being created: a small bright shimmer. */
+  spark: 4,
+} as const;
+
+export type BurstKindValue = (typeof BurstKind)[keyof typeof BurstKind];
+
+export type Burst = {
+  kind: BurstKindValue;
+  /** Canvas-space pixels, origin top-left. */
+  x: number;
+  y: number;
+  /** Linear RGB, each channel 0..1. */
+  color: readonly [number, number, number];
+  count: number;
+  /** 0..1 — scales speed, size and lifetime together. */
+  energy: number;
+  /** Unit vector; only `streak` uses it. */
+  dirX?: number;
+  dirY?: number;
+};
+
+export interface ParticleField {
+  readonly backend: 'webgpu' | 'canvas';
+  /** CSS pixel size of the canvas; the backend applies device-pixel scaling. */
+  resize(width: number, height: number): void;
+  /**
+   * Where the board's top-left corner sits on the canvas.
+   *
+   * The canvas is deliberately larger than the board — it spans the whole app
+   * shell — so sparks can leave the board and keep going instead of being
+   * guillotined at its border. Callers still emit in *board* coordinates and
+   * the backend shifts them, so nothing that describes an effect has to know
+   * where the board happens to be sitting.
+   */
+  setOrigin(x: number, y: number): void;
+  emit(burst: Burst): void;
+  /** Simulates and draws one frame. `dt` is in seconds. */
+  frame(dt: number): void;
+  clear(): void;
+  destroy(): void;
+}
+
+export const MAX_PARTICLES = 6144;
+export const MAX_BURSTS = 64;
+
+/**
+ * How long a backend keeps accepting bursts after its last drawn frame.
+ *
+ * Browsers stop firing `requestAnimationFrame` for a hidden or throttled page,
+ * so a game left running there keeps *emitting* bursts that nothing simulates
+ * or draws; they then all arrive at once on the first frame back, as one absurd
+ * wall of confetti. The fix is to ask the render loop whether it is actually
+ * running rather than to ask `document.hidden` — embedded and preview surfaces
+ * report themselves hidden while plainly on screen, and trusting that flag
+ * silently deletes every effect in them.
+ */
+export const LOOP_STALE_MS = 250;

--- a/docs/web-app/src/screens/games/index.tsx
+++ b/docs/web-app/src/screens/games/index.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react';
+import { TopBar } from '../../components/TopBar';
+import { CandyCascade } from './candy/CandyCascade';
+
+export const GAMES = [
+  {
+    slug: 'candy-cascade',
+    title: 'Candy Cascade',
+    tagline: 'Match three, chase cascades, feel every combo.',
+    render: () => <CandyCascade />,
+  },
+] as const satisfies readonly {
+  slug: string;
+  title: string;
+  tagline: string;
+  render: () => ReactElement;
+}[];
+
+export type GameSlug = (typeof GAMES)[number]['slug'];
+
+export function isGameSlug(value: string | undefined): value is GameSlug {
+  return GAMES.some((game) => game.slug === value);
+}
+
+export function GameScreen({ slug, onBack }: { slug: GameSlug; onBack: () => void }) {
+  const game = GAMES.find((entry) => entry.slug === slug)!;
+  return (
+    <div className="screen">
+      <TopBar onBack={onBack} label="Games" />
+      {game.render()}
+    </div>
+  );
+}

--- a/docs/web-app/src/styles.css
+++ b/docs/web-app/src/styles.css
@@ -72,6 +72,47 @@ a {
   overflow: hidden;
 }
 
+/*
+ * Super-combo screen kick. Amplitude comes in as `--shake` so one keyframe
+ * serves every intensity, and the whole shell moves — board, HUD and tab bar —
+ * because a wipeout should read as an impact on the app rather than a panel
+ * wobbling inside it.
+ */
+.shell--shaking {
+  animation: screen-shake 520ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@keyframes screen-shake {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  12% {
+    transform: translate3d(calc(var(--shake, 8px) * -1), calc(var(--shake, 8px) * 0.45), 0)
+      rotate(-0.5deg);
+  }
+  26% {
+    transform: translate3d(calc(var(--shake, 8px) * 0.82), calc(var(--shake, 8px) * -0.5), 0)
+      rotate(0.45deg);
+  }
+  40% {
+    transform: translate3d(calc(var(--shake, 8px) * -0.6), calc(var(--shake, 8px) * -0.28), 0)
+      rotate(-0.32deg);
+  }
+  56% {
+    transform: translate3d(calc(var(--shake, 8px) * 0.44), calc(var(--shake, 8px) * 0.34), 0)
+      rotate(0.24deg);
+  }
+  72% {
+    transform: translate3d(calc(var(--shake, 8px) * -0.26), calc(var(--shake, 8px) * -0.18), 0)
+      rotate(-0.14deg);
+  }
+  88% {
+    transform: translate3d(calc(var(--shake, 8px) * 0.12), calc(var(--shake, 8px) * 0.09), 0)
+      rotate(0.06deg);
+  }
+}
+
 /* On a roomy screen the app reads as a device sitting on the page. */
 @media (min-width: 900px) {
   body {
@@ -681,4 +722,843 @@ input[type='range'] {
   place-items: center;
   padding: 0;
   border-radius: var(--radius);
+}
+
+/* ----------------------------------------------------------- candy game -- */
+
+.candy-hud {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 14px 0 12px;
+}
+
+.counter {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.counter--right {
+  align-items: flex-end;
+}
+
+.counter__label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+/*
+ * The delta chip is absolutely positioned against this, so the counter can
+ * throw a "+240" without the HUD reflowing and shoving the board down.
+ */
+.counter__slot {
+  position: relative;
+  display: block;
+}
+
+.counter__value {
+  display: inline-block;
+  font-size: 30px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums; /* digits stop jittering mid-count */
+  animation: counter-pop 420ms cubic-bezier(0.3, 1.6, 0.5, 1);
+  transform-origin: center bottom;
+}
+
+.counter--right .counter__value {
+  transform-origin: right bottom;
+}
+
+.counter__value--warn {
+  color: var(--danger);
+}
+
+/*
+ * The pop. It also flashes the number's colour and lights a glow behind it, so
+ * a score bump reads at the edge of vision while the player is watching the
+ * board rather than the HUD.
+ */
+@keyframes counter-pop {
+  0% {
+    transform: scale(1);
+  }
+  28% {
+    transform: scale(1.3);
+    color: var(--accent);
+    text-shadow: 0 0 14px rgba(56, 172, 221, 0.85);
+  }
+  55% {
+    transform: scale(0.96);
+  }
+  100% {
+    transform: scale(1);
+    text-shadow: none;
+  }
+}
+
+.counter--moves .counter__value {
+  animation-name: counter-pop-moves;
+}
+
+/* Moves only ever go down, so its flash is a warning tone, not a reward. */
+@keyframes counter-pop-moves {
+  0% {
+    transform: scale(1);
+  }
+  28% {
+    transform: scale(1.22);
+    color: var(--danger);
+    text-shadow: 0 0 12px rgba(255, 98, 89, 0.75);
+  }
+  55% {
+    transform: scale(0.97);
+  }
+  100% {
+    transform: scale(1);
+    text-shadow: none;
+  }
+}
+
+.counter__delta {
+  position: absolute;
+  left: 0;
+  bottom: 100%;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: counter-delta 900ms cubic-bezier(0.2, 0.9, 0.3, 1) forwards;
+}
+
+.counter--right .counter__delta {
+  left: auto;
+  right: 0;
+}
+
+.counter--moves .counter__delta {
+  background: var(--danger);
+}
+
+@keyframes counter-delta {
+  0% {
+    transform: translateY(6px) scale(0.7);
+    opacity: 0;
+  }
+  22% {
+    transform: translateY(-2px) scale(1.06);
+    opacity: 1;
+  }
+  38% {
+    transform: translateY(-4px) scale(1);
+  }
+  100% {
+    transform: translateY(-26px) scale(0.94);
+    opacity: 0;
+  }
+}
+
+/*
+ * The board is the positioning context for everything: candies are absolutely
+ * placed and moved with percentage translations, so one `aspect-ratio` box
+ * drives the layout at every screen size without a single pixel measurement.
+ */
+.candy-board {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  border: 2px solid var(--accent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(213, 238, 249, 0.9)), var(--surface);
+  overflow: hidden;
+  touch-action: none; /* the board owns dragging; the page must not scroll */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+
+.candy {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 12.5%; /* 100% / COLS */
+  height: 12.5%; /* 100% / ROWS */
+  will-change: transform;
+  transition: transform 265ms cubic-bezier(0.35, 1.35, 0.55, 1);
+  /*
+   * Freshly spawned candies mount at their final grid position, so the drop-in
+   * has to come from `translate`, which composes with (rather than overwrites)
+   * the `transform` that places them.
+   *
+   * This runs once, when the element is created — but only for as long as
+   * `animation` is never overridden anywhere else. Setting `animation: none` in
+   * an interaction class (and thereby restoring it when the class comes off)
+   * changes `animation-name`, which RESTARTS the drop-in: the candy jumps 2.2
+   * cells above the board and falls back through its neighbours. Do not reach
+   * for `animation: none` on `.candy`; use a transition instead.
+   */
+  animation: candy-drop-in 265ms cubic-bezier(0.35, 1.35, 0.55, 1);
+}
+
+/*
+ * While a candy is being pushed it must track the finger, so the settling
+ * transition is cut right down rather than removed — keeping a transition
+ * (instead of `none`) is what lets it spring back smoothly when the class comes
+ * off on release.
+ */
+.candy--grabbed,
+.candy--displaced {
+  transition: transform 60ms linear;
+}
+
+/*
+ * The illegal-move spring. The bounce is staged in JS rather than baked into an
+ * overshooting curve here: the stages are fractions of how far the player
+ * actually pushed, so the recoil stays inside the candy's own cell no matter
+ * how hard the swap was attempted. A curve like the grid's would scale its
+ * overshoot with the distance and throw the candy into its neighbours.
+ */
+.candy--rejecting {
+  transition: transform var(--settle-ms, 140ms) cubic-bezier(0.22, 0.85, 0.3, 1);
+}
+
+/* Only the candy under the finger lifts — the neighbour just gets shoved. */
+.candy--grabbed {
+  z-index: 2;
+}
+
+.candy--grabbed .candy__art {
+  transform: scale(1.14);
+  filter: drop-shadow(0 0 8px var(--accent)) drop-shadow(0 4px 3px rgba(0, 26, 114, 0.28));
+}
+
+@keyframes candy-drop-in {
+  from {
+    translate: 0 -220%;
+    opacity: 0;
+  }
+  to {
+    translate: 0 0;
+    opacity: 1;
+  }
+}
+
+/*
+ * Sized with width/height rather than padding on `.candy`: a percentage padding
+ * would resolve against the *board's* width, not the cell's, and shrink every
+ * candy to a third of its square.
+ */
+.candy__art {
+  /*
+   * The board handles pointers by coordinate, so the artwork takes no hits.
+   * Leaving it interactive lets the browser treat an SVG as a draggable image
+   * and start its own ghost-drag on top of the gesture.
+   */
+  pointer-events: none;
+  width: 86%;
+  height: 86%;
+  margin: 7%;
+  display: block;
+  filter: drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+  transition:
+    transform 150ms ease,
+    opacity 150ms ease;
+}
+
+.candy--special .candy__art {
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.95)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+}
+
+.candy--selected .candy__art {
+  transform: scale(1.16);
+  filter: drop-shadow(0 0 7px var(--accent)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+}
+
+/*
+ * The nudge shown after a few idle seconds. It pulses rather than flashing once
+ * so it stays findable in peripheral vision without demanding attention, and it
+ * sits under the drag classes so grabbing the candy cancels it cleanly.
+ */
+.candy--hint .candy__art {
+  animation: candy-hint 1350ms ease-in-out infinite;
+}
+
+@keyframes candy-hint {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+  }
+  50% {
+    transform: scale(1.13);
+    filter: drop-shadow(0 0 9px var(--accent)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+  }
+}
+
+.candy--clearing {
+  /* Pointer-inert while it pops, so a fast player cannot grab a dying candy. */
+  pointer-events: none;
+}
+
+.candy--clearing .candy__art {
+  animation: candy-pop 285ms ease-in forwards;
+}
+
+@keyframes candy-pop {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  35% {
+    transform: scale(1.32);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.1);
+    opacity: 0;
+  }
+}
+
+/*
+ * Spans the whole shell, not the board. The board has to clip its children
+ * (candies drop in from above it), so a canvas inside it would slice every
+ * spark off at the blue border. Up here a blast can throw confetti across the
+ * HUD and past the tab bar, and the shell's own `overflow: hidden` keeps it
+ * inside the app frame.
+ */
+.candy-particles {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 20;
+}
+
+/*
+ * `@property` is what makes the ring's angle animatable — a plain custom
+ * property is a string to the animation engine and would just snap. Where it is
+ * unsupported the fallback below keeps the gradient valid, so the ring renders
+ * as a static rainbow instead of disappearing.
+ */
+@property --banner-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+/* ------------------------------------------------------ combo counter -- */
+
+/*
+ * The live chain counter. `--heat` runs 0 to 1 as the chain deepens and is the
+ * only thing that changes: it climbs the hue from the app's cyan through purple
+ * to red, and widens the glow. One number driving colour, glow and
+ * scale keeps a deep chain unmistakable at a glance without a second style.
+ *
+ * `top` matches `COMBO_TOP` in effects.ts, which is where its sparks are aimed.
+ */
+.candy-combo {
+  --heat: 0;
+  /*
+   * Climbs the wheel rather than descending it: cyan to blue to purple to red.
+   * Going the other way passes through green and yellow, which read as cooling
+   * off just as the chain is getting serious.
+   */
+  --combo-hue: calc(195 + var(--heat) * 165);
+
+  position: absolute;
+  left: 50%;
+  top: 13%;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  padding: 7px 18px;
+  border-radius: 999px;
+  background: hsl(var(--combo-hue) 85% 32% / 0.62);
+  -webkit-backdrop-filter: blur(10px) saturate(1.6);
+  backdrop-filter: blur(10px) saturate(1.6);
+  border: 2px solid hsl(var(--combo-hue) 95% 62%);
+  box-shadow:
+    0 0 calc(10px + var(--heat) * 26px) hsl(var(--combo-hue) 95% 60% / 0.75),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  color: #fff;
+  pointer-events: none;
+  white-space: nowrap;
+  /*
+   * The centring has to live here, not only in the keyframes. `combo-pop` is
+   * not a `forwards` animation, so the moment it ends the element falls back to
+   * this rule — and if that rule has no transform, the counter snaps half its
+   * own width to the right and sits off-centre until the next tick.
+   */
+  transform: translate(-50%, 0);
+  animation: combo-pop 430ms cubic-bezier(0.25, 1.7, 0.4, 1);
+}
+
+.candy-combo__value {
+  font-size: calc(24px + var(--heat) * 12px);
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 calc(8px + var(--heat) * 18px) hsl(var(--combo-hue) 100% 70%);
+}
+
+.candy-combo__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+/* Each tick lands with a slam and a shake — the shake grows with the heat. */
+@keyframes combo-pop {
+  0% {
+    transform: translate(-50%, 0) scale(1.75);
+    opacity: 0;
+  }
+  22% {
+    transform: translate(-50%, 0) scale(0.9);
+    opacity: 1;
+  }
+  42% {
+    transform: translate(-50%, 0) scale(1.08) rotate(calc(var(--heat) * 2.5deg));
+  }
+  62% {
+    transform: translate(-50%, 0) scale(0.98) rotate(calc(var(--heat) * -2deg));
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1) rotate(0deg);
+  }
+}
+
+/* Chain over: it swells and fades rather than blinking out. */
+.candy-combo--out {
+  animation: combo-out 400ms cubic-bezier(0.3, 0, 0.6, 1) forwards;
+}
+
+@keyframes combo-out {
+  0% {
+    transform: translate(-50%, 0) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -18px) scale(1.45);
+    opacity: 0;
+  }
+}
+
+/*
+ * Banners share a shell — translucent pill, blurred backdrop, gradient rim —
+ * and then each kind overrides the parts that carry meaning: its colour, how
+ * fast the rim turns, how big the text is, and above all how it enters and
+ * leaves. A bonus tip should not arrive like a wipeout.
+ *
+ * `--banner-top` must match `BANNER_TOP` in effects.ts, which is where the
+ * banner's own sparks are thrown.
+ */
+.candy-banner {
+  --banner-angle: 0deg; /* fallback for engines without @property */
+  --banner-top: 38%;
+  --banner-ring-speed: 2200ms;
+  --banner-tint: rgba(0, 26, 114, 0.58);
+  --banner-ring: conic-gradient(
+    from var(--banner-angle),
+    #38acdd,
+    #ffc93c,
+    #ff5a5f,
+    #a06be8,
+    #3dd68c,
+    #38acdd
+  );
+
+  position: absolute;
+  left: 50%;
+  top: var(--banner-top);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 13px 26px;
+  border-radius: 999px;
+  /*
+   * Translucent on purpose: the celebration should sit *over* the cascade that
+   * earned it, not hide it. The blur keeps the text legible against whatever
+   * colours happen to be churning underneath.
+   */
+  background: var(--banner-tint);
+  -webkit-backdrop-filter: blur(14px) saturate(1.7);
+  backdrop-filter: blur(14px) saturate(1.7);
+  box-shadow:
+    0 12px 32px rgba(0, 26, 114, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  color: #fff;
+  text-align: center;
+  pointer-events: none;
+  white-space: nowrap;
+  isolation: isolate;
+  /* Resting position, so the pill is never centred by an animation alone. */
+  transform: translate(-50%, 0);
+}
+
+/* Sheen: a highlight that sweeps across once as the banner arrives. Sits in
+ * ::before so it passes under the text rather than washing over it. */
+.candy-banner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(130% 150% at 50% 0%, rgba(255, 255, 255, 0.3), transparent 62%),
+    linear-gradient(100deg, transparent 22%, rgba(255, 255, 255, 0.4) 46%, transparent 68%);
+  background-size:
+    100% 100%,
+    240% 100%;
+  background-repeat: no-repeat;
+  animation: banner-sheen 1400ms cubic-bezier(0.3, 0, 0.2, 1);
+}
+
+@keyframes banner-sheen {
+  from {
+    background-position:
+      0 0,
+      -130% 0;
+  }
+  to {
+    background-position:
+      0 0,
+      130% 0;
+  }
+}
+
+/*
+ * The rim. A gradient masked down to a 2px ring — `exclude` knocks the middle
+ * out so only the border of the pill is painted.
+ */
+.candy-banner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2px;
+  background: var(--banner-ring);
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: banner-ring var(--banner-ring-speed) linear infinite;
+}
+
+@keyframes banner-ring {
+  to {
+    --banner-angle: 360deg;
+  }
+}
+
+.candy-banner__title {
+  position: relative;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.1;
+  text-shadow: 0 0 18px rgba(56, 172, 221, 0.75);
+}
+
+.candy-banner__detail {
+  position: relative;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+/* ------------------------------------------------------- banner kinds -- */
+
+/* A tip, not a trophy: cool, calm, and it rises gently into place. */
+.candy-banner--bonus {
+  --banner-tint: rgba(11, 92, 128, 0.6);
+  --banner-ring: linear-gradient(120deg, var(--accent), #b5e1f1, var(--accent));
+  animation: banner-bonus 1700ms cubic-bezier(0.25, 0.9, 0.3, 1) forwards;
+}
+
+.candy-banner--bonus .candy-banner__title {
+  font-size: 21px;
+  text-shadow: 0 0 14px rgba(56, 172, 221, 0.9);
+}
+
+/* The rim does not spin here — a static sweep keeps it quiet. */
+.candy-banner--bonus::after {
+  animation: none;
+}
+
+@keyframes banner-bonus {
+  0% {
+    transform: translate(-50%, 30px) scale(0.9);
+    opacity: 0;
+  }
+  12% {
+    transform: translate(-50%, 0) scale(1.03);
+    opacity: 1;
+  }
+  20% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  82% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -16px) scale(0.97);
+    opacity: 0;
+  }
+}
+
+/* Chain reactions run hot: gold, tilted in, floating away like a score pop. */
+.candy-banner--cascade {
+  --banner-tint: rgba(104, 62, 6, 0.58);
+  --banner-ring: conic-gradient(from var(--banner-angle), #ffc93c, #ff9f45, #ff5a5f, #ffc93c);
+  --banner-ring-speed: 3200ms;
+  animation: banner-cascade 1300ms cubic-bezier(0.3, 1.2, 0.4, 1) forwards;
+}
+
+.candy-banner--cascade .candy-banner__title {
+  text-shadow: 0 0 18px rgba(255, 201, 60, 0.85);
+}
+
+@keyframes banner-cascade {
+  0% {
+    transform: translate(-50%, 14px) scale(0.6) rotate(-7deg);
+    opacity: 0;
+  }
+  14% {
+    transform: translate(-50%, 0) scale(1.16) rotate(3deg);
+    opacity: 1;
+  }
+  26% {
+    transform: translate(-50%, 0) scale(1) rotate(0deg);
+  }
+  72% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -44px) scale(0.9) rotate(0deg);
+    opacity: 0;
+  }
+}
+
+/* A special combo slams down from above, then bursts outward on the way out. */
+.candy-banner--combo {
+  animation: banner-combo 1500ms cubic-bezier(0.25, 1, 0.35, 1) forwards;
+}
+
+@keyframes banner-combo {
+  0% {
+    transform: translate(-50%, -46px) scale(1.3);
+    opacity: 0;
+  }
+  10% {
+    transform: translate(-50%, 7px) scale(0.93);
+    opacity: 1;
+  }
+  19% {
+    transform: translate(-50%, 0) scale(1.06);
+  }
+  28% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1.4);
+    opacity: 0;
+  }
+}
+
+/* The loudest one: near-black, a fast rim, and it detonates on both ends. */
+.candy-banner--super {
+  --banner-tint: rgba(9, 8, 34, 0.66);
+  --banner-ring-speed: 1100ms;
+  padding: 16px 32px;
+  box-shadow:
+    0 16px 44px rgba(0, 26, 114, 0.5),
+    0 0 30px rgba(160, 107, 232, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  animation: banner-super 1900ms cubic-bezier(0.2, 1.1, 0.3, 1) forwards;
+}
+
+.candy-banner--super .candy-banner__title {
+  font-size: 33px;
+  letter-spacing: -0.01em;
+  text-shadow:
+    0 0 22px rgba(255, 255, 255, 0.9),
+    0 0 44px rgba(160, 107, 232, 0.8);
+}
+
+@keyframes banner-super {
+  0% {
+    transform: translate(-50%, 0) scale(0.15);
+    opacity: 0;
+  }
+  8% {
+    transform: translate(-50%, 0) scale(1.34);
+    opacity: 1;
+  }
+  17% {
+    transform: translate(-50%, 0) scale(0.94);
+  }
+  25% {
+    transform: translate(-50%, 0) scale(1.07);
+  }
+  33% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  82% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -12px) scale(1.55);
+    opacity: 0;
+  }
+}
+
+/*
+ * Shockwave. A ring that expands out of the pill and fades, drawn as its own
+ * element because ::before and ::after are already the sheen and the rim.
+ */
+.candy-banner__wave {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  pointer-events: none;
+  animation: banner-wave 760ms cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+}
+
+@keyframes banner-wave {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+/* Housekeeping. No rim, no fanfare — it just says what happened. */
+.candy-banner--info {
+  --banner-tint: rgba(43, 133, 171, 0.6);
+  animation: banner-info 1500ms ease-out forwards;
+}
+
+.candy-banner--info .candy-banner__title {
+  font-size: 21px;
+  text-shadow: none;
+}
+
+.candy-banner--info::after {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  animation: none;
+}
+
+@keyframes banner-info {
+  0% {
+    transform: translate(-50%, 0) scale(0.96);
+    opacity: 0;
+  }
+  10% {
+    transform: translate(-50%, 0) scale(1);
+    opacity: 1;
+  }
+  86% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -12px) scale(1);
+    opacity: 0;
+  }
+}
+
+.candy-over {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: rgba(225, 243, 250, 0.94);
+  backdrop-filter: blur(2px);
+}
+
+.candy-over__title {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.candy-over__score {
+  font-size: 18px;
+  color: var(--ink-muted);
+}
+
+.candy-footnote {
+  margin-top: 12px;
+}
+
+/*
+ * Players who ask for less motion still get the game, just without the
+ * springing, popping and drop-in. Haptics and audio are untouched — they are
+ * the point of the demo, and neither is vestibular.
+ */
+@media (prefers-reduced-motion: reduce) {
+  /*
+   * `.candy` covers the interaction classes too, and listing them separately
+   * would only invite someone to reintroduce an `animation` override that
+   * toggles. Here it is static, so nothing ever restarts.
+   */
+  .candy,
+  .candy__art,
+  .candy--hint .candy__art {
+    animation: none;
+    transition: none;
+  }
+
+  /* The hint still has to be findable without its pulse. */
+  .candy--hint .candy__art {
+    filter: drop-shadow(0 0 9px var(--accent));
+  }
+
+  .candy-combo,
+  .candy-combo--out,
+  .candy-banner,
+  .candy-banner::before,
+  .candy-banner::after,
+  .candy-banner__wave,
+  .shell--shaking,
+  .counter__value,
+  .counter__delta {
+    animation: none;
+  }
+
+  /* Without its animation the chip would sit there forever; hide it instead. */
+  .counter__delta {
+    display: none;
+  }
 }

--- a/docs/web-app/tsconfig.json
+++ b/docs/web-app/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "types": ["vite/client"],
+    "types": ["vite/client", "@webgpu/types"],
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "strict": true,


### PR DESCRIPTION
The web app's **Games** tab was a placeholder. This fills it with a playable
match-3 built to show Pulsar doing real work — every match, drop, special and
combo is a distinct haptic pattern rather than one buzz reused.

Lives at `/pulsar/web-app/#/games/candy-cascade`.

## Why it's built this way

**Resolution happens before animation.** `resolveMove` plays a whole move out —
every cascade, every chain reaction — and returns an ordered list of steps that
the screen then animates. That's what lets a celebration know a chain is five
deep *before* the first candy pops, so the finale is scheduled rather than
discovered.

**Haptics are arbitrated, not queued.** The Web Vibration API has one global
timeline: starting a pattern *cancels* the last one. A cascade fires a dozen
events a second, so `playHaptic` takes a priority and refuses to let a
tile-landing tick interrupt a combo finale.

**Sound is synthesised so it can share the haptics' numbers.** Match pitch walks
a pentatonic scale with cascade depth — the same value that raises the pulse
frequency — and the finale's riser is built against `FINALE_MS`, the constant
the finale haptic uses. Sound and vibration rise and land together by
construction. Nothing is sampled, so there are no binaries to license or keep in
sync.

## Particles

Both spawning and integration run on the GPU via TypeGPU: the CPU appends a
*description* of each burst to a storage array and dispatches one thread per
particle to be born, so a nine-tile cascade costs one buffer write and one
dispatch. TypeGPU is imported lazily, so browsers without WebGPU never download
the ~310 kB chunk and get a Canvas 2D fallback with matching motion constants.

The canvas is portalled into `.shell` rather than the board, because the board
needs `overflow: hidden` for the candies' drop-in and that clipped every spark
at its border. Effects stay written in board coordinates; the backend shifts
them via `setOrigin`.

`unplugin-typegpu` is added to the Vite config — without it TypeGPU has no AST
for the `'use gpu'` shader bodies and throws at runtime.

## Pacing was measured, not guessed

Two dials, both tuned against 500 played-out moves rather than by feel:

| | before | after |
|---|---|---|
| moves that chain at all | 43% | 69% |
| moves worth celebrating | 24% | 49% |
| worst run with no special | 14 moves | 4 moves |

`cascadeBias` gives refilled candies a chance to copy a neighbour so they arrive
clumped — a uniformly random refill is why cascades felt rare. It's deliberately
held at 0.20: past ~0.3, 88% of moves chain at nearly six steps each, and at
550ms a step the player spends the game watching rather than playing.
`MAX_CASCADE` bounds the worst case regardless.

`generousAt` grants a striped candy during the opening moves and again after a
drought, so a new player sees what a special *does* before learning to aim for
one. Left on permanently it yields more than one special per move, so it's
temporary in both cases.

An idle hint pulses a playable move after a few seconds for anyone who can't
find one (`findBestMove`, ~0.2ms).

## Accessibility

Candies carry a distinct **shape** as well as a colour, so the board stays
playable without colour vision. Every animation is disabled under
`prefers-reduced-motion`; haptics and audio are untouched, since they're the
point of the demo and neither is vestibular.

## Reviewer notes

- `docs/web-app/README.md` documents the architecture and the invariants worth
  knowing before changing anything here.
- One trap bit three times during development and is commented at each site: **a
  CSS animation must never be the sole source of truth for a value the base
  style should own.** Setting `animation: none` in an interaction class restarts
  the drop-in when the class comes off; centring an overlay only inside
  keyframes makes it snap sideways when they end.
- Anything driven by `requestAnimationFrame` has a backstop — browsers pause rAF
  for hidden pages, and embedded/preview surfaces report `document.hidden` while
  plainly on screen, so the particle field asks its own render loop whether it's
  running instead of trusting that flag.
- Verified: 1,200 simulated moves with no holed or unsettled boards; WebGPU
  output confirmed by pixel-sampling the canvas; typecheck, Prettier and the
  full Astro build all pass.

Nothing outside `docs/` is touched, and none of the existing web-app screens
change behaviour.
