### PR TITLE
docs(skills): make npx the single recommended install path

### DIFF
--- a/docs/src/content/docs/skills/index.mdx
+++ b/docs/src/content/docs/skills/index.mdx
@@ -7,19 +7,14 @@ Install the `pulsar-haptics` skill from the [software-mansion-labs/skills](https
 
 ## Installation
 
-### As a plugin
-
-```text
-/plugin marketplace add software-mansion-labs/skills
-/plugin install skills@swmansion
-/reload-plugins
-```
-
-### Via `npx`
+Run this in the root of your project:
 
 ```bash
-npx skills add software-mansion-labs/skills
+npx skills add software-mansion-labs/skills --skill pulsar-haptics
 ```
+
+This is the recommended way to install the skill — it pulls in just
+`pulsar-haptics` and sets it up for the coding agents configured in your project.
 
 ## What the skill helps with
 


### PR DESCRIPTION
The [AI Skills overview](https://docs.swmansion.com/pulsar/skills/) listed two ways to install `pulsar-haptics`: a Claude Code plugin marketplace flow, and a bare `npx skills add software-mansion-labs/skills` that pulls the whole repo.

Both are replaced by the one recommended command:

```bash
npx skills add software-mansion-labs/skills --skill pulsar-haptics
```

It installs just the `pulsar-haptics` skill, and it is already what the [Figma MCP](https://docs.swmansion.com/pulsar/skills/figma-mcp/) page tells people to run — so the two pages now agree.