### PR TITLE
fix(app): recover the Figma preview WebView when its renderer dies

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View, ActivityIndicator, ScrollView, TouchableOpacity } fro
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import * as Sentry from '@sentry/react-native';
 
 import type { Pattern } from 'react-native-pulsar';
 
@@ -33,6 +34,11 @@ const fullscreenEdges = {
   bottom: 'off',
   right: 'off',
 };
+
+// A killed renderer paints plain white forever, so the only cure is a fresh
+// WebView. Bounded, so a WebView that dies on every load stops remounting.
+const MAX_RENDERER_RESTARTS = 3;
+const RENDERER_RESTART_WINDOW_MS = 60_000;
 
 // Build a script that delivers a live haptics-config update into the preview.
 // The preview runs either at the top level (local dev) or inside an <iframe
@@ -100,6 +106,42 @@ function FigmaPreviewWebView({ token }: { token: string }) {
   // success and failure), and the overlay is pointerEvents="none" so it can
   // never trap a tap even if it lingers.
   const [loading, setLoading] = useState(true);
+
+  const [webViewGeneration, setWebViewGeneration] = useState(0);
+  const [gaveUpRestarting, setGaveUpRestarting] = useState(false);
+  const restartTimesRef = useRef<number[]>([]);
+
+  const remountWebView = useCallback(() => {
+    setGaveUpRestarting(false);
+    setLoading(true);
+    // The replacement page starts with its nav-bar toggle off.
+    setTabBarHidden(false);
+    setWebViewGeneration((generation) => generation + 1);
+  }, []);
+
+  const restartAfterGivingUp = useCallback(() => {
+    restartTimesRef.current = [];
+    remountWebView();
+  }, [remountWebView]);
+
+  const onRendererGone = useCallback(() => {
+    const now = Date.now();
+    restartTimesRef.current = [
+      ...restartTimesRef.current.filter((at) => now - at < RENDERER_RESTART_WINDOW_MS),
+      now,
+    ];
+    // The JS inside the dead renderer is gone, so the preview cannot report this itself.
+    Sentry.captureMessage('figma-preview: webview renderer terminated', {
+      level: 'warning',
+      extra: { restartsInWindow: restartTimesRef.current.length },
+    });
+    if (restartTimesRef.current.length > MAX_RENDERER_RESTARTS) {
+      setLoading(false);
+      setGaveUpRestarting(true);
+      return;
+    }
+    remountWebView();
+  }, [remountWebView]);
 
   // Leave the active preview and return to the Figma list/explainer by clearing
   // the route's token (FigmaScreen renders the explainer when it's empty).
@@ -172,19 +214,47 @@ function FigmaPreviewWebView({ token }: { token: string }) {
               Close preview
             </ThemedText>
           </TouchableOpacity>
+          {/* Figma's embed can report itself loaded and still paint nothing,
+              which the page cannot detect across origins. */}
+          <TouchableOpacity
+            onPress={remountWebView}
+            style={styles.closeBtn}
+            hitSlop={8}
+            accessibilityLabel="Reload preview"
+          >
+            <Icon name="refresh-cw" size={18} color="#001A72" />
+          </TouchableOpacity>
         </View>
       )}
       <View style={styles.webContainer}>
-        <WebView
-          ref={webRef}
-          source={{ uri: previewUrl }}
-          originWhitelist={['*']}
-          javaScriptEnabled
-          domStorageEnabled
-          onMessage={onMessage}
-          onLoadEnd={() => setLoading(false)}
-          style={styles.webview}
-        />
+        {gaveUpRestarting ? (
+          <View style={styles.errorBox}>
+            <ThemedText type="defaultSemiBold">The preview keeps crashing</ThemedText>
+            <ThemedText style={styles.errorText}>
+              Try again, or reopen the preview from the Figma plugin.
+            </ThemedText>
+            <TouchableOpacity onPress={restartAfterGivingUp} style={styles.retryBtn} hitSlop={8}>
+              <Icon name="refresh-cw" size={18} color="#001A72" />
+              <ThemedText type="defaultSemiBold" style={styles.closeLabel}>
+                Try again
+              </ThemedText>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <WebView
+            key={webViewGeneration}
+            ref={webRef}
+            source={{ uri: previewUrl }}
+            originWhitelist={['*']}
+            javaScriptEnabled
+            domStorageEnabled
+            onMessage={onMessage}
+            onLoadEnd={() => setLoading(false)}
+            onContentProcessDidTerminate={onRendererGone}
+            onRenderProcessGone={onRendererGone}
+            style={styles.webview}
+          />
+        )}
         {loading && (
           <View style={styles.loader} pointerEvents="none">
             <ActivityIndicator />
@@ -279,9 +349,26 @@ const styles = StyleSheet.create({
   },
   webContainer: { flex: 1, backgroundColor: '#fff' },
   webview: { flex: 1 },
+  errorBox: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    padding: 24,
+  },
+  errorText: { textAlign: 'center' },
+  retryBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
   previewBar: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderBottomWidth: 1,


### PR DESCRIPTION
## Problem

Reported symptom: with a phone connected to a Figma live preview, the WebView sometimes goes entirely white — no prototype, no chrome — and stays that way.

`app/(tabs)/figma.tsx` had **no handler for a terminated renderer process**. When the OS kills it, the native view is dead: it paints plain white and cannot be reloaded. The user had no way out short of leaving the screen. On Android an unhandled `onRenderProcessGone` crashes the app outright.

The live preview invites this — it was keeping up to 6 Figma prototype embeds alive in one WebView content process. That side is fixed separately in software-mansion-labs/pulsar-private#82 (down to 2). This PR is the host-side recovery, which is needed regardless of why the renderer dies.

## Changes

- `onContentProcessDidTerminate` (iOS) and `onRenderProcessGone` (Android) remount the WebView. A dead native view can't be reloaded, so the remount goes through a generation counter on `key`.
- Bounded to 3 restarts per minute, after which a retry card replaces what would otherwise be a silent remount loop.
- Report the termination to Sentry as `figma-preview: webview renderer terminated`. The JS inside the dead renderer is gone, so the preview's own Sentry can never report this — it was completely invisible until now.
- Add a reload control to the preview bar. Figma's embed can report itself loaded and still paint nothing; the page cannot detect that across origins, so the host needs an escape hatch the user can always reach. (In fullscreen the in-page nav toggle brings the bar back.)
- `remountWebView` restores the tab bar, since the replacement page starts with its nav-bar toggle off.

## Testing

- `tsc --noEmit` clean for this file; eslint unchanged (the 3 errors it reports in `figma.tsx` are pre-existing on `main`).
- The white screen itself was reproduced and diagnosed against the deployed preview with a real share token at mobile width — see software-mansion-labs/pulsar-private#82 for that write-up.
- **Not exercised on a device.** Renderer termination can't be triggered from a simulator without artificial memory pressure, so the recovery path here is reviewed rather than run. The Sentry message is deliberately included so the first real occurrence is visible.

## Note for the reviewer

Figma's embed reporting `INITIAL_LOAD` and then painting nothing is an upstream failure I could reproduce but not fix from either side. The reload button is the mitigation; if white screens persist after both PRs ship, that Sentry message tells you whether the renderer is being killed or the embed is simply not painting.