### PR TITLE
feat(app): play plain haptic patterns from the library, like audio and Lottie

### DIFF
--- a/PulsarApp/app/mediaLibraryModal.tsx
+++ b/PulsarApp/app/mediaLibraryModal.tsx
@@ -5,8 +5,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Button from '@/components/Button';
 import Card from '@/components/Card';
-import { Icon } from '@/components/Icon';
+import { Icon, type IconName } from '@/components/Icon';
 import LottieCanvas from '@/components/media/LottieCanvas';
+import PatternCanvas from '@/components/media/PatternCanvas';
 import { formatMs, sessionStatusText } from '@/components/media/MediaProgress';
 import MediaScrubber from '@/components/media/MediaScrubber';
 import { ThemedText } from '@/components/themed-text';
@@ -14,11 +15,22 @@ import { Collapsible } from '@/components/ui/collapsible';
 import { Margins } from '@/constants/theme';
 import { connectionDisplayName, useConnections } from '@/contexts/ConnectionsContext';
 import { useMediaSession } from '@/contexts/MediaSessionContext';
-import type { ResourceRecord } from '@/src/connections/mediaLibrary';
+import type { MediaKind, ResourceRecord } from '@/src/connections/mediaLibrary';
 
 const NAVY = '#001A72';
 const SKY = '#38ACDD';
 const RED = '#FF6259';
