### PR TITLE
feat(app): give the audio and Lottie demos the Studio player UI

### DIFF
--- a/PulsarApp/app/(tabs)/demos/_layout.tsx
+++ b/PulsarApp/app/(tabs)/demos/_layout.tsx
@@ -4,15 +4,15 @@ export default function DemosLayout() {
   return (
     <Stack screenOptions={{ headerShown: true }}>
       <Stack.Screen name="index" options={{ headerShown: false, title: 'Demos' }} />
+      <Stack.Screen name="audio-demo" options={{ headerShown: true, title: 'Audio Haptics' }} />
+      <Stack.Screen name="lottie-demo" options={{ headerShown: true, title: 'Lottie Haptics' }} />
+      <Stack.Screen name="sensor-haptics-demo" options={{ headerShown: true, title: 'Accelerometer Haptics' }} />
       <Stack.Screen name="slider-demo" options={{ headerShown: true, title: 'Slider Demo' }} />
       <Stack.Screen name="buttons-demo" options={{ headerShown: true, title: 'Buttons Demo' }} />
       <Stack.Screen name="countdown-timer-demo" options={{ headerShown: true, title: 'Countdown Timer' }} />
       <Stack.Screen name="balloon-demo" options={{ headerShown: true, title: 'Balloon Demo' }} />
       <Stack.Screen name="dot-loader-demo" options={{ headerShown: true, title: 'Dot Loader' }} />
       <Stack.Screen name="notification-haptics-demo" options={{ headerShown: true, title: 'Notification Haptics' }} />
-      <Stack.Screen name="sensor-haptics-demo" options={{ headerShown: true, title: 'Accelerometer Haptics' }} />
-      <Stack.Screen name="audio-demo" options={{ headerShown: true, title: 'Audio Haptics' }} />
-      <Stack.Screen name="lottie-demo" options={{ headerShown: true, title: 'Lottie Haptics' }} />
     </Stack>
   );
 }

