### PR TITLE
fix(app): point the live preview at the apex /figma-preview/

### DIFF
--- a/PulsarApp/constants/env.ts
+++ b/PulsarApp/constants/env.ts
@@ -37,14 +37,15 @@ const HOSTS: Record<PulsarEnv, PulsarHosts> = {
   staging: {
     api: 'https://pulsar-server.swmtest.xyz',
     socket: 'wss://pulsar-server.swmtest.xyz',
-    preview: 'https://pulsar.swmtest.xyz/studio/figma-preview/',
+    preview: 'https://pulsar.swmtest.xyz/figma-preview/',
   },
   production: {
     api: 'https://pulsar-server.swmansion.com',
     socket: 'wss://pulsar-server.swmansion.com',
-    // The live preview ships as a subpage of Studio (same origin), not on the docs
-    // site — mirrors the Figma plugin's `preview` host.
-    preview: 'https://pulsar.swmansion.com/studio/figma-preview/',
+    // The live preview is served by the Studio deployment, at the APEX — NOT
+    // under the /studio prefix (that path falls through to the Studio SPA's
+    // index.html). Mirrors the Figma plugin's `preview` host.
+    preview: 'https://pulsar.swmansion.com/figma-preview/',
   },
 };
 


### PR DESCRIPTION
## What

`PULSAR_HOSTS.preview` for the **staging** and **production** tiers pointed at `<apex>/studio/figma-preview/`. That URL does not serve the live-preview page. Corrected to `<apex>/figma-preview/`.

## Why

Studio's reverse proxy forwards `/studio/*` to Studio's nginx **without stripping the prefix**, and that nginx serves the built files at its *root* (`studio/nginx/default.conf` in `pulsar-private`). So `/studio/figma-preview/` finds no static file and falls through to the SPA fallback, returning Studio's `index.html` — the app shell, not the preview. The page really lives at the apex.

Verified against both live tiers before and after:

| URL | Response |
| --- | --- |
| `pulsar.swmansion.com/figma-preview/` | 391 KB, `<title>Pulsar · Live Preview</title>` |
| `pulsar.swmansion.com/studio/figma-preview/` | 1.4 KB, `<title>Pulsar Studio</title>` |
| `pulsar.swmtest.xyz/figma-preview/` | 391 KB, `<title>Pulsar · Live Preview</title>` |
| `pulsar.swmtest.xyz/studio/figma-preview/` | 1.4 KB, `<title>Pulsar Studio</title>` |

The 391 KB response is byte-identical (sha1 `25a878e1251660f18fdacdc4778538928754e961`) to the committed build in `pulsar-private` at `studio/public/figma-preview/index.html`, confirming the apex path is the one the Studio deployment actually serves.

## Notes for reviewers

- **The `local` tier is deliberately untouched** — it points at `http://localhost:5173/`, the preview dev server, which is unaffected by the proxy behaviour.
- **This is one half of the fix.** The same wrong URL is baked into the Figma plugin's build (`figma/src/ui/lib/env.ts`), which is what produced the bad "open in browser" link that surfaced this. That side ships as a separate PR in `pulsar-private`, along with comment/README corrections in `figma/preview` and `studio`.
- The plugin and the app both resolve their tier at **build** time, so each needs a rebuild to pick this up.

## Testing

`npx tsc --noEmit` in `PulsarApp/` reports only pre-existing `Cannot find name 'global'` errors in `hooks/*`, unrelated to this change; `constants/env.ts` is clean.