### PR TITLE
perf(docs): cut Shape Cascade's cost on WebKit

### DIFF
--- a/docs/web-app/src/screens/games/shape/ShapeSprite.tsx
+++ b/docs/web-app/src/screens/games/shape/ShapeSprite.tsx
@@ -19,6 +19,24 @@ const SILHOUETTES: Record<SilhouetteKind, string> = {
   star: 'M50 6 61.2 34.6 91.9 36.4 68.1 55.9 75.9 85.6 50 69 24.1 85.6 31.9 55.9 8.1 36.4 38.8 34.6Z',
 };
 
+/**
+ * The drop shadow, in the artwork's own coordinates.
+ *
+ * This used to be `filter: drop-shadow(0 2px 0 …)` in CSS, which put a filter
+ * on all sixty-four tiles at once. A drop-shadow with zero blur is only an
+ * offset copy of the silhouette, so drawing that copy here is the same picture
+ * for none of the cost — and it matters most on WebKit, where a filtered
+ * element takes a separate rendering path rather than compositing like its
+ * neighbours.
+ *
+ * The offset has to be a constant in user units where the filter's was 2 CSS
+ * pixels, so it cannot track the tile's size exactly. 100 user units render as
+ * 42–49 CSS px across every board width the game supports, which puts this
+ * between 1.85 and 2.15 px — indistinguishable at 16% alpha.
+ */
+const SHADOW_DY = 4.4;
+const SHADOW_FILL = 'rgba(0, 26, 114, 0.16)';
+
 type Props = {
   color: number;
   special: SpecialKind;
@@ -34,6 +52,7 @@ export function ShapeSprite({ color, special }: Props) {
         // A colour bomb belongs to no colour: a dark sphere speckled with every
         // shape hue, so it reads as "all of them at once".
         <>
+          <circle cx="50" cy={50 + SHADOW_DY} r="40" fill={SHADOW_FILL} />
           <circle cx="50" cy="50" r="40" fill="#1b1b3a" />
           {SHAPES.map((entry, index) => {
             const angle = (index / SHAPES.length) * Math.PI * 2 - Math.PI / 2;
@@ -51,6 +70,11 @@ export function ShapeSprite({ color, special }: Props) {
         </>
       ) : (
         <>
+          <path
+            d={SILHOUETTES[shape.silhouette]}
+            fill={SHADOW_FILL}
+            transform={`translate(0 ${SHADOW_DY})`}
+          />
           <path d={SILHOUETTES[shape.silhouette]} fill={shape.color} />
           <path
             d={SILHOUETTES[shape.silhouette]}

--- a/docs/web-app/src/screens/games/shape/particles/canvas.ts
+++ b/docs/web-app/src/screens/games/shape/particles/canvas.ts
@@ -241,7 +241,19 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
 
       width = w;
       height = h;
-      dpr = Math.min(2, window.devicePixelRatio || 1);
+      /*
+       * Deliberately below the device's own ratio, and below what the WebGPU
+       * backend uses.
+       *
+       * Everything this backend draws is soft: radial glows with no edge, and
+       * confetti cards a few pixels across that are spinning. There is no
+       * detail in any of it to lose, and its entire cost is fill rate — which
+       * goes with the square of this number, so 2 to 1.5 is a 44% cut for a
+       * picture nobody can tell apart. It matters because this is the path a
+       * browser without WebGPU takes, and those are the machines with the least
+       * to spare.
+       */
+      dpr = Math.min(1.5, window.devicePixelRatio || 1);
       canvas.width = Math.round(width * dpr);
       canvas.height = Math.round(height * dpr);
     },
@@ -270,6 +282,7 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
 
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, width, height);
+      let lastAlpha = -1;
 
       for (const p of pool) {
         if (p.life <= 0) continue;
@@ -294,17 +307,32 @@ export function createCanvasParticles(canvas: HTMLCanvasElement): ParticleField 
         const grow = Math.min(1, age / 0.12) * (1 - Math.max(0, (age - 0.55) / 0.45) * 0.75);
         const size = p.size * (0.35 + grow);
 
-        ctx.globalAlpha = Math.max(0, Math.min(1, fade));
+        const alpha = Math.max(0, Math.min(1, fade));
+        // Below this it is not on screen in any meaningful sense, and the last
+        // slice of a particle's life is where most of the pool sits.
+        if (alpha < 0.02) continue;
+        // Only write the state when it actually changes: a canvas state write
+        // flushes batched drawing, and this loop runs over a thousand times a
+        // frame.
+        if (alpha !== lastAlpha) {
+          ctx.globalAlpha = alpha;
+          lastAlpha = alpha;
+        }
 
         if (p.kind === BurstKind.confetti) {
           // Confetti is a solid card on the GPU too — its glow term is masked
           // out there — so it stays a flat fill here.
+          //
+          // Rotated with `setTransform` rather than save/translate/rotate/
+          // restore: the pair costs a full state push and pop per card, and the
+          // matrix here is a plain rotation about the particle, which is
+          // cheaper to write out than to build up.
           ctx.fillStyle = p.color;
-          ctx.save();
-          ctx.translate(p.x, p.y);
-          ctx.rotate(p.angle);
+          const cos = Math.cos(p.angle) * dpr;
+          const sin = Math.sin(p.angle) * dpr;
+          ctx.setTransform(cos, sin, -sin, cos, p.x * dpr, p.y * dpr);
           ctx.fillRect(-size, -size * 0.42, size * 2, size * 0.84);
-          ctx.restore();
+          ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         } else if (p.sprite) {
           // Diameter `size * 2`, matching the GPU's quad of ±size per corner.
           ctx.drawImage(p.sprite, p.x - size, p.y - size, size * 2, size * 2);

--- a/docs/web-app/src/styles.css
+++ b/docs/web-app/src/styles.css
@@ -893,7 +893,6 @@ input[type='range'] {
   left: 0;
   width: 12.5%; /* 100% / COLS */
   height: 12.5%; /* 100% / ROWS */
-  will-change: transform;
   transition: transform 265ms cubic-bezier(0.35, 1.35, 0.55, 1);
   /*
    * Freshly spawned shapes mount at their final grid position, so the drop-in
@@ -919,6 +918,18 @@ input[type='range'] {
 .shape--grabbed,
 .shape--displaced {
   transition: transform 60ms linear;
+  /*
+   * The only tiles that ask to be kept on their own layer.
+   *
+   * `will-change` used to sit on `.shape` itself, which promoted all
+   * sixty-four of them permanently — sixty-four backing stores at the device's
+   * pixel ratio, held for the whole session, for a board that is perfectly
+   * still most of the time. Everything else here animates `transform` through
+   * a transition, which promotes on its own for the duration and hands the
+   * layer back afterwards. These two are different: they track a finger, so
+   * they are re-transformed every pointer event and want the layer up front.
+   */
+  will-change: transform;
 }
 
 /*
@@ -939,6 +950,12 @@ input[type='range'] {
 
 .shape--grabbed .shape__art {
   transform: scale(1.14);
+  /*
+   * The second shadow is the *lift* — offset further and blurred, so the tile
+   * under the finger reads as picked up off the board. It is not the base
+   * shadow (which the artwork now draws itself) and has to stay here: only one
+   * tile is ever grabbed, so this filter costs nothing.
+   */
   filter: drop-shadow(0 0 8px var(--accent)) drop-shadow(0 4px 3px rgba(0, 26, 114, 0.28));
 }
 
@@ -969,19 +986,18 @@ input[type='range'] {
   height: 86%;
   margin: 7%;
   display: block;
-  filter: drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
   transition:
     transform 150ms ease,
     opacity 150ms ease;
 }
 
 .shape--special .shape__art {
-  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.95)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.95));
 }
 
 .shape--selected .shape__art {
   transform: scale(1.16);
-  filter: drop-shadow(0 0 7px var(--accent)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
+  filter: drop-shadow(0 0 7px var(--accent));
 }
 
 /*
@@ -990,6 +1006,14 @@ input[type='range'] {
  * sits under the drag classes so grabbing the shape cancels it cleanly.
  */
 .shape--hint .shape__art {
+  /*
+   * Transform only. This used to animate `filter` between a plain shadow and a
+   * glow, and an animated filter is a repaint of the element on every frame —
+   * forever, since the hint loops for as long as the player is thinking. The
+   * glow is now constant and the scale carries the pulse, which is what the eye
+   * was following anyway.
+   */
+  filter: drop-shadow(0 0 9px var(--accent));
   animation: shape-hint 1350ms ease-in-out infinite;
 }
 
@@ -997,11 +1021,9 @@ input[type='range'] {
   0%,
   100% {
     transform: scale(1);
-    filter: drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
   }
   50% {
     transform: scale(1.13);
-    filter: drop-shadow(0 0 9px var(--accent)) drop-shadow(0 2px 0 rgba(0, 26, 114, 0.16));
   }
 }
 
@@ -1086,9 +1108,12 @@ input[type='range'] {
   gap: 1px;
   padding: 7px 18px;
   border-radius: 999px;
-  background: hsl(var(--combo-hue) 85% 32% / 0.62);
-  -webkit-backdrop-filter: blur(10px) saturate(1.6);
-  backdrop-filter: blur(10px) saturate(1.6);
+  /*
+   * Tinted rather than blurred, for the reason given on `.shape-banner`. This
+   * one mattered more: the chain counter is up for the whole cascade, which is
+   * the one moment the board is already asking for everything it has.
+   */
+  background: hsl(var(--combo-hue) 85% 30% / 0.82);
   border: 2px solid hsl(var(--combo-hue) 95% 62%);
   box-shadow:
     0 0 calc(10px + var(--heat) * 26px) hsl(var(--combo-hue) 95% 60% / 0.75),
@@ -1172,7 +1197,7 @@ input[type='range'] {
   --banner-angle: 0deg; /* fallback for engines without @property */
   --banner-top: 38%;
   --banner-ring-speed: 2200ms;
-  --banner-tint: rgba(0, 26, 114, 0.58);
+  --banner-tint: rgba(0, 26, 114, 0.76);
   --banner-ring: conic-gradient(
     from var(--banner-angle),
     #38acdd,
@@ -1195,12 +1220,16 @@ input[type='range'] {
   border-radius: 999px;
   /*
    * Translucent on purpose: the celebration should sit *over* the cascade that
-   * earned it, not hide it. The blur keeps the text legible against whatever
-   * colours happen to be churning underneath.
+   * earned it, not hide it. The tint is what keeps the text legible against
+   * whatever colours happen to be churning underneath.
+   *
+   * It used to be a thinner tint over `backdrop-filter: blur(14px)`. A backdrop
+   * blur is one of the most expensive things a page can ask for, and this one
+   * asked for it on the busiest part of the busiest moment — and then re-asked
+   * every frame, because the rim above animates and keeps invalidating the
+   * pill. A slightly heavier tint reads the same and costs a single fill.
    */
   background: var(--banner-tint);
-  -webkit-backdrop-filter: blur(14px) saturate(1.7);
-  backdrop-filter: blur(14px) saturate(1.7);
   box-shadow:
     0 12px 32px rgba(0, 26, 114, 0.38),
     inset 0 1px 0 rgba(255, 255, 255, 0.28);
@@ -1291,7 +1320,7 @@ input[type='range'] {
 
 /* A tip, not a trophy: cool, calm, and it rises gently into place. */
 .shape-banner--bonus {
-  --banner-tint: rgba(11, 92, 128, 0.6);
+  --banner-tint: rgba(11, 92, 128, 0.78);
   --banner-ring: linear-gradient(120deg, var(--accent), #b5e1f1, var(--accent));
   animation: banner-bonus 1700ms cubic-bezier(0.25, 0.9, 0.3, 1) forwards;
 }
@@ -1329,7 +1358,7 @@ input[type='range'] {
 
 /* Chain reactions run hot: gold, tilted in, floating away like a score pop. */
 .shape-banner--cascade {
-  --banner-tint: rgba(104, 62, 6, 0.58);
+  --banner-tint: rgba(104, 62, 6, 0.76);
   --banner-ring: conic-gradient(from var(--banner-angle), #ffc93c, #ff9f45, #ff5a5f, #ffc93c);
   --banner-ring-speed: 3200ms;
   animation: banner-cascade 1300ms cubic-bezier(0.3, 1.2, 0.4, 1) forwards;
@@ -1391,7 +1420,7 @@ input[type='range'] {
 
 /* The loudest one: near-black, a fast rim, and it detonates on both ends. */
 .shape-banner--super {
-  --banner-tint: rgba(9, 8, 34, 0.66);
+  --banner-tint: rgba(9, 8, 34, 0.82);
   --banner-ring-speed: 1100ms;
   padding: 16px 32px;
   box-shadow:
@@ -1462,7 +1491,7 @@ input[type='range'] {
 
 /* Housekeeping. No rim, no fanfare — it just says what happened. */
 .shape-banner--info {
-  --banner-tint: rgba(43, 133, 171, 0.6);
+  --banner-tint: rgba(43, 133, 171, 0.78);
   animation: banner-info 1500ms ease-out forwards;
 }
 


### PR DESCRIPTION
Shape Cascade is smooth on Android and laggy on iOS. The markup and CSS are the same on both, so the interesting question was what actually *differs* between them — and one thing measurably does.

## The measured asymmetry

Same page, same bench, real hardware:

| | backend | main-thread draw / frame |
|---|---|---|
| Pixel 10, Chrome | **`webgpu`** | 0.60 ms (p95 1.00) |
| Safari (iOS 26.5) | **`canvas`** | — |

Safari's `requestAdapter()` returns nothing (`Error: Could not find a compatible GPU`), so the chooser drops to the Canvas 2D backend. That backend was written for a desktop: a canvas at twice the device pixel ratio, up to twelve hundred soft glow sprites drawn over it, a `save()`/`restore()` pair per confetti card, and a `globalAlpha` write per particle whether or not it changed.

Everything it draws is soft-edged — radial glows with no edge, and confetti a few pixels across that is spinning — so there is no detail in it to lose by drawing it smaller, and its entire cost is fill rate. At a 390×780 shell the backing store goes from 780×1560 to 585×1170: **1.22 megapixels a frame down to 0.68, a 44% cut**, for a picture that is indistinguishable in a screenshot.

## The rest: CSS that Blink shrugs off and WebKit does not

Counted directly in the running game:

| | before | after |
|---|---|---|
| Tiles carrying a CSS `filter` at rest | 64 | 0 (plus whatever specials are on the board) |
| Tiles promoted to their own layer at rest | 64 | 0 |
| Elements with `backdrop-filter` during play | 2 | 0 |
| Elements repainting every frame while the hint loops | 2 | 0 |

- **`.shape__art` had `filter: drop-shadow(0 2px 0 …)` on all sixty-four tiles.** A drop shadow with zero blur is only an offset copy of the silhouette, so the artwork draws that copy itself now. The offset becomes a constant in the SVG's own units rather than 2 CSS px; across every board width the game supports that lands between 1.85 and 2.15 px, which at 16% alpha is not a difference. The grabbed tile keeps its CSS filter — its second shadow is the *lift*, offset and blurred, and only one tile is ever grabbed.
- **`will-change: transform` sat on `.shape`**, promoting all sixty-four tiles permanently — sixty-four backing stores at the device pixel ratio, held for a board that is still most of the time. Everything animates `transform` through a transition, which promotes on its own for the duration; only the two tiles tracking a finger keep the hint.
- **The hint pulsed its `filter`.** An animated filter repaints the element every frame, and the hint loops for as long as the player is thinking. The glow is constant now and the scale carries the pulse, which is what the eye was following anyway.
- **The chain counter and the banners were translucent over `backdrop-filter: blur()`.** A backdrop blur is one of the most expensive things a page can ask for, and these asked for it over the busiest part of the busiest moment — then re-asked every frame, because the animated rim above kept invalidating the pill. Heavier tints read the same and cost a single fill.

## Verification

- Game plays normally on Chrome after the change: three matches, board holds 64 tiles throughout, particles peak at 41,146 lit pixels and settle to 0, clean console.
- Banner and chain-counter legibility checked against a live board with the new tints — screenshots below the fold of the diff discussion if wanted.
- Loads and renders correctly in Safari on an iOS 26.5 simulator.
- `typecheck:web-app`, `build:web-app` and `prettier --check` pass.

## For the reviewer — the honest limit

**None of this is measured on an iPhone.** The iOS simulator runs on the Mac's GPU and holds 58.8 fps at sixteen hundred filtered, promoted, animating tiles, so it cannot reproduce the symptom at all; a Pixel 10 holds 59.9 fps on the Canvas 2D fallback too. What is measured is the backend split (real hardware, both sides) and the work reductions (counted directly in the DOM). What is *reasoned* is that those reductions are what WebKit is disproportionately sensitive to.

So: this should help, and nothing here can hurt — but whether it is enough on the device that was actually stuttering needs a run on that device. Worth confirming which iOS version it is, too: WebGPU only shipped in Safari 26, so anything older takes the Canvas 2D path unconditionally.