--- a/PulsarApp/app/(tabs)/demos/audio-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/audio-demo.tsx
@@ -1,19 +1,17 @@
+import { useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { Pattern, usePatternComposer } from 'react-native-pulsar';
+import { usePatternComposer, type Pattern } from 'react-native-pulsar';
 
 import BasicLayout from '@/components/BasicLayout';
+import Button from '@/components/Button';
+import Card from '@/components/Card';
+import { formatMs } from '@/components/media/MediaProgress';
+import MediaScrubber from '@/components/media/MediaScrubber';
 import { ThemedText } from '@/components/themed-text';
 import { Margins } from '@/constants/theme';
-import HapticDemoButton from '@/components/demo/HapticDemoButton';
+import { patternDurationMs, patternStartingAt } from '@/src/haptics/patternSeek';
+import { usePlaybackClock } from '@/src/haptics/usePlaybackClock';
 
-// The haptic track was generated from `sample-3s.mp3` by onset/energy analysis,
-// so its discrete beats land on the music and its continuous envelope follows
-// the track's loudness. The JSON is already a `Pattern`; attaching the clip via
-// the `sound` field plays audio and haptics on one shared clock.
-//
-// Note: `require()` resolves a bundled asset to a remote Metro URL in dev but a
-// local file in release. iOS synced playback needs a local file, so verify the
-// sync on a release build / real device.
 const hapticTrack = require('@/assets/audio/sample-3s.haptics.json') as Pattern;
 
 const audioPattern: Pattern = {
@@ -24,8 +22,42 @@ const audioPattern: Pattern = {
   },
 };
 
+const durationMs = patternDurationMs(audioPattern);
+
 export default function AudioDemo() {
-  const composer = usePatternComposer(audioPattern);
+  const composer = usePatternComposer();
+  const clock = usePlaybackClock(durationMs);
+  const [draggedToMs, setDraggedToMs] = useState<number | null>(null);
+
+  const playFrom = (fromMs: number) => {
+    composer.stop();
+    composer.parse(patternStartingAt(audioPattern, fromMs));
+    composer.play();
+    clock.start(fromMs);
+  };
+
+  const stop = () => {
+    composer.stop();
+    clock.stop();
+  };
+
+  const togglePlay = () => {
+    if (clock.isRunning) {
+      stop();
+      return;
+    }
+    const hasRunToTheEnd = clock.positionMs >= durationMs;
+    playFrom(hasRunToTheEnd ? 0 : clock.positionMs);
+  };
+
+  const seek = (toMs: number) => {
+    if (clock.isRunning) {
+      playFrom(toMs);
+      return;
+    }
+    composer.stop();
+    clock.jumpTo(toMs);
+  };
 
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -34,28 +66,35 @@ export default function AudioDemo() {
           Audio-synced haptics
         </ThemedText>
         <ThemedText style={Margins.marginTop2X}>
-          A short music clip played through the pattern composer, with haptics
-          that fall on the beat. Best felt on a real device.
+          A short music clip attached to the pattern&apos;s{' '}
+          <ThemedText type="defaultSemiBold">sound</ThemedText> field, so audio and haptics share
+          one clock. Drag the progress bar to play from anywhere. Best felt on a real device.
         </ThemedText>
 
-        <View style={styles.controls}>
-          <HapticDemoButton
-            label="▶ Play"
-            onPress={() => composer.play()}
-            style={styles.button}
-          />
-          <HapticDemoButton
-            label="■ Stop"
-            onPress={() => composer.stop()}
-            style={styles.button}
-          />
-        </View>
+        <Card style={Margins.marginTop4X}>
+          <ThemedText type="defaultSemiBold" numberOfLines={1}>
+            sample-3s.mp3
+          </ThemedText>
+          <View style={Margins.marginTop1X}>
+            <MediaScrubber
+              positionMs={clock.positionMs}
+              durationMs={durationMs}
+              onScrub={setDraggedToMs}
+              onSeek={seek}
+            />
+          </View>
+          <ThemedText style={styles.meta}>
+            {formatMs(draggedToMs ?? clock.positionMs)} / {formatMs(durationMs)}
+          </ThemedText>
 
-        <ThemedText style={Margins.marginTop4X}>
-          The clip is attached through the pattern&apos;s{' '}
-          <ThemedText type="defaultSemiBold">sound</ThemedText> field, so audio
-          and haptics share one clock — no manual scheduling.
-        </ThemedText>
+          <Button
+            label={clock.isRunning ? 'Stop' : 'Play'}
+            showIcon={clock.isRunning ? 'stop' : 'play'}
+            style={Margins.marginTop3X}
+            disableHaptics
+            onClick={togglePlay}
+          />
+        </Card>
       </BasicLayout>
     </ScrollView>
   );
@@ -65,13 +104,8 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: 28,
   },
-  controls: {
-    marginTop: 22,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    columnGap: 16,
-  },
-  button: {
-    flex: 1,
+  meta: {
+    fontSize: 14,
+    color: '#496695',
   },
 });

