### PR TITLE
feat(app): open the player on a push, and make the progress bar seekable

### DIFF
--- a/PulsarApp/app/mediaLibraryModal.tsx
+++ b/PulsarApp/app/mediaLibraryModal.tsx
@@ -20,11 +20,6 @@ const NAVY = '#001A72';
 const SKY = '#38ACDD';
 const RED = '#FF6259';
 
-/**
- * A connection's media-haptics library: the player for whatever is loaded, plus the
- * resources cached on this device — each replayable without Studio pushing again.
- * Opened by tapping a Studio connection on Home, or the mini-player.
- */
 export default function MediaLibraryModal() {
   const params = useLocalSearchParams<{ connectionId?: string }>();
   const connectionId = typeof params.connectionId === 'string' ? params.connectionId : '';
@@ -38,32 +33,25 @@ export default function MediaLibraryModal() {
     closeLibrary,
     playResource,
     removeResource,
-    play,
+    playFromPlayhead,
     seek,
     stop,
   } = useMediaSession();
   const { connections } = useConnections();
 
   const connection = connections.find((c) => c.id === connectionId);
-  // Where the finger is while dragging the scrubber, so the timestamp under it follows
-  // the drag rather than the (still running) playback clock.
-  const [scrubMs, setScrubMs] = useState<number | null>(null);
+  const [draggedToMs, setDraggedToMs] = useState<number | null>(null);
 
-  // The library is loaded for as long as this screen is mounted — dismissing it (button,
-  // swipe or back) tears the state down through the cleanup.
   useEffect(() => {
     if (!connectionId) return;
     openLibrary(connectionId);
     return () => closeLibrary(connectionId);
   }, [connectionId, openLibrary, closeLibrary]);
 
-  // Only this connection's session belongs on this screen.
   const active = session && session.connectionId === connectionId ? session : null;
   const isDownloading = active?.status === 'downloading';
   const isPlaying = active?.status === 'playing';
-  // The Lottie canvas follows the drag too, so scrubbing an animation previews the frame
-  // being seeked to.
-  const shownPositionMs = scrubMs ?? positionMs;
+  const shownPositionMs = draggedToMs ?? positionMs;
   const fraction = useMemo(() => {
     if (!active) return 0;
     if (active.status === 'downloading') return downloadProgress;
@@ -107,9 +95,8 @@ export default function MediaLibraryModal() {
                     positionMs={positionMs}
                     durationMs={active.durationMs}
                     color={isDownloading ? NAVY : SKY}
-                    // Nothing to seek through until the clip is on disk.
                     disabled={isDownloading || active.status === 'error'}
-                    onScrub={setScrubMs}
+                    onScrub={setDraggedToMs}
                     onSeek={seek}
                   />
                 </View>
@@ -122,10 +109,9 @@ export default function MediaLibraryModal() {
                     label={isPlaying ? 'Stop' : 'Play'}
                     showIcon={isPlaying ? 'stop' : 'play'}
                     style={Margins.marginTop3X}
-                    // The press starts the media pattern on its own composer; a confirmation
-                    // chip on top of it would fight the very haptics being played.
+                    // A confirmation chip would fight the pattern this press starts.
                     disableHaptics
-                    onClick={() => (isPlaying ? stop() : play())}
+                    onClick={() => (isPlaying ? stop() : playFromPlayhead())}
                   />
                 )}
               </Card>
@@ -160,7 +146,6 @@ export default function MediaLibraryModal() {
   );
 }
 
-/** One cached resource. Tapping the row plays it — mirroring how a connection row opens. */
 function ResourceRow({
   record,
   active,

--- a/PulsarApp/app/mediaLibraryModal.tsx
+++ b/PulsarApp/app/mediaLibraryModal.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -7,7 +7,8 @@ import Button from '@/components/Button';
 import Card from '@/components/Card';
 import { Icon } from '@/components/Icon';
 import LottieCanvas from '@/components/media/LottieCanvas';
-import { MediaProgressBar, formatMs, sessionStatusText } from '@/components/media/MediaProgress';
+import { formatMs, sessionStatusText } from '@/components/media/MediaProgress';
+import MediaScrubber from '@/components/media/MediaScrubber';
 import { ThemedText } from '@/components/themed-text';
 import { Collapsible } from '@/components/ui/collapsible';
 import { Margins } from '@/constants/theme';
@@ -37,30 +38,37 @@ export default function MediaLibraryModal() {
     closeLibrary,
     playResource,
     removeResource,
-    repeat,
+    play,
+    seek,
     stop,
   } = useMediaSession();
   const { connections } = useConnections();
 
   const connection = connections.find((c) => c.id === connectionId);
+  // Where the finger is while dragging the scrubber, so the timestamp under it follows
+  // the drag rather than the (still running) playback clock.
+  const [scrubMs, setScrubMs] = useState<number | null>(null);
 
   // The library is loaded for as long as this screen is mounted — dismissing it (button,
   // swipe or back) tears the state down through the cleanup.
   useEffect(() => {
     if (!connectionId) return;
     openLibrary(connectionId);
-    return () => closeLibrary();
+    return () => closeLibrary(connectionId);
   }, [connectionId, openLibrary, closeLibrary]);
 
   // Only this connection's session belongs on this screen.
   const active = session && session.connectionId === connectionId ? session : null;
   const isDownloading = active?.status === 'downloading';
   const isPlaying = active?.status === 'playing';
+  // The Lottie canvas follows the drag too, so scrubbing an animation previews the frame
+  // being seeked to.
+  const shownPositionMs = scrubMs ?? positionMs;
   const fraction = useMemo(() => {
     if (!active) return 0;
     if (active.status === 'downloading') return downloadProgress;
-    return active.durationMs > 0 ? positionMs / active.durationMs : 0;
-  }, [active, downloadProgress, positionMs]);
+    return active.durationMs > 0 ? shownPositionMs / active.durationMs : 0;
+  }, [active, downloadProgress, shownPositionMs]);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -94,11 +102,19 @@ export default function MediaLibraryModal() {
                 <ThemedText type="defaultSemiBold" numberOfLines={1}>
                   {active.name}
                 </ThemedText>
-                <View style={Margins.marginTop2X}>
-                  <MediaProgressBar fraction={fraction} color={isDownloading ? NAVY : SKY} />
+                <View style={Margins.marginTop1X}>
+                  <MediaScrubber
+                    positionMs={positionMs}
+                    durationMs={active.durationMs}
+                    color={isDownloading ? NAVY : SKY}
+                    // Nothing to seek through until the clip is on disk.
+                    disabled={isDownloading || active.status === 'error'}
+                    onScrub={setScrubMs}
+                    onSeek={seek}
+                  />
                 </View>
-                <ThemedText style={[styles.meta, Margins.marginTop1X]}>
-                  {sessionStatusText(active, downloadProgress, positionMs)}
+                <ThemedText style={styles.meta}>
+                  {sessionStatusText(active, downloadProgress, shownPositionMs)}
                 </ThemedText>
 
                 {!isDownloading && active.status !== 'error' && (
@@ -109,7 +125,7 @@ export default function MediaLibraryModal() {
                     // The press starts the media pattern on its own composer; a confirmation
                     // chip on top of it would fight the very haptics being played.
                     disableHaptics
-                    onClick={() => (isPlaying ? stop() : repeat())}
+                    onClick={() => (isPlaying ? stop() : play())}
                   />
                 )}
               </Card>

--- a/PulsarApp/components/media/MediaMiniPlayer.tsx
+++ b/PulsarApp/components/media/MediaMiniPlayer.tsx
@@ -20,7 +20,7 @@ const RED = '#FF6259';
  * and the cached resources live — so this bar carries only play/stop and dismiss.
  */
 export default function MediaMiniPlayer() {
-  const { session, downloadProgress, positionMs, openConnectionId, dismissPlayer, stop, repeat } =
+  const { session, downloadProgress, positionMs, openConnectionId, dismissPlayer, stop, play } =
     useMediaSession();
   const insets = useSafeAreaInsets();
 
@@ -35,8 +35,8 @@ export default function MediaMiniPlayer() {
       ? positionMs / session.durationMs
       : 0;
 
-  // One control, one meaning: stop what's running, or start it again from the top.
-  const onTogglePlay = () => (isPlaying ? stop() : repeat());
+  // One control, one meaning: stop what's running, or resume it from the playhead.
+  const onTogglePlay = () => (isPlaying ? stop() : play());
 
   return (
     <Animated.View

--- a/PulsarApp/components/media/MediaMiniPlayer.tsx
+++ b/PulsarApp/components/media/MediaMiniPlayer.tsx
@@ -13,19 +13,21 @@ const SKY = '#38ACDD';
 const SUBTLE = '#496695';
 const RED = '#FF6259';
 
-/**
- * The pinned mini-player for media-backed haptics received from Studio: it appears above
- * the tab bar on an incoming push and stays there while something is loaded. Tapping it
- * opens that connection's library (`/mediaLibraryModal`), which is where the full player
- * and the cached resources live — so this bar carries only play/stop and dismiss.
- */
+/** Pinned above the tab bar while a resource is loaded; tapping it opens the full player. */
 export default function MediaMiniPlayer() {
-  const { session, downloadProgress, positionMs, openConnectionId, dismissPlayer, stop, play } =
-    useMediaSession();
+  const {
+    session,
+    downloadProgress,
+    positionMs,
+    openConnectionId,
+    dismissPlayer,
+    stop,
+    playFromPlayhead,
+  } = useMediaSession();
   const insets = useSafeAreaInsets();
 
-  // The library modal shows a full player of its own; don't stack a second one under it.
-  if (!session || openConnectionId) return null;
+  const libraryScreenIsOpen = openConnectionId != null;
+  if (!session || libraryScreenIsOpen) return null;
 
   const isDownloading = session.status === 'downloading';
   const isPlaying = session.status === 'playing';
@@ -35,8 +37,7 @@ export default function MediaMiniPlayer() {
       ? positionMs / session.durationMs
       : 0;
 
-  // One control, one meaning: stop what's running, or resume it from the playhead.
-  const onTogglePlay = () => (isPlaying ? stop() : play());
+  const onTogglePlay = () => (isPlaying ? stop() : playFromPlayhead());
 
   return (
     <Animated.View
@@ -95,7 +96,6 @@ const styles = StyleSheet.create({
     left: 15,
     right: 15,
   },
-  // Matches the Card look used across the app (white, 2px sky border, offset shadow).
   card: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/PulsarApp/components/media/MediaProgress.tsx
+++ b/PulsarApp/components/media/MediaProgress.tsx
@@ -24,8 +24,9 @@ export function sessionStatusText(
   if (session.status === 'error') {
     return session.error ?? 'Could not load';
   }
-  const elapsed = session.status === 'playing' ? positionMs : session.durationMs;
-  return `${formatMs(elapsed)} / ${formatMs(session.durationMs)}`;
+  // Always the playhead, playing or not: it survives a stop and follows a scrub, and this
+  // line is what tells the user where a seek landed.
+  return `${formatMs(positionMs)} / ${formatMs(session.durationMs)}`;
 }
 
 /** The download/playback bar shared by the mini-player and the library modal; `fraction` 0..1. */

--- a/PulsarApp/components/media/MediaProgress.tsx
+++ b/PulsarApp/components/media/MediaProgress.tsx
@@ -4,7 +4,6 @@ import type { MediaSession } from '@/contexts/MediaSessionContext';
 
 const SKY = '#38ACDD';
 
-/** `1:07` from a millisecond duration/position. */
 export function formatMs(ms: number): string {
   const total = Math.max(0, Math.round(ms / 1000));
   const m = Math.floor(total / 60);
@@ -12,7 +11,6 @@ export function formatMs(ms: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-/** The one-line status under a session's name: download percentage, error, or elapsed/total. */
 export function sessionStatusText(
   session: MediaSession,
   downloadProgress: number,
@@ -24,12 +22,9 @@ export function sessionStatusText(
   if (session.status === 'error') {
     return session.error ?? 'Could not load';
   }
-  // Always the playhead, playing or not: it survives a stop and follows a scrub, and this
-  // line is what tells the user where a seek landed.
   return `${formatMs(positionMs)} / ${formatMs(session.durationMs)}`;
 }
 
-/** The download/playback bar shared by the mini-player and the library modal; `fraction` 0..1. */
 export function MediaProgressBar({ fraction, color = SKY }: { fraction: number; color?: string }) {
   const pct = `${Math.max(0, Math.min(1, fraction)) * 100}%` as const;
   return (

--- a/PulsarApp/components/media/MediaScrubber.tsx
+++ b/PulsarApp/components/media/MediaScrubber.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+
+const NAVY = '#001A72';
+const SKY = '#38ACDD';
+const TRACK_HEIGHT = 6;
+const THUMB_SIZE = 18;
+// The track is 6px tall — far too thin to grab. The gesture area is padded out to a
+// comfortable target while the bar itself stays slim.
+const TOUCH_HEIGHT = 32;
+
+/**
+ * The playback bar for a media-backed haptic, draggable to seek.
+ *
+ * Reports the scrub position continuously through `onScrub` (so the caller's timestamp
+ * follows the finger) and commits once on release through `onSeek` — the seek itself
+ * re-parses and replays the pattern, which is far too expensive to do per frame.
+ */
+export default function MediaScrubber({
+  positionMs,
+  durationMs,
+  color = SKY,
+  disabled = false,
+  onSeek,
+  onScrub,
+}: {
+  positionMs: number;
+  durationMs: number;
+  color?: string;
+  disabled?: boolean;
+  onSeek: (ms: number) => void;
+  onScrub?: (ms: number | null) => void;
+}) {
+  const [width, setWidth] = useState(0);
+  // Non-null only while a finger is down; it overrides the clock so the thumb tracks the
+  // drag instead of being yanked back by the next frame of playback.
+  const [scrubMs, setScrubMs] = useState<number | null>(null);
+
+  const seekable = !disabled && durationMs > 0 && width > 0;
+  const displayMs = scrubMs ?? positionMs;
+  const fraction = durationMs > 0 ? Math.max(0, Math.min(1, displayMs / durationMs)) : 0;
+
+  const msAt = (x: number) => Math.max(0, Math.min(1, x / width)) * durationMs;
+
+  const scrub = (x: number) => {
+    const ms = msAt(x);
+    setScrubMs(ms);
+    onScrub?.(ms);
+  };
+
+  const commit = (x: number) => {
+    const ms = msAt(x);
+    setScrubMs(null);
+    onScrub?.(null);
+    onSeek(ms);
+  };
+
+  // runOnJS: these handlers drive React state and the seek, matching how Button drives its
+  // press. `event.x` is relative to this view, so the maths holds wherever it is laid out.
+  const pan = Gesture.Pan()
+    .enabled(seekable)
+    .minDistance(0)
+    .onBegin((event) => scrub(event.x))
+    .onUpdate((event) => scrub(event.x))
+    .onEnd((event) => commit(event.x))
+    // A cancelled gesture must not leave the thumb stranded away from the real playhead.
+    .onFinalize(() => {
+      setScrubMs(null);
+      onScrub?.(null);
+    })
+    .runOnJS(true);
+
+  const tap = Gesture.Tap()
+    .enabled(seekable)
+    .onEnd((event) => commit(event.x))
+    .runOnJS(true);
+
+  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+
+  return (
+    <GestureDetector gesture={Gesture.Exclusive(pan, tap)}>
+      <View style={styles.touchArea} onLayout={onLayout}>
+        <View style={styles.track}>
+          <View style={[styles.fill, { width: `${fraction * 100}%`, backgroundColor: color }]} />
+        </View>
+        {seekable && (
+          <View
+            style={[
+              styles.thumb,
+              // Inset by half the thumb at each end so it stays inside the track's bounds.
+              { left: fraction * (width - THUMB_SIZE), borderColor: color },
+            ]}
+          />
+        )}
+      </View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  touchArea: {
+    height: TOUCH_HEIGHT,
+    justifyContent: 'center',
+  },
+  track: {
+    height: TRACK_HEIGHT,
+    borderRadius: TRACK_HEIGHT / 2,
+    backgroundColor: '#D5E6F2',
+    overflow: 'hidden',
+  },
+  fill: { height: '100%', borderRadius: TRACK_HEIGHT / 2 },
+  thumb: {
+    position: 'absolute',
+    width: THUMB_SIZE,
+    height: THUMB_SIZE,
+    borderRadius: THUMB_SIZE / 2,
+    backgroundColor: 'white',
+    borderWidth: 2,
+    borderColor: NAVY,
+  },
+});

--- a/PulsarApp/components/media/MediaScrubber.tsx
+++ b/PulsarApp/components/media/MediaScrubber.tsx
@@ -6,17 +6,8 @@ const NAVY = '#001A72';
 const SKY = '#38ACDD';
 const TRACK_HEIGHT = 6;
 const THUMB_SIZE = 18;
-// The track is 6px tall — far too thin to grab. The gesture area is padded out to a
-// comfortable target while the bar itself stays slim.
-const TOUCH_HEIGHT = 32;
+const TOUCH_TARGET_HEIGHT = 32;
 
-/**
- * The playback bar for a media-backed haptic, draggable to seek.
- *
- * Reports the scrub position continuously through `onScrub` (so the caller's timestamp
- * follows the finger) and commits once on release through `onSeek` — the seek itself
- * re-parses and replays the pattern, which is far too expensive to do per frame.
- */
 export default function MediaScrubber({
   positionMs,
   durationMs,
@@ -33,50 +24,47 @@ export default function MediaScrubber({
   onScrub?: (ms: number | null) => void;
 }) {
   const [width, setWidth] = useState(0);
-  // Non-null only while a finger is down; it overrides the clock so the thumb tracks the
-  // drag instead of being yanked back by the next frame of playback.
-  const [scrubMs, setScrubMs] = useState<number | null>(null);
+  const [draggedToMs, setDraggedToMs] = useState<number | null>(null);
 
   const seekable = !disabled && durationMs > 0 && width > 0;
-  const displayMs = scrubMs ?? positionMs;
-  const fraction = durationMs > 0 ? Math.max(0, Math.min(1, displayMs / durationMs)) : 0;
+  const shownMs = draggedToMs ?? positionMs;
+  const fraction = durationMs > 0 ? Math.max(0, Math.min(1, shownMs / durationMs)) : 0;
 
-  const msAt = (x: number) => Math.max(0, Math.min(1, x / width)) * durationMs;
+  const msAtTouch = (x: number) => Math.max(0, Math.min(1, x / width)) * durationMs;
 
-  const scrub = (x: number) => {
-    const ms = msAt(x);
-    setScrubMs(ms);
+  const dragTo = (x: number) => {
+    const ms = msAtTouch(x);
+    setDraggedToMs(ms);
     onScrub?.(ms);
   };
 
-  const commit = (x: number) => {
-    const ms = msAt(x);
-    setScrubMs(null);
+  const releaseDrag = () => {
+    setDraggedToMs(null);
     onScrub?.(null);
+  };
+
+  const seekTo = (x: number) => {
+    const ms = msAtTouch(x);
+    releaseDrag();
     onSeek(ms);
   };
 
-  // runOnJS: these handlers drive React state and the seek, matching how Button drives its
-  // press. `event.x` is relative to this view, so the maths holds wherever it is laid out.
   const pan = Gesture.Pan()
     .enabled(seekable)
     .minDistance(0)
-    .onBegin((event) => scrub(event.x))
-    .onUpdate((event) => scrub(event.x))
-    .onEnd((event) => commit(event.x))
-    // A cancelled gesture must not leave the thumb stranded away from the real playhead.
-    .onFinalize(() => {
-      setScrubMs(null);
-      onScrub?.(null);
-    })
+    .onBegin((event) => dragTo(event.x))
+    .onUpdate((event) => dragTo(event.x))
+    .onEnd((event) => seekTo(event.x))
+    .onFinalize(releaseDrag)
     .runOnJS(true);
 
   const tap = Gesture.Tap()
     .enabled(seekable)
-    .onEnd((event) => commit(event.x))
+    .onEnd((event) => seekTo(event.x))
     .runOnJS(true);
 
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+  const thumbLeft = fraction * (width - THUMB_SIZE);
 
   return (
     <GestureDetector gesture={Gesture.Exclusive(pan, tap)}>
@@ -84,15 +72,7 @@ export default function MediaScrubber({
         <View style={styles.track}>
           <View style={[styles.fill, { width: `${fraction * 100}%`, backgroundColor: color }]} />
         </View>
-        {seekable && (
-          <View
-            style={[
-              styles.thumb,
-              // Inset by half the thumb at each end so it stays inside the track's bounds.
-              { left: fraction * (width - THUMB_SIZE), borderColor: color },
-            ]}
-          />
-        )}
+        {seekable && <View style={[styles.thumb, { left: thumbLeft, borderColor: color }]} />}
       </View>
     </GestureDetector>
   );
@@ -100,7 +80,7 @@ export default function MediaScrubber({
 
 const styles = StyleSheet.create({
   touchArea: {
-    height: TOUCH_HEIGHT,
+    height: TOUCH_TARGET_HEIGHT,
     justifyContent: 'center',
   },
   track: {

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -26,80 +26,70 @@ import {
   type ResourceRecord,
 } from '@/src/connections/mediaLibrary';
 
-/**
- * The device-side player for media-backed haptics (audio, and — phase 2 — Lottie) received
- * from a Studio connection.
- *
- * It owns its OWN pattern composer (separate from the connection's confirmation buzzes),
- * downloads the clip, plays the haptics in sync with the media, and tracks a playback
- * clock manually — the SDK exposes no progress/`onComplete`, so elapsed time against the
- * known duration is the only signal. Cached clips live per-connection (see mediaLibrary),
- * so a resource can be replayed from the phone even when Studio isn't pushing.
- */
+/** Plays media-backed haptics from Studio on its own composer, off its own clock. */
 
-/**
- * Seeking, given an SDK with no seek.
- *
- * `PatternComposer` exposes only parse/play/stop — there is no way to move the playhead of
- * something already playing. So a seek re-anchors the pattern itself: drop everything before
- * `fromMs`, shift the rest back to a new zero, and move the audio's trim window forward by
- * the same amount. Parsing and playing that is indistinguishable from having seeked.
- *
- * All pattern times are milliseconds from pattern start, the same unit as `sound.start` and
- * the record's `durationMs`.
- */
+type EnvelopePoint = { time: number; value: number };
+type Sound = NonNullable<Pattern['sound']>;
 
-/** The envelope's value at `atMs`, linearly interpolated between the surrounding points. */
-function valueAt(points: { time: number; value: number }[], atMs: number): number {
+const PLAYS_TO_END_OF_FILE = 0;
+
+function interpolate(points: EnvelopePoint[], atMs: number): number {
   if (points.length === 0) return 0;
   if (atMs <= points[0].time) return points[0].value;
   const last = points[points.length - 1];
   if (atMs >= last.time) return last.value;
-  const next = points.findIndex((p) => p.time > atMs);
-  const before = points[next - 1];
-  const after = points[next];
+  const nextIndex = points.findIndex((point) => point.time > atMs);
+  const before = points[nextIndex - 1];
+  const after = points[nextIndex];
   const span = after.time - before.time;
   if (span <= 0) return after.value;
   return before.value + ((after.value - before.value) * (atMs - before.time)) / span;
 }
 
-/**
- * Re-anchor one envelope at `fromMs`. The interpolated value at the seek point is prepended
- * as the new time-zero, so a seek into the middle of a ramp resumes mid-ramp instead of
- * restarting the envelope from whatever the next authored point happens to be.
- */
-function sliceEnvelope(points: { time: number; value: number }[], fromMs: number) {
-  const after = points
-    .filter((p) => p.time > fromMs)
-    .map((p) => ({ time: p.time - fromMs, value: p.value }));
-  if (after.length === 0) return [];
-  return [{ time: 0, value: valueAt(points, fromMs) }, ...after];
+function envelopeStartingAt(points: EnvelopePoint[], fromMs: number): EnvelopePoint[] {
+  const remaining = points
+    .filter((point) => point.time > fromMs)
+    .map((point) => ({ time: point.time - fromMs, value: point.value }));
+  if (remaining.length === 0) return [];
+  return [{ time: 0, value: interpolate(points, fromMs) }, ...remaining];
 }
 
-/** Re-anchor a whole pattern (haptics + audio window) so playback starts at `fromMs`. */
-function sliceFrom(pattern: Pattern, fromMs: number): Pattern {
+function soundStartingAt(sound: Sound, fromMs: number): Sound {
+  const trimmedWindow = sound.duration;
+  return {
+    ...sound,
+    start: (sound.start ?? 0) + fromMs,
+    duration: trimmedWindow ? Math.max(0, trimmedWindow - fromMs) : PLAYS_TO_END_OF_FILE,
+  };
+}
+
+/** An animation plays the pattern alone; its visual runs off the same clock. */
+function patternFor(record: ResourceRecord): Pattern {
+  if (record.kind !== 'audio') return record.pattern;
+  return {
+    ...record.pattern,
+    sound: {
+      uri: record.localUri,
+      volume: record.volume ?? 1,
+      offset: record.offset ?? 0,
+      start: record.soundStartMs ?? 0,
+      duration: record.soundDurationMs ?? PLAYS_TO_END_OF_FILE,
+    },
+  };
+}
+
+/** The composer can only play from zero, so seeking replays a re-anchored pattern. */
+function patternStartingAt(pattern: Pattern, fromMs: number): Pattern {
   if (fromMs <= 0) return pattern;
   return {
     discretePattern: pattern.discretePattern
-      .filter((p) => p.time >= fromMs)
-      .map((p) => ({ ...p, time: p.time - fromMs })),
+      .filter((point) => point.time >= fromMs)
+      .map((point) => ({ ...point, time: point.time - fromMs })),
     continuousPattern: {
-      amplitude: sliceEnvelope(pattern.continuousPattern.amplitude, fromMs),
-      frequency: sliceEnvelope(pattern.continuousPattern.frequency, fromMs),
+      amplitude: envelopeStartingAt(pattern.continuousPattern.amplitude, fromMs),
+      frequency: envelopeStartingAt(pattern.continuousPattern.frequency, fromMs),
     },
-    ...(pattern.sound
-      ? {
-          sound: {
-            ...pattern.sound,
-            start: (pattern.sound.start ?? 0) + fromMs,
-            // `duration: 0` means "to the end of the file" — keep that open-ended, and
-            // shorten a real trim window by however much we skipped.
-            duration: pattern.sound.duration
-              ? Math.max(0, pattern.sound.duration - fromMs)
-              : 0,
-          },
-        }
-      : {}),
+    ...(pattern.sound ? { sound: soundStartingAt(pattern.sound, fromMs) } : {}),
   };
 }
 
@@ -118,45 +108,25 @@ export interface MediaSession {
 }
 
 interface MediaSessionContextValue {
-  /** The active player session (download/playback), or null when idle. */
   session: MediaSession | null;
-  /** Download fraction 0..1 while `status === 'downloading'`. */
+  /** 0..1 while `status === 'downloading'`. */
   downloadProgress: number;
-  /** Playback position in ms (drives the scrubber). */
   positionMs: number;
-  /** Which connection's library screen is open, or null. */
   openConnectionId: string | null;
-  /** Cached resources for `openConnectionId`. */
   library: ResourceRecord[];
 
-  // Called by the connection message handlers on an incoming push.
   startAudioHaptics: (connectionId: string, message: AudioHapticsBroadcast) => void;
   startAnimationHaptics: (connectionId: string, message: AnimationHapticsBroadcast) => void;
 
-  /** Load a connection's cached library (the `/mediaLibraryModal` screen calls this on mount). */
   openLibrary: (connectionId: string) => void;
-  /**
-   * Drop the loaded library when that screen goes away; playback continues. Takes the
-   * connection the leaving screen was showing: an incoming push can swap the screen to a
-   * different connection, and the departing one must not clear its successor's state.
-   */
+  /** Takes the id so a screen leaving after a swap cannot clear its successor's library. */
   closeLibrary: (connectionId: string) => void;
-  /** Hide the mini-player and stop playback. */
   dismissPlayer: () => void;
-  /** Play a cached resource from the library. */
   playResource: (connectionId: string, resourceId: string) => void;
-  /**
-   * Play the current resource from wherever the playhead sits — from the top once it has
-   * run to the end, so the button still reads as "play again" after a finished clip.
-   */
-  play: () => void;
-  /** Move the playhead, restarting playback there when something is playing. */
+  playFromPlayhead: () => void;
   seek: (positionMs: number) => void;
-  /** Stop playback, leaving the playhead where it stopped. */
   stop: () => void;
-  /** Delete a cached resource (file + record). */
   removeResource: (connectionId: string, resourceId: string) => void;
-  /** Purge a removed connection's cache and clear the player if it was showing it. */
   handleConnectionRemoved: (connectionId: string) => void;
 }
 
@@ -178,13 +148,10 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   const sessionRef = useRef<MediaSession | null>(null);
   sessionRef.current = session;
   const currentRecordRef = useRef<ResourceRecord | null>(null);
-  // The playhead, read by play()/seek() without making them depend on a value the clock
-  // rewrites every frame.
   const positionRef = useRef(0);
   positionRef.current = positionMs;
-  // The active rAF handle for the playback clock. Held in a ref so a newer play() can
-  // cancel an older loop before it publishes a stale position.
   const rafRef = useRef<number | null>(null);
+  const isClockRunning = () => rafRef.current != null;
 
   const stopClock = useCallback(() => {
     if (rafRef.current != null) {
@@ -193,12 +160,10 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // Drive the scrubber off wall-clock elapsed vs the known duration — the SDK gives no
-  // position, so this is the authority for "where are we" and "when did it end".
+  /** The SDK reports no position, so elapsed wall-clock against the known duration is it. */
   const startClock = useCallback(
     (durationMs: number, fromMs = 0) => {
       stopClock();
-      // Back-date the origin so elapsed time reads from the seek point, not from zero.
       const start = Date.now() - fromMs;
       const tick = () => {
         const elapsed = Date.now() - start;
@@ -221,47 +186,24 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     if (openRef.current === connectionId) setLibrary(list);
   }, []);
 
-  /**
-   * Put the player on screen for an incoming push. Without this the arrival is announced
-   * only by the mini-player, and the user has to find and tap it to reach the controls.
-   */
   const showLibraryScreen = useCallback((connectionId: string) => {
-    if (openRef.current === connectionId) return; // already the screen in front
+    const alreadyInFront = openRef.current === connectionId;
+    if (alreadyInFront) return;
     const target = { pathname: '/mediaLibraryModal' as const, params: { connectionId } };
-    // Swap rather than stack when a different connection's library is already open.
-    if (openRef.current) router.replace(target);
+    const anotherLibraryIsOpen = openRef.current != null;
+    if (anotherLibraryIsOpen) router.replace(target);
     else router.push(target);
   }, []);
 
-  // Parse + play one cached record, and start the shared clock. Audio rides on
-  // `pattern.sound`; an animation plays the pattern alone (its visual is driven off the
-  // same clock on the library screen).
   const playRecord = useCallback(
     (connectionId: string, record: ResourceRecord, fromMs = 0) => {
       currentRecordRef.current = record;
       try {
-        // Whatever is playing must end before the next parse, or a seek (and a play from
-        // the library while something else runs) would layer two patterns and two sounds.
         composerRef.current.stop();
-        const base =
-          record.kind === 'audio'
-            ? {
-                ...record.pattern,
-                sound: {
-                  uri: record.localUri,
-                  volume: record.volume ?? 1,
-                  offset: record.offset ?? 0,
-                  // The SDK plays only [start, start+duration] of the downloaded file, so a
-                  // trimmed design honors the trim without a re-download.
-                  start: record.soundStartMs ?? 0,
-                  duration: record.soundDurationMs ?? 0,
-                },
-              }
-            : record.pattern;
-        composerRef.current.parse(sliceFrom(base, fromMs));
+        composerRef.current.parse(patternStartingAt(patternFor(record), fromMs));
         composerRef.current.play();
       } catch {
-        // Haptics may fail on an unsupported device; the media/clock still run.
+        // An unsupported device still gets the media and the clock.
       }
       setSession({
         connectionId,
@@ -294,8 +236,6 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       setDownloadProgress(0);
       setPositionMs(0);
       setSession({ connectionId, resourceId, kind, name, durationMs, status: 'downloading' });
-      // Bring the player up with the download already running, so the progress and the
-      // controls are where the user is looking.
       showLibraryScreen(connectionId);
 
       try {
@@ -375,13 +315,11 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       // no-op
     }
     setSession((s) => (s ? { ...s, status: 'stopped' } : s));
-    // The playhead stays put — it is what the scrubber shows and what play() resumes from.
   }, [stopClock]);
 
   const closeLibrary = useCallback((connectionId: string) => {
-    // A push may have already swapped the screen to another connection; only the screen
-    // that still owns the state may tear it down.
-    if (openRef.current !== connectionId) return;
+    const stillOwnsTheLibrary = openRef.current === connectionId;
+    if (!stillOwnsTheLibrary) return;
     setOpenConnectionId(null);
     setLibrary([]);
   }, []);
@@ -403,14 +341,12 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     [playRecord],
   );
 
-  const play = useCallback(() => {
+  const playFromPlayhead = useCallback(() => {
     const record = currentRecordRef.current;
     const active = sessionRef.current;
     if (!record || !active) return;
-    // A playhead parked at the end means the clip finished; start it over rather than
-    // playing zero milliseconds of it.
-    const from = positionRef.current >= record.durationMs ? 0 : positionRef.current;
-    playRecord(active.connectionId, record, from);
+    const hasRunToTheEnd = positionRef.current >= record.durationMs;
+    playRecord(active.connectionId, record, hasRunToTheEnd ? 0 : positionRef.current);
   }, [playRecord]);
 
   const seek = useCallback(
@@ -418,18 +354,14 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       const record = currentRecordRef.current;
       const active = sessionRef.current;
       if (!record || !active) return;
-      const clamped = Math.max(0, Math.min(toMs, record.durationMs));
-      // Whether playback is live is the clock's business, not the session status's.
-      // `status` is React state read back through a ref, so a seek arriving before the
-      // render that follows play() sees a stale 'stopped' and silently kills the clock it
-      // should have re-anchored. The rAF handle is written synchronously and can't lie.
-      if (rafRef.current != null) {
-        // Re-anchor and play on: the audio and haptics restart from the new point.
-        playRecord(active.connectionId, record, clamped);
+      const target = Math.max(0, Math.min(toMs, record.durationMs));
+      // `session.status` is state read back through a ref, so it still reads 'stopped'
+      // for the render after a play; the clock handle is written synchronously.
+      if (isClockRunning()) {
+        playRecord(active.connectionId, record, target);
       } else {
-        // Nothing is running — just park the playhead for the next play().
-        setPositionMs(clamped);
-        positionRef.current = clamped;
+        setPositionMs(target);
+        positionRef.current = target;
       }
     },
     [playRecord],
@@ -477,7 +409,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         closeLibrary,
         dismissPlayer,
         playResource,
-        play,
+        playFromPlayhead,
         seek,
         stop,
         removeResource,

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router';
 import React, {
   createContext,
   useCallback,
@@ -7,7 +8,7 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
-import { usePatternComposer } from 'react-native-pulsar';
+import { usePatternComposer, type Pattern } from 'react-native-pulsar';
 
 import type {
   AudioHapticsBroadcast,
@@ -35,6 +36,72 @@ import {
  * known duration is the only signal. Cached clips live per-connection (see mediaLibrary),
  * so a resource can be replayed from the phone even when Studio isn't pushing.
  */
+
+/**
+ * Seeking, given an SDK with no seek.
+ *
+ * `PatternComposer` exposes only parse/play/stop — there is no way to move the playhead of
+ * something already playing. So a seek re-anchors the pattern itself: drop everything before
+ * `fromMs`, shift the rest back to a new zero, and move the audio's trim window forward by
+ * the same amount. Parsing and playing that is indistinguishable from having seeked.
+ *
+ * All pattern times are milliseconds from pattern start, the same unit as `sound.start` and
+ * the record's `durationMs`.
+ */
+
+/** The envelope's value at `atMs`, linearly interpolated between the surrounding points. */
+function valueAt(points: { time: number; value: number }[], atMs: number): number {
+  if (points.length === 0) return 0;
+  if (atMs <= points[0].time) return points[0].value;
+  const last = points[points.length - 1];
+  if (atMs >= last.time) return last.value;
+  const next = points.findIndex((p) => p.time > atMs);
+  const before = points[next - 1];
+  const after = points[next];
+  const span = after.time - before.time;
+  if (span <= 0) return after.value;
+  return before.value + ((after.value - before.value) * (atMs - before.time)) / span;
+}
+
+/**
+ * Re-anchor one envelope at `fromMs`. The interpolated value at the seek point is prepended
+ * as the new time-zero, so a seek into the middle of a ramp resumes mid-ramp instead of
+ * restarting the envelope from whatever the next authored point happens to be.
+ */
+function sliceEnvelope(points: { time: number; value: number }[], fromMs: number) {
+  const after = points
+    .filter((p) => p.time > fromMs)
+    .map((p) => ({ time: p.time - fromMs, value: p.value }));
+  if (after.length === 0) return [];
+  return [{ time: 0, value: valueAt(points, fromMs) }, ...after];
+}
+
+/** Re-anchor a whole pattern (haptics + audio window) so playback starts at `fromMs`. */
+function sliceFrom(pattern: Pattern, fromMs: number): Pattern {
+  if (fromMs <= 0) return pattern;
+  return {
+    discretePattern: pattern.discretePattern
+      .filter((p) => p.time >= fromMs)
+      .map((p) => ({ ...p, time: p.time - fromMs })),
+    continuousPattern: {
+      amplitude: sliceEnvelope(pattern.continuousPattern.amplitude, fromMs),
+      frequency: sliceEnvelope(pattern.continuousPattern.frequency, fromMs),
+    },
+    ...(pattern.sound
+      ? {
+          sound: {
+            ...pattern.sound,
+            start: (pattern.sound.start ?? 0) + fromMs,
+            // `duration: 0` means "to the end of the file" — keep that open-ended, and
+            // shorten a real trim window by however much we skipped.
+            duration: pattern.sound.duration
+              ? Math.max(0, pattern.sound.duration - fromMs)
+              : 0,
+          },
+        }
+      : {}),
+  };
+}
 
 type SessionStatus = 'downloading' | 'ready' | 'playing' | 'stopped' | 'error';
 
@@ -68,15 +135,24 @@ interface MediaSessionContextValue {
 
   /** Load a connection's cached library (the `/mediaLibraryModal` screen calls this on mount). */
   openLibrary: (connectionId: string) => void;
-  /** Drop the loaded library when that screen goes away; playback continues. */
-  closeLibrary: () => void;
+  /**
+   * Drop the loaded library when that screen goes away; playback continues. Takes the
+   * connection the leaving screen was showing: an incoming push can swap the screen to a
+   * different connection, and the departing one must not clear its successor's state.
+   */
+  closeLibrary: (connectionId: string) => void;
   /** Hide the mini-player and stop playback. */
   dismissPlayer: () => void;
   /** Play a cached resource from the library. */
   playResource: (connectionId: string, resourceId: string) => void;
-  /** Replay the current resource from the top (media + haptics). */
-  repeat: () => void;
-  /** Stop playback (the player stays visible). */
+  /**
+   * Play the current resource from wherever the playhead sits — from the top once it has
+   * run to the end, so the button still reads as "play again" after a finished clip.
+   */
+  play: () => void;
+  /** Move the playhead, restarting playback there when something is playing. */
+  seek: (positionMs: number) => void;
+  /** Stop playback, leaving the playhead where it stopped. */
   stop: () => void;
   /** Delete a cached resource (file + record). */
   removeResource: (connectionId: string, resourceId: string) => void;
@@ -102,6 +178,10 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   const sessionRef = useRef<MediaSession | null>(null);
   sessionRef.current = session;
   const currentRecordRef = useRef<ResourceRecord | null>(null);
+  // The playhead, read by play()/seek() without making them depend on a value the clock
+  // rewrites every frame.
+  const positionRef = useRef(0);
+  positionRef.current = positionMs;
   // The active rAF handle for the playback clock. Held in a ref so a newer play() can
   // cancel an older loop before it publishes a stale position.
   const rafRef = useRef<number | null>(null);
@@ -116,9 +196,10 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   // Drive the scrubber off wall-clock elapsed vs the known duration — the SDK gives no
   // position, so this is the authority for "where are we" and "when did it end".
   const startClock = useCallback(
-    (durationMs: number) => {
+    (durationMs: number, fromMs = 0) => {
       stopClock();
-      const start = Date.now();
+      // Back-date the origin so elapsed time reads from the seek point, not from zero.
+      const start = Date.now() - fromMs;
       const tick = () => {
         const elapsed = Date.now() - start;
         if (elapsed >= durationMs) {
@@ -140,14 +221,29 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     if (openRef.current === connectionId) setLibrary(list);
   }, []);
 
+  /**
+   * Put the player on screen for an incoming push. Without this the arrival is announced
+   * only by the mini-player, and the user has to find and tap it to reach the controls.
+   */
+  const showLibraryScreen = useCallback((connectionId: string) => {
+    if (openRef.current === connectionId) return; // already the screen in front
+    const target = { pathname: '/mediaLibraryModal' as const, params: { connectionId } };
+    // Swap rather than stack when a different connection's library is already open.
+    if (openRef.current) router.replace(target);
+    else router.push(target);
+  }, []);
+
   // Parse + play one cached record, and start the shared clock. Audio rides on
   // `pattern.sound`; an animation plays the pattern alone (its visual is driven off the
   // same clock on the library screen).
   const playRecord = useCallback(
-    (connectionId: string, record: ResourceRecord) => {
+    (connectionId: string, record: ResourceRecord, fromMs = 0) => {
       currentRecordRef.current = record;
       try {
-        const pattern =
+        // Whatever is playing must end before the next parse, or a seek (and a play from
+        // the library while something else runs) would layer two patterns and two sounds.
+        composerRef.current.stop();
+        const base =
           record.kind === 'audio'
             ? {
                 ...record.pattern,
@@ -162,7 +258,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
                 },
               }
             : record.pattern;
-        composerRef.current.parse(pattern);
+        composerRef.current.parse(sliceFrom(base, fromMs));
         composerRef.current.play();
       } catch {
         // Haptics may fail on an unsupported device; the media/clock still run.
@@ -176,8 +272,9 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         status: 'playing',
         localUri: record.localUri,
       });
-      setPositionMs(0);
-      startClock(record.durationMs);
+      setPositionMs(fromMs);
+      positionRef.current = fromMs;
+      startClock(record.durationMs, fromMs);
     },
     [startClock],
   );
@@ -194,11 +291,12 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       const { resourceId, name, version, durationMs, pattern } = message;
 
       stopClock();
-      // A push shows the compact mini-player; it doesn't force the library screen open —
-      // the user opens it by tapping the connection (or the bar).
       setDownloadProgress(0);
       setPositionMs(0);
       setSession({ connectionId, resourceId, kind, name, durationMs, status: 'downloading' });
+      // Bring the player up with the download already running, so the progress and the
+      // controls are where the user is looking.
+      showLibraryScreen(connectionId);
 
       try {
         const ext = extForContentType(media.contentType);
@@ -244,7 +342,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         );
       }
     },
-    [playRecord, refreshLibrary, stopClock],
+    [playRecord, refreshLibrary, showLibraryScreen, stopClock],
   );
 
   const startAudioHaptics = useCallback(
@@ -277,10 +375,13 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       // no-op
     }
     setSession((s) => (s ? { ...s, status: 'stopped' } : s));
-    setPositionMs(0);
+    // The playhead stays put — it is what the scrubber shows and what play() resumes from.
   }, [stopClock]);
 
-  const closeLibrary = useCallback(() => {
+  const closeLibrary = useCallback((connectionId: string) => {
+    // A push may have already swapped the screen to another connection; only the screen
+    // that still owns the state may tear it down.
+    if (openRef.current !== connectionId) return;
     setOpenConnectionId(null);
     setLibrary([]);
   }, []);
@@ -302,11 +403,37 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     [playRecord],
   );
 
-  const repeat = useCallback(() => {
+  const play = useCallback(() => {
     const record = currentRecordRef.current;
     const active = sessionRef.current;
-    if (record && active) playRecord(active.connectionId, record);
+    if (!record || !active) return;
+    // A playhead parked at the end means the clip finished; start it over rather than
+    // playing zero milliseconds of it.
+    const from = positionRef.current >= record.durationMs ? 0 : positionRef.current;
+    playRecord(active.connectionId, record, from);
   }, [playRecord]);
+
+  const seek = useCallback(
+    (toMs: number) => {
+      const record = currentRecordRef.current;
+      const active = sessionRef.current;
+      if (!record || !active) return;
+      const clamped = Math.max(0, Math.min(toMs, record.durationMs));
+      // Whether playback is live is the clock's business, not the session status's.
+      // `status` is React state read back through a ref, so a seek arriving before the
+      // render that follows play() sees a stale 'stopped' and silently kills the clock it
+      // should have re-anchored. The rAF handle is written synchronously and can't lie.
+      if (rafRef.current != null) {
+        // Re-anchor and play on: the audio and haptics restart from the new point.
+        playRecord(active.connectionId, record, clamped);
+      } else {
+        // Nothing is running — just park the playhead for the next play().
+        setPositionMs(clamped);
+        positionRef.current = clamped;
+      }
+    },
+    [playRecord],
+  );
 
   const removeResource = useCallback(
     (connectionId: string, resourceId: string) => {
@@ -350,7 +477,8 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         closeLibrary,
         dismissPlayer,
         playResource,
-        repeat,
+        play,
+        seek,
         stop,
         removeResource,
         handleConnectionRemoved,


### PR DESCRIPTION
Follow-up to [#242](https://github.com/software-mansion/pulsar/pull/242) (merged), on the same media-haptics player.

## Open the player on a push

An incoming push from Studio only raised the mini-player, so reaching the controls meant spotting a small bar above the tab bar and tapping it. `startMedia` now brings `/mediaLibraryModal` up itself, with the download already running.

- Already showing that connection's library → does nothing, so a repeat push can't stack a second modal.
- Showing a *different* connection's library → `replace`, not `push`.
- Because a push can swap the screen underneath it, `closeLibrary` now takes the connection the leaving screen was showing and only clears state it still owns — otherwise the departing screen's unmount cleanup would wipe its successor's.

## Drag the progress bar to seek

`PatternComposer` exposes only `parse`/`play`/`stop` — there is no way to move the playhead of something already playing. So `seek()` replays a re-anchored pattern instead: `patternStartingAt` drops the events before the target, shifts the rest back to a new zero and interpolates the envelope value at the seek point (so a seek into a ramp resumes mid-ramp rather than restarting it), while `soundStartingAt` moves the audio's trim window forward by the same amount. Playing that is indistinguishable from having seeked, and it costs nothing extra for audio — the SDK already slices the file to `start`/`duration`, so no re-download.

`MediaScrubber` reports the drag through `onScrub` (the timestamp and the Lottie canvas follow the finger) and commits once on release — a seek re-parses the pattern, far too much to do per frame. Tap-to-seek goes through the same commit. The bar is 6px, so the touch target is padded to 32px.

Around that:

- **The playhead survives a stop**, so `playFromPlayhead()` resumes from it, and restarts from the top once the clip has run out. `repeat()` is gone — it only ever meant "from zero".
- **`playRecord` stops the composer before parsing.** Without it a seek layers a second pattern and a second sound over the first. This also fixes playing a library row while something else is already running.
- **The timestamp always reads the playhead** instead of jumping to the total when stopped — it is now what tells you where a seek landed.

## The bug this shook out

The first cut had `seek` branch on `session.status === 'playing'`. That is React state read back through a ref, and a seek arriving before the render that follows a play read a stale `'stopped'`, took the park-the-playhead branch and stopped the clock it should have re-anchored. The bar froze mid-clip while the audio played on — intermittently, and only when the seek closely followed a play.

`seek` now asks `isClockRunning()`, which reads the rAF handle: written synchronously, so it can't go stale. `playRecord` and the park branch also write `positionRef` directly instead of waiting for the next render.

## Second commit: naming over commentary

`62e5e91` is a no-behaviour-change pass replacing explanatory comments with names — `patternStartingAt` / `patternFor` / `soundStartingAt` / `envelopeStartingAt`, `playFromPlayhead`, `draggedToMs`, `seekTo` / `dragTo`, and predicates like `isClockRunning`, `hasRunToTheEnd`, `stillOwnsTheLibrary`, `libraryScreenIsOpen`. `PLAYS_TO_END_OF_FILE` names the SDK's magic `0`. Net −108 lines. What survives is the handful of facts the code can't state itself: the composer only plays from zero, the SDK reports no position, and `session.status` reads stale for one render after a play.

## Testing

Verified on an iPhone 16 Pro simulator against the **real local relay** (`ws://localhost:8080`), driven by a stand-in producer that pairs as a sender, serves a 12s WAV and pushes a genuine `audio-haptics` broadcast — so the whole path ran for real: push → auto-open → download → play → seek.

- Push with the app on Home → the player opens by itself, "Downloading… 100%" then playing; the resource lands in the library.
- Push with the modal closed → reopens it, reusing the cached clip (no re-download).
- Two further pushes while it was open → no stacked modals (one tap on X returned to Home).
- Drag while stopped → playhead parks (predicted 0:03, landed 0:03); play then resumed from 0:03, not from zero.
- Drag while playing, forwards and backwards, including two seeks back-to-back → playback continues from the new point and the clock keeps advancing.
- The freeze above was reproduced, diagnosed from instrumentation read out of the running app over CDP, fixed, and the same sequence re-run clean.
- Re-ran push → auto-open → play → seek → resume after the naming pass.

`tsc` and `eslint` are clean on the touched files (the repo has pre-existing errors elsewhere).