+
+const KIND_ICON: Record<MediaKind, IconName> = {
+  audio: 'play',
+  animation: 'sparkles',
+  pattern: 'record',
+};
+const KIND_LABEL: Record<MediaKind, string> = {
+  audio: 'Audio',
+  animation: 'Animation',
+  pattern: 'Pattern',
+};
 
 export default function MediaLibraryModal() {
   const params = useLocalSearchParams<{ connectionId?: string }>();
@@ -35,6 +47,7 @@ export default function MediaLibraryModal() {
     removeResource,
     playFromPlayhead,
     seek,
+    pause,
     stop,
   } = useMediaSession();
   const { connections } = useConnections();
@@ -86,6 +99,13 @@ export default function MediaLibraryModal() {
                 {active.kind === 'animation' && active.localUri && (
                   <LottieCanvas uri={active.localUri} progress={fraction} />
                 )}
+                {active.kind === 'pattern' && (
+                  <PatternCanvas
+                    pattern={active.pattern}
+                    durationMs={active.durationMs}
+                    progress={fraction}
+                  />
+                )}
 
                 <ThemedText type="defaultSemiBold" numberOfLines={1}>
                   {active.name}
@@ -105,14 +125,27 @@ export default function MediaLibraryModal() {
                 </ThemedText>
 
                 {!isDownloading && active.status !== 'error' && (
-                  <Button
-                    label={isPlaying ? 'Stop' : 'Play'}
-                    showIcon={isPlaying ? 'stop' : 'play'}
-                    style={Margins.marginTop3X}
-                    // A confirmation chip would fight the pattern this press starts.
-                    disableHaptics
-                    onClick={() => (isPlaying ? stop() : playFromPlayhead())}
-                  />
+                  <View style={[styles.transport, Margins.marginTop3X]}>
+                    <Button
+                      label={isPlaying ? 'Pause' : 'Play'}
+                      showIcon={isPlaying ? 'stop' : 'play'}
+                      style={styles.transportPrimary}
+                      // A confirmation chip would fight the pattern this press starts.
+                      disableHaptics
+                      onClick={() => (isPlaying ? pause() : playFromPlayhead())}
+                    />
+                    <TouchableOpacity
+                      onPress={stop}
+                      disabled={!isPlaying && positionMs === 0}
+                      style={[
+                        styles.stopButton,
+                        !isPlaying && positionMs === 0 && styles.stopButtonDisabled,
+                      ]}
+                      accessibilityLabel="Stop"
+                    >
+                      <Icon name="square" size={20} color={RED} />
+                    </TouchableOpacity>
+                  </View>
                 )}
               </Card>
             )}
@@ -124,8 +157,7 @@ export default function MediaLibraryModal() {
             >
               {library.length === 0 ? (
                 <ThemedText style={[styles.meta, Margins.marginTop1X]}>
-                  Nothing yet. Play an audio- or animation-based haptic from Studio and it appears
-                  here.
+                  Nothing yet. Play a preset from Studio and it appears here.
                 </ThemedText>
               ) : (
                 library.map((record) => (
@@ -161,13 +193,13 @@ function ResourceRow({
     <Card style={[styles.resourceCard, active && styles.resourceCardActive]}>
       <View style={styles.resourceRow}>
         <TouchableOpacity style={styles.pressArea} onPress={onPlay} activeOpacity={0.6}>
-          <Icon name={record.kind === 'animation' ? 'sparkles' : 'play'} size={18} color={NAVY} />
+          <Icon name={KIND_ICON[record.kind]} size={18} color={NAVY} />
           <View style={styles.resourceInfo}>
             <ThemedText type="defaultSemiBold" numberOfLines={1}>
               {record.name}
             </ThemedText>
             <ThemedText style={styles.meta} numberOfLines={1}>
-              {record.kind === 'animation' ? 'Animation' : 'Audio'} · {formatMs(record.durationMs)}
+              {KIND_LABEL[record.kind]} · {formatMs(record.durationMs)}
             </ThemedText>
           </View>
         </TouchableOpacity>
@@ -216,6 +248,27 @@ const styles = StyleSheet.create({
   meta: {
     fontSize: 14,
     color: '#496695',
+  },
+  transport: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    gap: 10,
+  },
+  transportPrimary: {
+    flex: 1,
+  },
+  stopButton: {
+    width: 60,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'white',
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: RED,
+    boxShadow: '-3px 3px 0px #FF6259',
+  },
+  stopButtonDisabled: {
+    opacity: 0.4,
   },
   resourceCard: {
     paddingVertical: 12,

--- a/PulsarApp/components/media/MediaMiniPlayer.tsx
+++ b/PulsarApp/components/media/MediaMiniPlayer.tsx
@@ -21,7 +21,7 @@ export default function MediaMiniPlayer() {
     positionMs,
     openConnectionId,
     dismissPlayer,
-    stop,
+    pause,
     playFromPlayhead,
   } = useMediaSession();
   const insets = useSafeAreaInsets();
@@ -37,7 +37,7 @@ export default function MediaMiniPlayer() {
       ? positionMs / session.durationMs
       : 0;
 
-  const onTogglePlay = () => (isPlaying ? stop() : playFromPlayhead());
+  const onTogglePlay = () => (isPlaying ? pause() : playFromPlayhead());
 
   return (
     <Animated.View
@@ -72,7 +72,7 @@ export default function MediaMiniPlayer() {
             onPress={onTogglePlay}
             hitSlop={8}
             style={styles.iconBtn}
-            accessibilityLabel={isPlaying ? 'Stop' : 'Play'}
+            accessibilityLabel={isPlaying ? 'Pause' : 'Play'}
           >
             <Icon name={isPlaying ? 'stop' : 'play'} size={20} color={NAVY} />
           </TouchableOpacity>

--- a/PulsarApp/components/media/PatternCanvas.tsx
+++ b/PulsarApp/components/media/PatternCanvas.tsx
@@ -1,0 +1,171 @@
+import { useId, useState } from 'react';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import type { Pattern } from 'react-native-pulsar';
+import Svg, {
+  ClipPath,
+  Defs,
+  G,
+  Line,
+  LinearGradient,
+  Path,
+  Rect,
+  Stop,
+} from 'react-native-svg';
+
+const NAVY = '#001A72';
+const FLAT_FILL = '#B5E1F1';
+const FLAT_STROKE = '#38ACDD';
+const HEIGHT = 120;
+const INSET = 3;
+const UNPLAYED_OPACITY = 0.3;
+
+/** Frequency → hue, matching the Figma plugin: 0 → blue (220°), 1 → warm (20°). */
+const freqColor = (f: number) => `hsl(${Math.round(220 - clamp01(f) * 200)}, 70%, 45%)`;
+
+function clamp01(v: number) {
+  return Math.max(0, Math.min(1, v));
+}
+
+/**
+ * The pattern as the Figma plugin draws it: an amplitude envelope anchored to the
+ * baseline, tinted along the time axis by the continuous frequency, with one bar per
+ * discrete impulse coloured by its own frequency. What has played is drawn at full
+ * strength over a faded copy of the whole pattern, so `progress` (0..1, off the same
+ * clock as the haptics) reads as the pattern filling in.
+ */
+export default function PatternCanvas({
+  pattern,
+  durationMs,
+  progress,
+}: {
+  pattern: Pattern;
+  durationMs: number;
+  progress: number;
+}) {
+  const [size, setSize] = useState({ width: 0, height: HEIGHT });
+  const onLayout = (e: LayoutChangeEvent) => setSize(e.nativeEvent.layout);
+  const gradientId = `pulsar-freq-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
+
+  const { width, height } = size;
+  const amplitudePoints = pattern.continuousPattern.amplitude;
+  const frequencyPoints = pattern.continuousPattern.frequency;
+
+  const span = Math.max(durationMs, 1);
+  const xOf = (timeMs: number) => (timeMs / span) * (width - INSET * 2) + INSET;
+  const yOf = (value: number) => height - clamp01(value) * (height - INSET * 2) - INSET;
+
+  const envelopeLine =
+    width > 0 && amplitudePoints.length > 0
+      ? amplitudePoints
+          .map(
+            (p, i) => `${i === 0 ? 'M' : 'L'}${xOf(p.time).toFixed(1)},${yOf(p.value).toFixed(1)}`,
+          )
+          .join(' ')
+      : '';
+  const envelopeArea = envelopeLine
+    ? `${envelopeLine} L${xOf(span)},${height} L${xOf(0)},${height} Z`
+    : '';
+
+  // A gradient needs two stops; a single frequency point is a flat tint instead.
+  const gradientTint = frequencyPoints.length > 1;
+  const fill = gradientTint
+    ? `url(#${gradientId})`
+    : frequencyPoints.length === 1
+      ? freqColor(frequencyPoints[0].value)
+      : FLAT_FILL;
+  const stroke = gradientTint
+    ? `url(#${gradientId})`
+    : frequencyPoints.length === 1
+      ? freqColor(frequencyPoints[0].value)
+      : FLAT_STROKE;
+
+  const drawPattern = () => (
+    <>
+      {!!envelopeLine && <Path d={envelopeArea} fill={fill} opacity={0.45} />}
+      {!!envelopeLine && <Path d={envelopeLine} stroke={stroke} strokeWidth={2} fill="none" />}
+      {pattern.discretePattern.map((event, index) => (
+        <Line
+          key={`${event.time}-${index}`}
+          x1={xOf(event.time)}
+          x2={xOf(event.time)}
+          y1={height - INSET}
+          y2={yOf(event.amplitude)}
+          stroke={freqColor(event.frequency)}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+        />
+      ))}
+    </>
+  );
+
+  const playedWidth = width * clamp01(progress);
+
+  return (
+    <View style={styles.canvas}>
+      <View style={styles.plot} onLayout={onLayout}>
+        {width > 0 && (
+          <Svg width={width} height={height}>
+            <Defs>
+              {gradientTint && (
+                <LinearGradient
+                  id={gradientId}
+                  gradientUnits="userSpaceOnUse"
+                  x1={xOf(0)}
+                  y1={0}
+                  x2={xOf(span)}
+                  y2={0}
+                >
+                  {frequencyPoints.map((p, i) => (
+                    <Stop
+                      key={i}
+                      offset={clamp01(p.time / span)}
+                      stopColor={freqColor(p.value)}
+                    />
+                  ))}
+                </LinearGradient>
+              )}
+              <ClipPath id={`${gradientId}-played`}>
+                <Rect x={0} y={0} width={playedWidth} height={height} />
+              </ClipPath>
+            </Defs>
+
+            <Line
+              x1={0}
+              y1={height - INSET}
+              x2={width}
+              y2={height - INSET}
+              stroke={FLAT_FILL}
+              strokeWidth={1}
+            />
+            <G opacity={UNPLAYED_OPACITY}>{drawPattern()}</G>
+            <G clipPath={`url(#${gradientId}-played)`}>{drawPattern()}</G>
+
+            {playedWidth > 0 && (
+              <Line
+                x1={playedWidth}
+                y1={0}
+                x2={playedWidth}
+                y2={height}
+                stroke={NAVY}
+                strokeWidth={1.5}
+              />
+            )}
+          </Svg>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    height: HEIGHT,
+    borderRadius: 4,
+    backgroundColor: '#E1F3FA',
+    borderWidth: 2,
+    borderColor: '#B5E1F1',
+    overflow: 'hidden',
+    marginBottom: 12,
+  },
+  plot: { flex: 1 },
+});

--- a/PulsarApp/contexts/ConnectionsContext.tsx
+++ b/PulsarApp/contexts/ConnectionsContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
-import { Presets, usePatternComposer, type Pattern } from 'react-native-pulsar';
+import { Presets } from 'react-native-pulsar';
 
 import { handleServerMessage, type ServerMessageHandlers } from '@/src/connections/serverMessages';
 import { useMediaSession } from '@/contexts/MediaSessionContext';
@@ -73,14 +73,8 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   // preview consumer (e.g. a binding toggled back and forth).
   const previewNonce = useRef(0);
 
-  // The message handler closes over the composer, so read it through a ref that
-  // every render keeps current rather than closing over the first one.
-  const composer = usePatternComposer(undefined);
-  const composerRef = useRef(composer);
-  composerRef.current = composer;
-
-  // Media-backed haptics (audio / Lottie) are downloaded and played by the media session,
-  // read through a ref for the same reason as the composer.
+  // Every pushed haptic — pattern, audio or Lottie — is played by the media session,
+  // read through a ref so the handler never closes over a stale one.
   const media = useMediaSession();
   const mediaRef = useRef(media);
   mediaRef.current = media;
@@ -99,15 +93,7 @@ export function ConnectionsProvider({ children }: { children: ReactNode }) {
   const messageHandlers: ServerMessageHandlers = {
     patchConnection,
     notify,
-    playPreset: (pattern: Pattern) => {
-      try {
-        composerRef.current.parse(pattern);
-        composerRef.current.play();
-        return true;
-      } catch {
-        return false;
-      }
-    },
+    startPatternHaptics: (id, message) => mediaRef.current.startPatternHaptics(id, message),
     startAudioHaptics: (id, message) => mediaRef.current.startAudioHaptics(id, message),
     startAnimationHaptics: (id, message) => mediaRef.current.startAnimationHaptics(id, message),
     emitPreviewUpdate: (id, update) => {

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -13,6 +13,7 @@ import { usePatternComposer, type Pattern } from 'react-native-pulsar';
 import type {
   AudioHapticsBroadcast,
   AnimationHapticsBroadcast,
+  PatternHapticsBroadcast,
 } from '@/src/connections/serverMessages';
 import {
   downloadClip,
@@ -25,13 +26,17 @@ import {
   type MediaKind,
   type ResourceRecord,
 } from '@/src/connections/mediaLibrary';
-import { PLAYS_TO_END_OF_FILE, patternStartingAt } from '@/src/haptics/patternSeek';
+import {
+  PLAYS_TO_END_OF_FILE,
+  patternDurationMs,
+  patternStartingAt,
+} from '@/src/haptics/patternSeek';
 
-/** Plays media-backed haptics from Studio on its own composer, off its own clock. */
+/** Plays the haptics a producer pushes on its own composer, off its own clock. */
 
-/** An animation plays the pattern alone; its visual runs off the same clock. */
+/** Only audio scores the pattern with a sound; a pattern or animation plays it alone. */
 function patternFor(record: ResourceRecord): Pattern {
-  if (record.kind !== 'audio') return record.pattern;
+  if (record.kind !== 'audio' || !record.localUri) return record.pattern;
   return {
     ...record.pattern,
     sound: {
@@ -53,6 +58,8 @@ export interface MediaSession {
   name: string;
   durationMs: number;
   status: SessionStatus;
+  /** The haptics being played — drawn as the waveform for a `pattern` session. */
+  pattern: Pattern;
   /** `file://` uri of the downloaded clip, once ready. */
   localUri?: string;
   error?: string;
@@ -66,6 +73,7 @@ interface MediaSessionContextValue {
   openConnectionId: string | null;
   library: ResourceRecord[];
 
+  startPatternHaptics: (connectionId: string, message: PatternHapticsBroadcast) => void;
   startAudioHaptics: (connectionId: string, message: AudioHapticsBroadcast) => void;
   startAnimationHaptics: (connectionId: string, message: AnimationHapticsBroadcast) => void;
 
@@ -76,6 +84,9 @@ interface MediaSessionContextValue {
   playResource: (connectionId: string, resourceId: string) => void;
   playFromPlayhead: () => void;
   seek: (positionMs: number) => void;
+  /** Halts playback where it stands, so `playFromPlayhead` resumes from there. */
+  pause: () => void;
+  /** Halts playback and rewinds to the start. */
   stop: () => void;
   removeResource: (connectionId: string, resourceId: string) => void;
   handleConnectionRemoved: (connectionId: string) => void;
@@ -163,6 +174,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         name: record.name,
         durationMs: record.durationMs,
         status: 'playing',
+        pattern: record.pattern,
         localUri: record.localUri,
       });
       setPositionMs(fromMs);
@@ -186,7 +198,15 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       stopClock();
       setDownloadProgress(0);
       setPositionMs(0);
-      setSession({ connectionId, resourceId, kind, name, durationMs, status: 'downloading' });
+      setSession({
+        connectionId,
+        resourceId,
+        kind,
+        name,
+        durationMs,
+        status: 'downloading',
+        pattern,
+      });
       showLibraryScreen(connectionId);
 
       try {
@@ -236,6 +256,30 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     [playRecord, refreshLibrary, showLibraryScreen, stopClock],
   );
 
+  /** Haptics only: nothing to download, so it plays on arrival and is filed after. */
+  const startPatternHaptics = useCallback(
+    (connectionId: string, message: PatternHapticsBroadcast) => {
+      const name = message.name ?? 'Haptic preset';
+      const record: ResourceRecord = {
+        resourceId: message.resourceId ?? `name:${name}`,
+        name,
+        kind: 'pattern',
+        version: message.version ?? '',
+        durationMs: patternDurationMs(message.pattern),
+        pattern: message.pattern,
+        receivedAt: Date.now(),
+      };
+
+      stopClock();
+      setDownloadProgress(0);
+      showLibraryScreen(connectionId);
+      playRecord(connectionId, record);
+
+      void upsertResource(connectionId, record).then(() => refreshLibrary(connectionId));
+    },
+    [playRecord, refreshLibrary, showLibraryScreen, stopClock],
+  );
+
   const startAudioHaptics = useCallback(
     (connectionId: string, message: AudioHapticsBroadcast) => {
       void startMedia(connectionId, message, 'audio');
@@ -258,7 +302,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     [refreshLibrary],
   );
 
-  const stop = useCallback(() => {
+  const pause = useCallback(() => {
     stopClock();
     try {
       composerRef.current.stop();
@@ -268,6 +312,12 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     setSession((s) => (s ? { ...s, status: 'stopped' } : s));
   }, [stopClock]);
 
+  const stop = useCallback(() => {
+    pause();
+    setPositionMs(0);
+    positionRef.current = 0;
+  }, [pause]);
+
   const closeLibrary = useCallback((connectionId: string) => {
     const stillOwnsTheLibrary = openRef.current === connectionId;
     if (!stillOwnsTheLibrary) return;
@@ -276,11 +326,11 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const dismissPlayer = useCallback(() => {
-    stop();
+    pause();
     setSession(null);
     setOpenConnectionId(null);
     setLibrary([]);
-  }, [stop]);
+  }, [pause]);
 
   const playResource = useCallback(
     async (connectionId: string, resourceId: string) => {
@@ -321,27 +371,27 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   const removeResource = useCallback(
     (connectionId: string, resourceId: string) => {
       if (sessionRef.current?.resourceId === resourceId) {
-        stop();
+        pause();
         setSession(null);
       }
       void removeResourceFromLibrary(connectionId, resourceId).then(() =>
         refreshLibrary(connectionId),
       );
     },
-    [refreshLibrary, stop],
+    [pause, refreshLibrary],
   );
 
   const handleConnectionRemoved = useCallback(
     (connectionId: string) => {
       if (openRef.current === connectionId) {
-        stop();
+        pause();
         setSession(null);
         setOpenConnectionId(null);
         setLibrary([]);
       }
       void purgeConnection(connectionId);
     },
-    [stop],
+    [pause],
   );
 
   useEffect(() => () => stopClock(), [stopClock]);
@@ -354,6 +404,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         positionMs,
         openConnectionId,
         library,
+        startPatternHaptics,
         startAudioHaptics,
         startAnimationHaptics,
         openLibrary,
@@ -362,6 +413,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         playResource,
         playFromPlayhead,
         seek,
+        pause,
         stop,
         removeResource,
         handleConnectionRemoved,

--- a/PulsarApp/src/connections/mediaLibrary.ts
+++ b/PulsarApp/src/connections/mediaLibrary.ts
@@ -5,7 +5,8 @@ import * as FileSystem from 'expo-file-system/legacy';
 import type { Pattern } from 'react-native-pulsar';
 
 /**
- * The phone's on-device library of media-backed haptics received from a Studio connection.
+ * The phone's on-device library of haptics received from a Studio connection — a plain
+ * pattern, or one scored to an audio clip or a Lottie animation.
  *
  * Two stores, kept in step:
  *   - an AsyncStorage INDEX, `connectionId -> ResourceRecord[]` (small metadata), and
@@ -16,7 +17,8 @@ import type { Pattern } from 'react-native-pulsar';
  * connection row does (`purgeConnection` on remove), plus a per-resource manual delete.
  */
 
-export type MediaKind = 'audio' | 'animation';
+/** A `pattern` record is haptics only — it has none of the clip fields below. */
+export type MediaKind = 'audio' | 'animation' | 'pattern';
 
 export interface ResourceRecord {
   /** Stable identity = the Studio preset id. A re-push with a new version replaces it. */
@@ -26,11 +28,11 @@ export interface ResourceRecord {
   /** Content hash from Studio; the dedupe key that decides re-download vs reuse. */
   version: string;
   /** Addresses the delivered bytes (content hash / source id) — the on-disk filename. */
-  clipId: string;
+  clipId?: string;
   /** `file://` path to the downloaded clip. */
-  localUri: string;
-  contentType: string;
-  sizeBytes: number;
+  localUri?: string;
+  contentType?: string;
+  sizeBytes?: number;
   durationMs: number;
   /** The haptic pattern to play. */
   pattern: Pattern;
@@ -158,7 +160,7 @@ export async function upsertResource(
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const previous = list.find((r) => r.resourceId === record.resourceId);
-  if (previous && previous.localUri !== record.localUri) {
+  if (previous?.localUri && previous.localUri !== record.localUri) {
     await deleteFile(previous.localUri);
   }
   index[connectionId] = [...list.filter((r) => r.resourceId !== record.resourceId), record];
@@ -170,7 +172,7 @@ export async function removeResource(connectionId: string, resourceId: string): 
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const target = list.find((r) => r.resourceId === resourceId);
-  if (target) await deleteFile(target.localUri);
+  if (target?.localUri) await deleteFile(target.localUri);
   index[connectionId] = list.filter((r) => r.resourceId !== resourceId);
   await writeIndex(index);
 }

--- a/PulsarApp/src/connections/serverMessages.ts
+++ b/PulsarApp/src/connections/serverMessages.ts
@@ -24,6 +24,16 @@ export interface BroadcastMediaRef {
   size: number;
 }
 
+// A haptics-only preset from Studio or the Figma plugin. Older producers send no
+// `resourceId`, so the phone keys the library entry on the name instead.
+export interface PatternHapticsBroadcast {
+  kind: 'haptic-preset';
+  name?: string;
+  pattern: Pattern;
+  resourceId?: string;
+  version?: string;
+}
+
 // A preset scored to an AUDIO file, pushed from Studio (see device/toPattern.ts). The
 // clip is already trimmed, so the pattern and the audio both play from t=0.
 export interface AudioHapticsBroadcast {
@@ -62,9 +72,8 @@ export interface AnimationHapticsBroadcast {
 export interface ServerMessageHandlers {
   patchConnection: (id: string, patch: Partial<Connection>) => void;
   notify: (found: boolean, name: string) => void;
-  playPreset: (pattern: Pattern) => boolean;
-  // A media-backed haptic (audio / Lottie) — downloaded, then played in sync on the
-  // per-connection player sheet. `id` is the connection it arrived on.
+  // Everything a producer pushes lands on the player sheet for connection `id`.
+  startPatternHaptics: (id: string, message: PatternHapticsBroadcast) => void;
   startAudioHaptics: (id: string, message: AudioHapticsBroadcast) => void;
   startAnimationHaptics: (id: string, message: AnimationHapticsBroadcast) => void;
   emitPreviewUpdate: (id: string, update: Omit<PreviewUpdate, 'nonce'>) => void;
@@ -95,13 +104,9 @@ function handleBroadcast(id: string, message: unknown, handlers: ServerMessageHa
   const kind = (message as { kind?: unknown }).kind;
 
   if (kind === 'haptic-preset' && (message as { pattern?: unknown }).pattern) {
-    // A full JSON preset pushed from Pulsar Studio. Unlike the string path, this
-    // ALWAYS plays the supplied waveform via the composer — never a same-named
-    // built-in — so an edited preset plays as edited. Older app builds don't
-    // match this branch (the object isn't a 'preview-*'), so they harmlessly
-    // ignore it: the backward-compat seam.
-    const preset = message as { kind: string; name?: string; pattern: Pattern };
-    handlers.notify(handlers.playPreset(preset.pattern), preset.name ?? 'Haptic preset');
+    // Plays the supplied waveform, never a same-named built-in, so an edited preset
+    // plays as edited.
+    handlers.startPatternHaptics(id, message as PatternHapticsBroadcast);
     return;
   }
 

--- a/PulsarApp/src/haptics/patternSeek.ts
+++ b/PulsarApp/src/haptics/patternSeek.ts
@@ -18,12 +18,24 @@ export function envelopeValueAt(points: EnvelopePoint[], atMs: number): number {
   return before.value + ((after.value - before.value) * (atMs - before.time)) / span;
 }
 
-function envelopeStartingAt(points: EnvelopePoint[], fromMs: number): EnvelopePoint[] {
+/**
+ * An envelope whose points all sit before the seek HOLDS its last value for the rest of
+ * the pattern rather than emptying. Emptying it would silence the whole continuous
+ * channel: the SDK builds that channel only when the amplitude AND frequency curves are
+ * both non-empty, so seeking past the end of either one killed both.
+ */
+function envelopeStartingAt(
+  points: EnvelopePoint[],
+  fromMs: number,
+  remainingMs: number,
+): EnvelopePoint[] {
+  if (points.length === 0) return [];
+  const held = { time: 0, value: envelopeValueAt(points, fromMs) };
   const remaining = points
     .filter((point) => point.time > fromMs)
     .map((point) => ({ time: point.time - fromMs, value: point.value }));
-  if (remaining.length === 0) return [];
-  return [{ time: 0, value: envelopeValueAt(points, fromMs) }, ...remaining];
+  if (remaining.length > 0) return [held, ...remaining];
+  return remainingMs > 0 ? [held, { time: remainingMs, value: held.value }] : [held];
 }
 
 function soundStartingAt(sound: Sound, fromMs: number): Sound {
@@ -38,13 +50,14 @@ function soundStartingAt(sound: Sound, fromMs: number): Sound {
 /** The composer can only play from zero, so seeking replays a re-anchored pattern. */
 export function patternStartingAt(pattern: Pattern, fromMs: number): Pattern {
   if (fromMs <= 0) return pattern;
+  const remainingMs = patternDurationMs(pattern) - fromMs;
   return {
     discretePattern: pattern.discretePattern
       .filter((point) => point.time >= fromMs)
       .map((point) => ({ ...point, time: point.time - fromMs })),
     continuousPattern: {
-      amplitude: envelopeStartingAt(pattern.continuousPattern.amplitude, fromMs),
-      frequency: envelopeStartingAt(pattern.continuousPattern.frequency, fromMs),
+      amplitude: envelopeStartingAt(pattern.continuousPattern.amplitude, fromMs, remainingMs),
+      frequency: envelopeStartingAt(pattern.continuousPattern.frequency, fromMs, remainingMs),
     },
     ...(pattern.sound ? { sound: soundStartingAt(pattern.sound, fromMs) } : {}),
   };


### PR DESCRIPTION
## Why

A push carrying an audio clip or a Lottie animation opens the player sheet, is saved on the device, and can be replayed and scrubbed. A haptics-only push buzzed once behind a 1.2s toast and was gone — nothing kept, nothing to replay, no way to stop a long pattern.

## What

**A plain pattern is a third `MediaKind`.** `haptic-preset` now routes to the media session instead of a fire-and-forget composer call, so it shares the same clock, seek, library and player UI as the media-backed kinds. There is no clip to fetch, so it plays on arrival and is filed afterwards; `clipId` / `localUri` / `contentType` / `sizeBytes` become optional on `ResourceRecord`. Entries live in the same per-connection list, labelled `Pattern`.

Identity comes from `resourceId`, which Studio now sends (software-mansion-labs/pulsar-private#106). Producers that don't send one — the Figma plugin, older Studio builds — key their entry on the preset name, so a re-push still replaces rather than stacks. The toast now only covers built-in presets pushed *by name*, which have nothing to save.

**Seeking silenced the continuous channel.** The SDK builds that channel only when the amplitude and frequency curves are *both* non-empty:

```swift
// PatternComposer.swift:62 — Android has the same isNotEmpty() && check
if (!intensityCurveLine.isEmpty && !sharpnessCurveLine.isEmpty) {
```

`patternStartingAt` emptied any envelope whose points all sat before the seek. A Studio preset usually shades frequency over a shorter span than intensity, so seeking past the last frequency point dropped **both** channels and left only discrete events — playback worked near the start and went silent from the middle on. Such an envelope now holds its last value for the rest of the pattern.

Measured against the real module, with frequency authored only over the first 600ms of a 3s preset:

| seek | before | after |
| --- | --- | --- |
| 800ms | `freq=0` → silent | `freq=2` → plays |
| 1500ms | `freq=0` → silent | `freq=2` → plays |
| 2500ms | `freq=0` → silent | `freq=2` → plays |

A genuinely empty envelope (a discrete-only preset) still stays empty — nothing was authored there.

**Transport.** The single Play/Stop button was a pause in all but name. `MediaSessionContext` now exposes `pause()` (halts where it stands) and `stop()` (halts and rewinds); the sheet gets Play/Pause plus a Stop that disables itself when idle at 0:00. The mini player keeps its play/pause toggle.

**Waveform.** `PatternCanvas` follows the Figma plugin's `Visualization.tsx`: a baseline-anchored amplitude envelope tinted along the time axis by the continuous frequency (same `hsl(220 - f*200, 70%, 45%)` scale), a bar per discrete impulse coloured by its own frequency, and the played portion drawn at full strength over a faded copy of the whole, so progress reads as the pattern filling in.

## Testing

Verified on an iOS simulator against a paired producer:

- push opens the player and plays; a second `resourceId` adds a row, a re-push of the same id replaces and renames it, and a `resourceId`-less push twice yields one row
- seek by drag, play-from-playhead, pause holding position, stop rewinding and disabling itself
- 3 entries survive an app restart; play from a library row; mini player appears when the sheet is dismissed
- a preset pushed *by name* still just buzzes without touching the library

Not verified: that the seek fix actually buzzes. The Simulator has no Core Haptics, so the fix is proven at the JS boundary against the native constraint rather than felt — worth a check on a real device before merge.

## Note

The Figma plugin sends custom presets under this same `haptic-preset` kind (`figma/src/ui/lib/phoneRelay.ts`), so tapping a custom preset there now opens the player on the phone too. Baked library presets go by name and are unaffected. Happy to gate that if it's unwanted.