--- a/PulsarApp/app/(tabs)/demos/index.tsx
+++ b/PulsarApp/app/(tabs)/demos/index.tsx
@@ -17,6 +17,18 @@ const defaultEdges = {
 
 const demos = [
   {
+    slug: 'audio-demo',
+    title: 'Audio Sync',
+  },
+  {
+    slug: 'lottie-demo',
+    title: 'Lottie',
+  },
+  {
+    slug: 'sensor-haptics-demo',
+    title: 'Accelerometer',
+  },
+  {
     slug: 'slider-demo',
     title: 'Slider',
   },
@@ -39,18 +51,6 @@ const demos = [
   {
     slug: 'notification-haptics-demo',
     title: 'Notification',
-  },
-  {
-    slug: 'sensor-haptics-demo',
-    title: 'Accelerometer',
-  },
-  {
-    slug: 'audio-demo',
-    title: 'Audio Sync',
-  },
-  {
-    slug: 'lottie-demo',
-    title: 'Lottie',
   },
 ];
 

--- a/PulsarApp/app/(tabs)/demos/lottie-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/lottie-demo.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { HapticLottieView, type HapticLottieRef } from 'react-native-pulsar-lottie';
-import type { Pattern } from 'react-native-pulsar';
+import { HapticLottieView } from 'react-native-pulsar-lottie';
+import { usePatternComposer, useRealtimeComposer, type Pattern } from 'react-native-pulsar';
 
 import BasicLayout from '@/components/BasicLayout';
 import Button from '@/components/Button';
@@ -10,6 +10,7 @@ import { formatMs } from '@/components/media/MediaProgress';
 import MediaScrubber from '@/components/media/MediaScrubber';
 import { ThemedText } from '@/components/themed-text';
 import { Margins } from '@/constants/theme';
+import { envelopeValueAt, patternStartingAt } from '@/src/haptics/patternSeek';
 import { usePlaybackClock } from '@/src/haptics/usePlaybackClock';
 
 const verifiedAnimation = require('@/assets/animations/verified.json');
@@ -42,18 +43,24 @@ const verifiedPattern: Pattern = {
 };
 
 export default function LottieDemo() {
-  const animation = useRef<HapticLottieRef>(null);
+  const composer = usePatternComposer();
+  const realtime = useRealtimeComposer();
   const clock = usePlaybackClock(durationMs);
   const [draggedToMs, setDraggedToMs] = useState<number | null>(null);
+  const dragging = useRef(false);
+  const playAfterDrag = useRef(false);
+
+  const shownMs = draggedToMs ?? clock.positionMs;
 
   const playFrom = (fromMs: number) => {
-    animation.current?.setTimestamp(fromMs);
-    animation.current?.resume();
+    composer.stop();
+    composer.parse(patternStartingAt(verifiedPattern, fromMs));
+    composer.play();
     clock.start(fromMs);
   };
 
   const stop = () => {
-    animation.current?.pause();
+    composer.stop();
     clock.stop();
   };
 
@@ -66,13 +73,32 @@ export default function LottieDemo() {
     playFrom(hasRunToTheEnd ? 0 : clock.positionMs);
   };
 
-  const seek = (toMs: number) => {
-    if (clock.isRunning) {
-      playFrom(toMs);
+  const scrub = (toMs: number | null) => {
+    if (toMs == null) {
+      dragging.current = false;
+      realtime.stop();
+      setDraggedToMs(null);
       return;
     }
-    animation.current?.setTimestamp(toMs);
-    clock.jumpTo(toMs);
+    if (!dragging.current) {
+      dragging.current = true;
+      playAfterDrag.current = clock.isRunning;
+      stop();
+    }
+    setDraggedToMs(toMs);
+    realtime.set(
+      envelopeValueAt(verifiedPattern.continuousPattern.amplitude, toMs),
+      envelopeValueAt(verifiedPattern.continuousPattern.frequency, toMs),
+    );
+  };
+
+  const seek = (toMs: number) => {
+    const resume = playAfterDrag.current || clock.isRunning;
+    dragging.current = false;
+    playAfterDrag.current = false;
+    realtime.stop();
+    if (resume) playFrom(toMs);
+    else clock.jumpTo(toMs);
   };
 
   return (
@@ -82,20 +108,16 @@ export default function LottieDemo() {
           Lottie + haptics
         </ThemedText>
         <ThemedText style={Margins.marginTop2X}>
-          A drop-in replacement for LottieView that plays a haptic pattern in lockstep with the
-          animation timeline. Drag the progress bar to move both together. Best felt on a real
-          device.
+          A haptic pattern played in lockstep with the animation timeline. Play runs the whole
+          pattern through the composer; dragging the progress bar streams the envelope under your
+          finger. Best felt on a real device.
         </ThemedText>
 
         <Card style={Margins.marginTop4X}>
           <View style={styles.canvas}>
             <HapticLottieView
-              ref={animation}
               source={verifiedAnimation}
-              haptics={verifiedPattern}
-              hapticMode="realtime"
-              autoPlay={false}
-              loop={false}
+              progress={durationMs > 0 ? shownMs / durationMs : 0}
               style={styles.lottie}
             />
           </View>
@@ -107,12 +129,12 @@ export default function LottieDemo() {
             <MediaScrubber
               positionMs={clock.positionMs}
               durationMs={durationMs}
-              onScrub={setDraggedToMs}
+              onScrub={scrub}
               onSeek={seek}
             />
           </View>
           <ThemedText style={styles.meta}>
-            {formatMs(draggedToMs ?? clock.positionMs)} / {formatMs(durationMs)}
+            {formatMs(shownMs)} / {formatMs(durationMs)}
           </ThemedText>
 
           <Button

--- a/PulsarApp/app/(tabs)/demos/lottie-demo.tsx
+++ b/PulsarApp/app/(tabs)/demos/lottie-demo.tsx
@@ -1,17 +1,20 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { HapticLottieView, type HapticLottieRef } from 'react-native-pulsar-lottie';
 import type { Pattern } from 'react-native-pulsar';
 
 import BasicLayout from '@/components/BasicLayout';
+import Button from '@/components/Button';
+import Card from '@/components/Card';
+import { formatMs } from '@/components/media/MediaProgress';
+import MediaScrubber from '@/components/media/MediaScrubber';
 import { ThemedText } from '@/components/themed-text';
 import { Margins } from '@/constants/theme';
-import HapticDemoButton from '@/components/demo/HapticDemoButton';
+import { usePlaybackClock } from '@/src/haptics/usePlaybackClock';
 
-// A haptic pattern spanning the ~2.4s "verified" animation. In the default
-// `realtime` mode the animation timeline is the master clock, so the haptics
-// follow play / pause / replay and land with the check: a gentle swell that
-// resolves into a firm confirming tap as the checkmark snaps in.
+const verifiedAnimation = require('@/assets/animations/verified.json');
+const durationMs = ((verifiedAnimation.op - verifiedAnimation.ip) / verifiedAnimation.fr) * 1000;
+
 const verifiedPattern: Pattern = {
   discretePattern: [
     { time: 100, amplitude: 0.35, frequency: 0.55 },
@@ -39,7 +42,38 @@ const verifiedPattern: Pattern = {
 };
 
 export default function LottieDemo() {
-  const ref = useRef<HapticLottieRef>(null);
+  const animation = useRef<HapticLottieRef>(null);
+  const clock = usePlaybackClock(durationMs);
+  const [draggedToMs, setDraggedToMs] = useState<number | null>(null);
+
+  const playFrom = (fromMs: number) => {
+    animation.current?.setTimestamp(fromMs);
+    animation.current?.resume();
+    clock.start(fromMs);
+  };
+
+  const stop = () => {
+    animation.current?.pause();
+    clock.stop();
+  };
+
+  const togglePlay = () => {
+    if (clock.isRunning) {
+      stop();
+      return;
+    }
+    const hasRunToTheEnd = clock.positionMs >= durationMs;
+    playFrom(hasRunToTheEnd ? 0 : clock.positionMs);
+  };
+
+  const seek = (toMs: number) => {
+    if (clock.isRunning) {
+      playFrom(toMs);
+      return;
+    }
+    animation.current?.setTimestamp(toMs);
+    clock.jumpTo(toMs);
+  };
 
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -48,39 +82,47 @@ export default function LottieDemo() {
           Lottie + haptics
         </ThemedText>
         <ThemedText style={Margins.marginTop2X}>
-          A drop-in replacement for LottieView that plays a haptic pattern in
-          lockstep with the animation timeline. Best felt on a real device.
+          A drop-in replacement for LottieView that plays a haptic pattern in lockstep with the
+          animation timeline. Drag the progress bar to move both together. Best felt on a real
+          device.
         </ThemedText>
 
-        <View style={styles.canvas}>
-          <HapticLottieView
-            ref={ref}
-            source={require('@/assets/animations/verified.json')}
-            haptics={verifiedPattern}
-            hapticMode="realtime"
-            autoPlay
-            loop={false}
-            style={styles.lottie}
-          />
-        </View>
+        <Card style={Margins.marginTop4X}>
+          <View style={styles.canvas}>
+            <HapticLottieView
+              ref={animation}
+              source={verifiedAnimation}
+              haptics={verifiedPattern}
+              hapticMode="realtime"
+              autoPlay={false}
+              loop={false}
+              style={styles.lottie}
+            />
+          </View>
 
-        <View style={styles.controls}>
-          <HapticDemoButton
-            label="▶ Replay"
-            onPress={() => ref.current?.play()}
-            style={styles.button}
-          />
-          <HapticDemoButton
-            label="■ Stop"
-            onPress={() => ref.current?.stop()}
-            style={styles.button}
-          />
-        </View>
+          <ThemedText type="defaultSemiBold" numberOfLines={1}>
+            Verified
+          </ThemedText>
+          <View style={Margins.marginTop1X}>
+            <MediaScrubber
+              positionMs={clock.positionMs}
+              durationMs={durationMs}
+              onScrub={setDraggedToMs}
+              onSeek={seek}
+            />
+          </View>
+          <ThemedText style={styles.meta}>
+            {formatMs(draggedToMs ?? clock.positionMs)} / {formatMs(durationMs)}
+          </ThemedText>
 
-        <ThemedText style={Margins.marginTop4X}>
-          The timeline drives the haptics, so pausing or replaying the animation
-          keeps them in sync automatically.
-        </ThemedText>
+          <Button
+            label={clock.isRunning ? 'Stop' : 'Play'}
+            showIcon={clock.isRunning ? 'stop' : 'play'}
+            style={Margins.marginTop3X}
+            disableHaptics
+            onClick={togglePlay}
+          />
+        </Card>
       </BasicLayout>
     </ScrollView>
   );
@@ -91,27 +133,22 @@ const styles = StyleSheet.create({
     paddingBottom: 28,
   },
   canvas: {
-    marginTop: 22,
-    height: 220,
-    borderRadius: 8,
+    height: 200,
+    borderRadius: 4,
+    backgroundColor: '#E1F3FA',
     borderWidth: 2,
-    borderColor: '#38ACDD',
-    backgroundColor: 'white',
+    borderColor: '#B5E1F1',
+    overflow: 'hidden',
+    marginBottom: 12,
     alignItems: 'center',
     justifyContent: 'center',
-    overflow: 'hidden',
   },
   lottie: {
     width: 180,
     height: 180,
   },
-  controls: {
-    marginTop: 22,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    columnGap: 16,
-  },
-  button: {
-    flex: 1,
+  meta: {
+    fontSize: 14,
+    color: '#496695',
   },
 });

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -25,43 +25,9 @@ import {
   type MediaKind,
   type ResourceRecord,
 } from '@/src/connections/mediaLibrary';
+import { PLAYS_TO_END_OF_FILE, patternStartingAt } from '@/src/haptics/patternSeek';
 
 /** Plays media-backed haptics from Studio on its own composer, off its own clock. */
-
-type EnvelopePoint = { time: number; value: number };
-type Sound = NonNullable<Pattern['sound']>;
-
-const PLAYS_TO_END_OF_FILE = 0;
-
-function interpolate(points: EnvelopePoint[], atMs: number): number {
-  if (points.length === 0) return 0;
-  if (atMs <= points[0].time) return points[0].value;
-  const last = points[points.length - 1];
-  if (atMs >= last.time) return last.value;
-  const nextIndex = points.findIndex((point) => point.time > atMs);
-  const before = points[nextIndex - 1];
-  const after = points[nextIndex];
-  const span = after.time - before.time;
-  if (span <= 0) return after.value;
-  return before.value + ((after.value - before.value) * (atMs - before.time)) / span;
-}
-
-function envelopeStartingAt(points: EnvelopePoint[], fromMs: number): EnvelopePoint[] {
-  const remaining = points
-    .filter((point) => point.time > fromMs)
-    .map((point) => ({ time: point.time - fromMs, value: point.value }));
-  if (remaining.length === 0) return [];
-  return [{ time: 0, value: interpolate(points, fromMs) }, ...remaining];
-}
-
-function soundStartingAt(sound: Sound, fromMs: number): Sound {
-  const trimmedWindow = sound.duration;
-  return {
-    ...sound,
-    start: (sound.start ?? 0) + fromMs,
-    duration: trimmedWindow ? Math.max(0, trimmedWindow - fromMs) : PLAYS_TO_END_OF_FILE,
-  };
-}
 
 /** An animation plays the pattern alone; its visual runs off the same clock. */
 function patternFor(record: ResourceRecord): Pattern {
@@ -75,21 +41,6 @@ function patternFor(record: ResourceRecord): Pattern {
       start: record.soundStartMs ?? 0,
       duration: record.soundDurationMs ?? PLAYS_TO_END_OF_FILE,
     },
-  };
-}
-
-/** The composer can only play from zero, so seeking replays a re-anchored pattern. */
-function patternStartingAt(pattern: Pattern, fromMs: number): Pattern {
-  if (fromMs <= 0) return pattern;
-  return {
-    discretePattern: pattern.discretePattern
-      .filter((point) => point.time >= fromMs)
-      .map((point) => ({ ...point, time: point.time - fromMs })),
-    continuousPattern: {
-      amplitude: envelopeStartingAt(pattern.continuousPattern.amplitude, fromMs),
-      frequency: envelopeStartingAt(pattern.continuousPattern.frequency, fromMs),
-    },
-    ...(pattern.sound ? { sound: soundStartingAt(pattern.sound, fromMs) } : {}),
   };
 }
 

--- a/PulsarApp/src/haptics/patternSeek.ts
+++ b/PulsarApp/src/haptics/patternSeek.ts
@@ -1,0 +1,61 @@
+import type { Pattern } from 'react-native-pulsar';
+
+type EnvelopePoint = { time: number; value: number };
+type Sound = NonNullable<Pattern['sound']>;
+
+export const PLAYS_TO_END_OF_FILE = 0;
+
+function valueAt(points: EnvelopePoint[], atMs: number): number {
+  if (points.length === 0) return 0;
+  if (atMs <= points[0].time) return points[0].value;
+  const last = points[points.length - 1];
+  if (atMs >= last.time) return last.value;
+  const nextIndex = points.findIndex((point) => point.time > atMs);
+  const before = points[nextIndex - 1];
+  const after = points[nextIndex];
+  const span = after.time - before.time;
+  if (span <= 0) return after.value;
+  return before.value + ((after.value - before.value) * (atMs - before.time)) / span;
+}
+
+function envelopeStartingAt(points: EnvelopePoint[], fromMs: number): EnvelopePoint[] {
+  const remaining = points
+    .filter((point) => point.time > fromMs)
+    .map((point) => ({ time: point.time - fromMs, value: point.value }));
+  if (remaining.length === 0) return [];
+  return [{ time: 0, value: valueAt(points, fromMs) }, ...remaining];
+}
+
+function soundStartingAt(sound: Sound, fromMs: number): Sound {
+  const trimmedWindow = sound.duration;
+  return {
+    ...sound,
+    start: (sound.start ?? 0) + fromMs,
+    duration: trimmedWindow ? Math.max(0, trimmedWindow - fromMs) : PLAYS_TO_END_OF_FILE,
+  };
+}
+
+/** The composer can only play from zero, so seeking replays a re-anchored pattern. */
+export function patternStartingAt(pattern: Pattern, fromMs: number): Pattern {
+  if (fromMs <= 0) return pattern;
+  return {
+    discretePattern: pattern.discretePattern
+      .filter((point) => point.time >= fromMs)
+      .map((point) => ({ ...point, time: point.time - fromMs })),
+    continuousPattern: {
+      amplitude: envelopeStartingAt(pattern.continuousPattern.amplitude, fromMs),
+      frequency: envelopeStartingAt(pattern.continuousPattern.frequency, fromMs),
+    },
+    ...(pattern.sound ? { sound: soundStartingAt(pattern.sound, fromMs) } : {}),
+  };
+}
+
+export function patternDurationMs(pattern: Pattern): number {
+  const lastTimeOf = (points: { time: number }[]) =>
+    points.reduce((latest, point) => Math.max(latest, point.time), 0);
+  return Math.max(
+    lastTimeOf(pattern.discretePattern),
+    lastTimeOf(pattern.continuousPattern.amplitude),
+    lastTimeOf(pattern.continuousPattern.frequency),
+  );
+}

--- a/PulsarApp/src/haptics/patternSeek.ts
+++ b/PulsarApp/src/haptics/patternSeek.ts
@@ -1,11 +1,11 @@
 import type { Pattern } from 'react-native-pulsar';
 
-type EnvelopePoint = { time: number; value: number };
+export type EnvelopePoint = { time: number; value: number };
 type Sound = NonNullable<Pattern['sound']>;
 
 export const PLAYS_TO_END_OF_FILE = 0;
 
-function valueAt(points: EnvelopePoint[], atMs: number): number {
+export function envelopeValueAt(points: EnvelopePoint[], atMs: number): number {
   if (points.length === 0) return 0;
   if (atMs <= points[0].time) return points[0].value;
   const last = points[points.length - 1];
@@ -23,7 +23,7 @@ function envelopeStartingAt(points: EnvelopePoint[], fromMs: number): EnvelopePo
     .filter((point) => point.time > fromMs)
     .map((point) => ({ time: point.time - fromMs, value: point.value }));
   if (remaining.length === 0) return [];
-  return [{ time: 0, value: valueAt(points, fromMs) }, ...remaining];
+  return [{ time: 0, value: envelopeValueAt(points, fromMs) }, ...remaining];
 }
 
 function soundStartingAt(sound: Sound, fromMs: number): Sound {

--- a/PulsarApp/src/haptics/usePlaybackClock.ts
+++ b/PulsarApp/src/haptics/usePlaybackClock.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PlaybackClock {
+  positionMs: number;
+  isRunning: boolean;
+  start: (fromMs: number) => void;
+  stop: () => void;
+  jumpTo: (ms: number) => void;
+}
+
+/** The SDK reports no position, so elapsed wall-clock against the known duration is it. */
+export function usePlaybackClock(durationMs: number): PlaybackClock {
+  const [positionMs, setPositionMs] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const frameRef = useRef<number | null>(null);
+
+  const cancelFrame = useCallback(() => {
+    if (frameRef.current != null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(
+    (fromMs: number) => {
+      cancelFrame();
+      const startedAt = Date.now() - fromMs;
+      setPositionMs(fromMs);
+      setIsRunning(true);
+      const tick = () => {
+        const elapsed = Date.now() - startedAt;
+        if (elapsed >= durationMs) {
+          frameRef.current = null;
+          setPositionMs(durationMs);
+          setIsRunning(false);
+          return;
+        }
+        setPositionMs(elapsed);
+        frameRef.current = requestAnimationFrame(tick);
+      };
+      frameRef.current = requestAnimationFrame(tick);
+    },
+    [cancelFrame, durationMs],
+  );
+
+  const stop = useCallback(() => {
+    cancelFrame();
+    setIsRunning(false);
+  }, [cancelFrame]);
+
+  const jumpTo = useCallback(
+    (ms: number) => {
+      cancelFrame();
+      setIsRunning(false);
+      setPositionMs(Math.max(0, Math.min(ms, durationMs)));
+    },
+    [cancelFrame, durationMs],
+  );
+
+  useEffect(() => cancelFrame, [cancelFrame]);
+
+  return { positionMs, isRunning, start, stop, jumpTo };
+}


### PR DESCRIPTION
## What

The **Audio Sync** and **Lottie** demos now look and behave like the media player the app already shows when it is paired with Studio (`mediaLibraryModal`):

- a `Card` holding the clip name, a **seekable progress bar** (`MediaScrubber`), an elapsed / total readout, and a single **Play / Stop** button
- dragging the bar seeks; releasing it resumes from there when playing, or just moves the playhead when stopped
- one description per demo instead of two paragraphs sandwiching the controls
- the demo list (and the stack) now opens with **Audio Sync → Lottie → Accelerometer**, then the rest

## How

- `src/haptics/patternSeek.ts` — the pattern re-anchoring helpers (`patternStartingAt`, plus the sound-window trim) move out of `MediaSessionContext` so the demos and the Studio player share one implementation. The composer can only play from zero, so seeking replays a pattern shifted to the target time; audio follows via the `sound.start` window.
- `src/haptics/usePlaybackClock.ts` — the wall-clock playhead (rAF against a known duration) the progress bar reads, since the SDK reports no position.
- Both demos drive `usePatternComposer` directly. The Lottie demo plays its pattern on the composer too, rather than streaming it through `RealtimeComposer`: the realtime path has no audio simulation on iOS, so the demo was silent in the simulator while every pattern-based demo could be heard. `RealtimeComposer` is now used only for scrubbing — dragging the bar streams the envelope under the finger, pauses playback for the drag, and resumes from where it is dropped. The animation follows the playhead through `progress`, the way the Studio player's `LottieCanvas` does.

`MediaSessionContext` keeps its behaviour — only the extracted helpers changed hands.

## Test plan

- `tsc --noEmit` clean for the touched files (the repo has a pre-existing baseline of unrelated errors)
- `expo export -p ios` bundles the whole app
- iPhone 17 Pro simulator, both screens: play, stop mid-playback (playhead freezes where it was), run to the end (button flips back to Play), tap-seek and drag-seek while stopped, resume from the dragged position, scrub while playing, and replay after the clip ended. Seeking the Lottie demo while stopped moves the animation frame with the bar.

Playback is audible in the simulator through Pulsar's `AudioSimulator` (wired into `PatternComposer` only); the scrub feedback and the haptics themselves need a real device.
