### PR TITLE
fix(docs): stop Shape Cascade whiting out the app on a phone

### DIFF
--- a/docs/web-app/src/screens/games/shape/Counter.tsx
+++ b/docs/web-app/src/screens/games/shape/Counter.tsx
@@ -93,7 +93,14 @@ export function Counter({ value, label, tone, align = 'left', warn = false }: Pr
 
       <span className="counter__slot">
         <span
-          key={popId}
+          /*
+           * Namespaced because the delta chips are siblings in this same slot
+           * and their ids advance in lockstep with `popId` — both counters are
+           * bumped by the very same change. Bare numbers collided on every
+           * bump, and React resolves a duplicate key by dropping one of the
+           * two children, which is the value itself as often as the chip.
+           */
+          key={`value-${popId}`}
           className={`counter__value${warn ? ' counter__value--warn' : ''}`}
           // Announce the settled value, not every frame of the tween.
           aria-label={`${label}: ${value}`}
@@ -102,7 +109,7 @@ export function Counter({ value, label, tone, align = 'left', warn = false }: Pr
         </span>
 
         {deltas.map((delta) => (
-          <span key={delta.id} className="counter__delta" aria-hidden="true">
+          <span key={`delta-${delta.id}`} className="counter__delta" aria-hidden="true">
             {delta.text}
           </span>
         ))}

--- a/docs/web-app/src/screens/games/shape/ShapeCascade.tsx
+++ b/docs/web-app/src/screens/games/shape/ShapeCascade.tsx
@@ -328,6 +328,17 @@ export function ShapeCascade() {
    * the frame.
    */
   const [shell, setShell] = useState<HTMLElement | null>(null);
+  /**
+   * Bumped to throw the particle canvas away and mount a fresh one — see
+   * `onLost` below. It keys the element, so React replaces it rather than
+   * reusing it, which matters because a canvas that has handed out a `webgpu`
+   * context can never hand out a `2d` one.
+   */
+  const [fieldGeneration, setFieldGeneration] = useState(0);
+  /** Set once the GPU has failed here, so the rebuild does not try it again. */
+  const gpuLostRef = useRef(false);
+  /** Both backends have now failed; the game plays on without sparks. */
+  const [particlesOff, setParticlesOff] = useState(false);
   const effectsRef = useRef<Effects>({ field: null });
   const sizeRef = useRef({ width: 1, height: 1 });
   const [nudge, setNudge] = useState<Nudge | null>(null);
@@ -376,37 +387,90 @@ export function ShapeCascade() {
     let last = performance.now();
     let cancelled = false;
 
-    void createParticleField(canvas).then((created) => {
-      if (cancelled) {
-        created.destroy();
+    /**
+     * The backend died mid-game. Replacing the canvas is not optional tidying:
+     * this one is stretched over the whole shell above everything else, so a
+     * context that has stopped presenting hides the entire app while the game
+     * keeps running and answering touches underneath it. Dropping the element
+     * uncovers the board even if the rebuild then fails outright.
+     */
+    const onLost = (reason: string) => {
+      if (cancelled) return;
+      effectsRef.current.field = null;
+
+      // Canvas 2D is the last resort, so if that is what just died there is
+      // nothing left to fall back to and the canvas comes off the page for
+      // good. Every effect is written to no-op without a field, so the game
+      // loses its sparks and nothing else.
+      if (gpuLostRef.current) {
+        console.warn('[shape] particles disabled, no backend left:', reason);
+        setParticlesOff(true);
         return;
       }
-      field = created;
-      effectsRef.current.field = created;
 
-      const loop = (now: number) => {
-        // Clamped so a backgrounded tab does not resume with a huge timestep
-        // that teleports every particle off screen.
-        const dt = Math.min(0.05, (now - last) / 1000);
-        last = now;
+      console.warn('[shape] particle backend lost, rebuilding on Canvas 2D:', reason);
+      gpuLostRef.current = true;
+      setFieldGeneration((generation) => generation + 1);
+    };
 
-        // Re-read each frame so the origin survives scrolling and resizing
-        // without needing listeners for either; two rect reads are far cheaper
-        // than getting this subtly wrong.
-        const boardElement = boardRef.current;
-        const shellElement = canvas.parentElement;
-        if (boardElement && shellElement) {
-          const boardRect = boardElement.getBoundingClientRect();
-          const shellRect = shellElement.getBoundingClientRect();
-          created.resize(shellRect.width, shellRect.height);
-          created.setOrigin(boardRect.left - shellRect.left, boardRect.top - shellRect.top);
+    void createParticleField(canvas, { forceCanvas: gpuLostRef.current, onLost }).then(
+      (created) => {
+        if (cancelled) {
+          created.destroy();
+          return;
         }
+        field = created;
+        effectsRef.current.field = created;
 
-        created.frame(dt);
+        const loop = (now: number) => {
+          // Clamped so a backgrounded tab does not resume with a huge timestep
+          // that teleports every particle off screen.
+          const dt = Math.min(0.05, (now - last) / 1000);
+          last = now;
+
+          // Re-read each frame so the origin survives scrolling and resizing
+          // without needing listeners for either; two rect reads are far cheaper
+          // than getting this subtly wrong.
+          const boardElement = boardRef.current;
+          const shellElement = canvas.parentElement;
+          if (boardElement && shellElement) {
+            const boardRect = boardElement.getBoundingClientRect();
+            const shellRect = shellElement.getBoundingClientRect();
+            /*
+             * Size comes from the layout box, not the rect.
+             *
+             * A super combo shakes the shell, and that shake rotates it — which
+             * means its *bounding* rect swells and shrinks on every frame of the
+             * animation. Sized from that, one 520ms shake reallocates the
+             * canvas's backing store 37 times — measured — wiping the very
+             * sparks it is meant to be showing and, on the GPU path, churning a
+             * full-screen texture the whole time. `clientWidth`/`clientHeight`
+             * are the layout box and so are immune to transforms, and
+             * they measure the padding box, which is exactly the area
+             * `inset: 0` stretches the canvas over.
+             */
+            created.resize(shellElement.clientWidth, shellElement.clientHeight);
+            created.setOrigin(
+              boardRect.left - shellRect.left - shellElement.clientLeft,
+              boardRect.top - shellRect.top - shellElement.clientTop,
+            );
+          }
+
+          // A backend can fail in the middle of a frame — the throw must not be
+          // allowed to end the loop, or the particles never come back even once
+          // a replacement is standing.
+          try {
+            created.frame(dt);
+          } catch (error) {
+            created.destroy();
+            onLost(String(error));
+            return;
+          }
+          raf = requestAnimationFrame(loop);
+        };
         raf = requestAnimationFrame(loop);
-      };
-      raf = requestAnimationFrame(loop);
-    });
+      },
+    );
 
     return () => {
       cancelled = true;
@@ -414,7 +478,7 @@ export function ShapeCascade() {
       effectsRef.current.field = null;
       field?.destroy();
     };
-  }, [shell]);
+  }, [shell, fieldGeneration, particlesOff]);
 
   // Keep the particle canvas locked to the board's pixel size.
   useLayoutEffect(() => {
@@ -981,7 +1045,12 @@ export function ShapeCascade() {
 
           return (
             <Tile
-              key={tile.id}
+              // Namespaced: the combo pill and the banner are siblings of every
+              // tile inside the board, and all three counters are small
+              // integers that collide constantly. React answers a duplicate key
+              // by dropping one of the two children — a shape silently missing
+              // from the grid, or a banner that never appears.
+              key={`tile-${tile.id}`}
               tile={tile}
               index={index}
               clearing={clearing.has(tile.id)}
@@ -1000,7 +1069,7 @@ export function ShapeCascade() {
         {combo && combo.level >= 2 && (
           <div
             // Keyed on the level so each tick remounts and replays the pop.
-            key={combo.level}
+            key={`combo-${combo.level}`}
             className={`shape-combo${combo.exiting ? ' shape-combo--out' : ''}`}
             style={{ '--heat': `${Math.min(1, (combo.level - 2) / 6)}` } as CSSProperties}
             aria-live="polite"
@@ -1011,7 +1080,7 @@ export function ShapeCascade() {
         )}
 
         {banner && (
-          <div className={`shape-banner shape-banner--${banner.kind}`} key={banner.id}>
+          <div className={`shape-banner shape-banner--${banner.kind}`} key={`banner-${banner.id}`}>
             {banner.kind === 'super' && <span className="shape-banner__wave" aria-hidden="true" />}
             <span className="shape-banner__title">{banner.title}</span>
             <span className="shape-banner__detail">{banner.detail}</span>
@@ -1033,7 +1102,12 @@ export function ShapeCascade() {
         <Panda mood={pandaMood} onPoke={pokeEffect} />
       </Suspense>
 
-      {shell && createPortal(<canvas ref={canvasRef} className="shape-particles" />, shell)}
+      {shell &&
+        !particlesOff &&
+        createPortal(
+          <canvas key={fieldGeneration} ref={canvasRef} className="shape-particles" />,
+          shell,
+        )}
 
       {/*
         Kept only where it explains something the player would otherwise find

--- a/docs/web-app/src/screens/games/shape/particles/canvas.ts
+++ b/docs/web-app/src/screens/games/shape/particles/canvas.ts
@@ -129,12 +129,19 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
   let lastFrameAt = performance.now();
   let originX = 0;
   let originY = 0;
+  /**
+   * How many pool slots are alive. Kept as a running count so an idle frame
+   * costs one comparison rather than a walk of 1200 particles — see the note on
+   * idling in `gpu.ts`, which this mirrors.
+   */
+  let alive = 0;
 
   function spawn(burst: Burst) {
     const count = Math.min(burst.count, POOL);
     for (let i = 0; i < count; i++) {
       const p = pool[cursor];
       cursor = (cursor + 1) % POOL;
+      if (p.life <= 0) alive++;
 
       const angle = Math.random() * Math.PI * 2;
       const spread = (Math.random() - 0.5) * 0.55;
@@ -257,6 +264,10 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
       lastFrameAt = performance.now();
       elapsed += dt;
 
+      // The pool is empty and the canvas was cleared on the frame the last
+      // particle died, so there is nothing to clear and nothing to draw.
+      if (alive === 0) return;
+
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, width, height);
 
@@ -273,7 +284,10 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
         p.y += p.vy * dt;
         p.life -= dt;
         p.angle += p.spin * dt * 5;
-        if (p.life <= 0) continue;
+        if (p.life <= 0) {
+          alive--;
+          continue;
+        }
 
         const age = 1 - p.life / p.maxLife;
         const fade = 1 - Math.max(0, (age - 0.45) / 0.55);
@@ -307,6 +321,7 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
 
     clear() {
       for (const p of pool) p.life = 0;
+      alive = 0;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, width, height);
     },

--- a/docs/web-app/src/screens/games/shape/particles/gpu.ts
+++ b/docs/web-app/src/screens/games/shape/particles/gpu.ts
@@ -5,8 +5,10 @@ import {
   BurstKind,
   LOOP_STALE_MS,
   MAX_BURSTS,
+  MAX_LIFETIME_MS,
   MAX_PARTICLES,
   type Burst,
+  type FieldOptions,
   type ParticleField,
 } from './types';
 
@@ -87,7 +89,10 @@ const inRange = (value: number, lo: number, hi: number) => {
   return std.step(lo, value) * (1 - std.step(hi, value));
 };
 
-export async function createGpuParticles(canvas: HTMLCanvasElement): Promise<ParticleField> {
+export async function createGpuParticles(
+  canvas: HTMLCanvasElement,
+  options: FieldOptions = {},
+): Promise<ParticleField> {
   // Device and shaders are brought up *before* the canvas context is claimed.
   // `getContext('webgpu')` is irreversible — once it succeeds the same element
   // can never hand out a 2D context — so anything that might fail (no adapter,
@@ -312,9 +317,24 @@ export async function createGpuParticles(canvas: HTMLCanvasElement): Promise<Par
   let height = 0;
   let cursor = 0;
   let elapsed = 0;
+  /** Inert: stops accepting and drawing. Set by a loss as well as a teardown. */
   let destroyed = false;
+  /** Torn down: the GPU resources have been handed back. Only `destroy()` sets it. */
+  let released = false;
   /** Seeded so bursts emitted before the very first frame are still accepted. */
   let lastFrameAt = performance.now();
+  /**
+   * When the pool is guaranteed empty again.
+   *
+   * The game is idle most of the time — a player thinking about their next swap
+   * is several seconds of nothing to draw. Dispatching a 6144-thread compute
+   * pass and a full-screen render pass at 60fps through all of that keeps a
+   * phone's GPU at load for no picture at all, which is what heats a device up
+   * and, on a memory-tight one, is what eventually costs us the device
+   * altogether. Bursts are the only thing that create work, so `emit` pushes
+   * this out and `frame` skips both passes once it has gone by.
+   */
+  let busyUntil = 0;
   let originX = 0;
   let originY = 0;
   const pending: Burst[] = [];
@@ -350,12 +370,19 @@ export async function createGpuParticles(canvas: HTMLCanvasElement): Promise<Par
       // Shifted here rather than at the call site: effects are written in board
       // coordinates and should stay that way.
       pending.push({ ...burst, x: burst.x + originX, y: burst.y + originY });
+      busyUntil = performance.now() + MAX_LIFETIME_MS;
     },
 
     frame(dt) {
       if (destroyed) return;
       lastFrameAt = performance.now();
       elapsed += dt;
+
+      // Nothing alive and nothing queued: the last drawn frame was already
+      // empty, so leave it on screen rather than clearing it again. See
+      // `busyUntil`.
+      if (pending.length === 0 && lastFrameAt > busyUntil) return;
+
       frameBuffer.write({ resolution: d.vec2f(width, height), dt, time: elapsed });
 
       if (pending.length > 0) {
@@ -398,18 +425,61 @@ export async function createGpuParticles(canvas: HTMLCanvasElement): Promise<Par
     },
 
     clear() {
+      if (destroyed) return;
       pending.length = 0;
       cursor = 0;
       particleBuffer.clear();
     },
 
     destroy() {
-      if (destroyed) return;
+      if (released) return;
+      released = true;
       destroyed = true;
       pending.length = 0;
       root.destroy();
     },
   };
+
+  /**
+   * Losing the GPU out from under the game.
+   *
+   * A phone takes its device away for reasons the page never sees: memory
+   * pressure, the browser going to the background, a driver reset. What is left
+   * behind is the worst possible thing to leave behind — this canvas is
+   * stretched over the entire app shell at `z-index: 20`, so a context that has
+   * stopped presenting is a sheet of nothing covering the board, the HUD and
+   * the tab bar, while `pointer-events: none` lets every touch through to a
+   * game that is still running perfectly well underneath it. That is the white
+   * screen you can still play blind.
+   *
+   * So a loss is reported rather than swallowed: the field goes inert and the
+   * caller throws this canvas away and stands a fresh one up on Canvas 2D.
+   */
+  const reportLost = (reason: string) => {
+    // `released` rather than `destroyed`: a field that has gone inert on its
+    // own still owns its buffers, and the caller's teardown has to be able to
+    // hand them back.
+    if (released || destroyed) return;
+    destroyed = true;
+    pending.length = 0;
+    options.onLost?.(reason);
+  };
+
+  // Tearing the root down ourselves resolves this promise too, which `released`
+  // is what distinguishes from a device that went away on its own.
+  void root.device.lost.then((info) => reportLost(info.message || 'GPU device lost'));
+
+  // Out of memory is fatal in the same way but arrives on a different channel,
+  // and is the likeliest of the two on a phone. Validation errors are the
+  // game's own bugs and must stay loud rather than silently downgrading it.
+  root.device.addEventListener('uncapturederror', (event) => {
+    const error = (event as GPUUncapturedErrorEvent).error;
+    if (typeof GPUOutOfMemoryError !== 'undefined' && error instanceof GPUOutOfMemoryError) {
+      reportLost(`GPU out of memory: ${error.message}`);
+      return;
+    }
+    console.error('[shape] WebGPU error:', error);
+  });
 
   field.resize(canvas.clientWidth || 1, canvas.clientHeight || 1);
   particleBuffer.clear();

--- a/docs/web-app/src/screens/games/shape/particles/index.ts
+++ b/docs/web-app/src/screens/games/shape/particles/index.ts
@@ -1,5 +1,5 @@
 import { createCanvasParticles } from './canvas';
-import type { ParticleField } from './types';
+import type { FieldOptions, ParticleField } from './types';
 
 export * from './types';
 
@@ -8,13 +8,19 @@ export * from './types';
  * that goes wrong (no `navigator.gpu`, no adapter, a shader that fails to
  * compile on an odd driver) falls back to Canvas 2D rather than taking the
  * game down with it.
+ *
+ * `options.forceCanvas` skips the attempt entirely, which is how a field is
+ * rebuilt after the GPU has already been lost once on this page.
  */
-export async function createParticleField(canvas: HTMLCanvasElement): Promise<ParticleField> {
-  if (typeof navigator !== 'undefined' && navigator.gpu) {
+export async function createParticleField(
+  canvas: HTMLCanvasElement,
+  options: FieldOptions = {},
+): Promise<ParticleField> {
+  if (!options.forceCanvas && typeof navigator !== 'undefined' && navigator.gpu) {
     try {
       // Loaded lazily so browsers without WebGPU never download TypeGPU.
       const { createGpuParticles } = await import('./gpu');
-      return await createGpuParticles(canvas);
+      return await createGpuParticles(canvas, options);
     } catch (error) {
       console.warn('[shape] WebGPU particles unavailable, using Canvas 2D:', error);
     }

--- a/docs/web-app/src/screens/games/shape/particles/types.ts
+++ b/docs/web-app/src/screens/games/shape/particles/types.ts
@@ -71,3 +71,32 @@ export const MAX_BURSTS = 64;
  * silently deletes every effect in them.
  */
 export const LOOP_STALE_MS = 250;
+
+/**
+ * The longest a particle can live, in milliseconds.
+ *
+ * Confetti is the slowest to die at 1.25s + up to 0.9s of jitter; every other
+ * kind is well under that. Both backends use this to know when the pool has
+ * certainly emptied so they can stop simulating and drawing — see the note on
+ * idling in `gpu.ts`. It is an upper bound with margin, not a measurement: too
+ * high only wastes a few frames, too low would cut particles off mid-flight.
+ */
+export const MAX_LIFETIME_MS = 2400;
+
+/** How a caller sets up a field, and how a backend reports back. */
+export type FieldOptions = {
+  /**
+   * Skip WebGPU and go straight to Canvas 2D. Set when rebuilding after a lost
+   * device: the GPU has already proven unreliable on this page, and a canvas
+   * that has handed out a `webgpu` context can never hand out a `2d` one, so
+   * the retry needs both a fresh element and a reason not to try again.
+   */
+  forceCanvas?: boolean;
+  /**
+   * The backend died under the game — a lost GPU device, a driver reset, a
+   * fatal out-of-memory. Fired at most once, and never for an ordinary
+   * `destroy()`. The field is already inert; the caller is expected to drop it
+   * and stand a new one up.
+   */
+  onLost?: (reason: string) => void;
+};


### PR DESCRIPTION
Playing Shape Cascade on a physical device would sometimes leave the whole page white — nothing drawn, but every gesture still working, haptics and all.

## What was happening

The particle canvas is portaled into `.shell` at `inset: 0; z-index: 20`, so it is the one element in the game that spans the entire app. When it stops presenting it becomes a blank sheet over the board, the HUD and the tab bar, and `pointer-events: none` lets every touch through to a game that is still running perfectly well underneath. A white screen you can carry on playing blind is that element's failure signature, not the app dying.

Two defects made it reachable on a phone, and permanent once reached.

**A backing-store reallocation storm on every super combo.** The frame loop sized the canvas from `shell.getBoundingClientRect()`. A super combo adds `.shell--shaking`, whose keyframes *rotate* the shell — so its bounding rect swells and shrinks on every frame of the animation. Measured against a live shake: 68 frames, **37 distinct rect sizes**, i.e. 37 reallocations of the 912×1176 backing store in half a second — a full-screen GPU texture churned around seventy times a second. It also wiped the very sparks the shake was celebrating.

**Nothing handled a lost GPU device.** `root.device.lost` was never awaited, `uncapturederror` was never listened for, and `created.frame(dt)` had no `try`/`catch` — so a single throw skipped the `requestAnimationFrame` reschedule and killed the loop for good, leaving the dead canvas sitting on top of everything.

Compounding both: the loop dispatched a 6144-thread compute pass and a full-screen render pass at 60 fps *forever*, including the many seconds a player spends just thinking about their next swap.

## What changed

- **Size from the layout box.** `clientWidth`/`clientHeight` are immune to transforms and measure the padding box — exactly the area `inset: 0` covers. Against the same live shake: **37 reallocations → 1**. It also corrects a 2px border offset the rect was carrying.
- **Survive a lost device.** `device.lost` and out-of-memory `uncapturederror` report through a new `onLost` callback, and `frame()` is wrapped. On loss the component bumps a generation that re-keys the canvas, so React throws the dead element away and stands a fresh one up on Canvas 2D (a canvas that has handed out a `webgpu` context can never hand out a `2d` one, hence the fresh element). If Canvas 2D fails too, the canvas comes off the page entirely — the game loses its sparks and nothing else, and can never be left hidden behind a dead context.
- **Idle when idle.** Both backends skip simulate and draw once the pool is provably empty (`MAX_LIFETIME_MS` after the last burst).

## Also fixed, unrelated

The console was throwing `Encountered two children with the same key`. Inside `.shape-board`, the tiles (`tile.id`), the combo pill (`combo.level`) and the banner (`banner.id`) are all siblings all keyed by bare small integers, and `Counter.tsx` had `popId` colliding with `delta.id` in the same slot. React answers a duplicate key by dropping one of the two children — a shape silently missing from the grid, or a banner that never appears. All namespaced.

## Verification

Driven in Chrome against the dev server:

| Check | Result |
|---|---|
| Both backends draw | 0 → 164,823 lit pixels (WebGPU) / 185,954 (Canvas 2D) → 0 once the pool empties |
| Canvas reallocations across a played session | 0 |
| Simulated device loss (`getCurrentTexture` made to throw) | one warning, canvas replaced (2 distinct elements), board stays visible and playable |
| Real match on the WebGPU path | 59,445 lit pixels at peak, 0 once settled, score climbing normally |
| Five played moves | board holds 64 tiles throughout, console clean |

`typecheck:web-app`, `build:web-app` and `prettier --check` all pass.

## For the reviewer

I could not reproduce the white screen on a physical device — the diagnosis is from the code plus the desktop measurements above, and the mechanism explains why it is phone-only (desktop GPUs do not lose devices under this pressure). Worth a run on a device that showed it before merging.