### PR TITLE
fix(examples): pin shared modules to one copy in the RN example's Metro config

### DIFF
--- a/react-native/PulsarApp/metro.config.js
+++ b/react-native/PulsarApp/metro.config.js
@@ -2,40 +2,53 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withPulsar } = require('react-native-pulsar/metro');
 const path = require('path');
 
-/**
- * Metro configuration
- * https://reactnative.dev/docs/metro
- *
- * @type {import('@react-native/metro-config').MetroConfig}
- */
+// Packages linked with `file:` live outside `projectRoot`, so Metro has to watch them directly.
+const linkedPackages = {
+  'react-native-pulsar': path.resolve(__dirname, '../react-native-pulsar'),
+  'react-native-pulsar-lottie': path.resolve(__dirname, '../PulsarLottie'),
+};
+
+// Modules that must resolve to exactly one copy — the app's. Each linked package installs its own
+// dev copies at its own versions, and picking one of those up breaks at runtime: worklets, for
+// instance, compares the version of its JS against the version of the Babel plugin that compiled
+// the app.
+const sharedModules = [
+  ...Object.keys(linkedPackages),
+  'react',
+  'react-native',
+  'react-native-worklets',
+  'react-native-reanimated',
+  'lottie-react-native',
+  'react-native-gesture-handler',
+  'react-native-safe-area-context',
+];
+
+const isSharedModule = moduleName =>
+  sharedModules.some(name => moduleName === name || moduleName.startsWith(`${name}/`));
+
+/** @type {import('@react-native/metro-config').MetroConfig} */
 const config = {
   projectRoot: __dirname,
-  watchFolders: [
-    path.resolve(__dirname, '../react-native-pulsar'),
-    path.resolve(__dirname, '../PulsarLottie'),
-  ],
+  watchFolders: Object.values(linkedPackages),
   resolver: {
-    extraNodeModules: {
-      'react-native': path.resolve(__dirname, './node_modules/react-native'),
-      react: path.resolve(__dirname, './node_modules/react'),
-      'react-native-reanimated': path.resolve(__dirname, './node_modules/react-native-reanimated'),
-      'react-native-worklets': path.resolve(__dirname, './node_modules/react-native-worklets'),
-      'lottie-react-native': path.resolve(__dirname, './node_modules/lottie-react-native'),
+    // Keep the linked packages' own copies out of the graph entirely, so they are neither crawled
+    // nor reachable by a relative path that sidesteps `resolveRequest`.
+    blockList: Object.values(linkedPackages).flatMap(dir =>
+      sharedModules.map(name => new RegExp(`^${escapeRegExp(path.join(dir, 'node_modules', name))}/`)),
+    ),
+    resolveRequest: (context, moduleName, platform) => {
+      // Resolve shared modules as if the import came from the app root, whatever imported them.
+      const origin = isSharedModule(moduleName)
+        ? { ...context, originModulePath: path.join(__dirname, 'metro.config.js') }
+        : context;
+      return context.resolveRequest(origin, moduleName, platform);
     },
-    blockList: [
-      // Prevent Metro from using react-native from a library's node_modules
-      /react-native-pulsar\/node_modules\/react-native\/.*/,
-      /react-native-pulsar\/node_modules\/react\/.*/,
-      // ...and the same for the Lottie wrapper package.
-      /PulsarLottie\/node_modules\/react-native\/.*/,
-      /PulsarLottie\/node_modules\/react\/.*/,
-      /PulsarLottie\/node_modules\/react-native-reanimated\/.*/,
-      /PulsarLottie\/node_modules\/react-native-worklets\/.*/,
-      /PulsarLottie\/node_modules\/lottie-react-native\/.*/,
-      /PulsarLottie\/node_modules\/react-native-pulsar\/.*/,
-    ],
   },
 };
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 // `withPulsar` adds `.pulsar` to assetExts, so `require('./assets/test.pulsar')` resolves. Only
 // the binary path (bundle audio) needs it — the inline sidecar is a plain JSON import.


### PR DESCRIPTION
## Problem

Opening the audio screen in `react-native/PulsarApp` crashed with:

> worklets mismatch between JavaScript code version and WorkletsBabelPlugin (0.7.2 vs 0.10.3)

`react-native-pulsar/src/useSharableState.ts` imports `react-native-worklets`, and Metro resolved it from `react-native-pulsar/node_modules/react-native-worklets` — **0.7.2**, the library's own devDependency — while the app's Babel plugin is 0.10.3.

The old `blockList` excluded `react` and `react-native` from that directory but not worklets, and the `extraNodeModules` mapping couldn't compensate: Metro only consults `extraNodeModules` *after* the normal `node_modules` walk fails, and the nested copy made it succeed.

`PulsarLottie/node_modules` had the same problem in waiting — worklets 0.11.3, reanimated 4.5.3, lottie 7.3.8, and a published `react-native-pulsar@1.7.0`.

## Change

Instead of adding one more hand-written blockList line, the config now derives everything from two lists:

- `linkedPackages` — the `file:`-linked packages, used for both `watchFolders` and blockList generation.
- `sharedModules` — modules that must resolve to exactly one copy (the app's).

From those:

- A `resolveRequest` resolves any shared module *as if the import came from the app root*, whatever imported it. Deterministic, and it covers subpath imports like `react-native-worklets/plugin`.
- `blockList` is generated as `linkedPackages × sharedModules` (18 entries, was 9 hand-written), keeping the nested copies out of the graph entirely.

Adding a linked package or a new shared peer is now a one-line edit.

## Verification

`npx react-native bundle --platform ios --dev true --reset-cache`:

- bundle builds clean
- `0.7.2` no longer appears anywhere in the output
- `jsVersion = '0.10.3'`, matching the Babel plugin
- 14 modules resolve from `PulsarLottie/src`, zero from any linked package's `node_modules`

## Note

The underlying smell is that both linked packages pin shared peers as exact devDependencies at versions the app doesn't use. Metro now papers over it for the example app, but Jest runs and `bob build` inside those packages still use their own copies.