### PR TITLE
fix(rn): wire kotlinx-serialization into the Android local-sources build

### DIFF
--- a/react-native/react-native-pulsar/android/build.gradle
+++ b/react-native/react-native-pulsar/android/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     classpath "com.android.tools.build:gradle:8.7.2"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion')}"
+    classpath "org.jetbrains.kotlin:kotlin-serialization:${getExtOrDefault('kotlinVersion')}"
   }
 }
 
@@ -40,6 +41,7 @@ if (useLocalPulsarAndroid) {
     throw new GradleException("USE_LOCAL_PULSAR_ANDROID=1 but local Pulsar Android sources were not found at ${localPulsarAndroidSourceDir}")
   }
   logger.lifecycle("Using local Pulsar Android sources from ${localPulsarAndroidSourceDir}")
+  apply plugin: "org.jetbrains.kotlin.plugin.serialization"
 } else {
   logger.lifecycle("Using published Pulsar Android artifact com.swmansion:pulsar:${pulsarAndroidVersion}")
 }
@@ -102,6 +104,7 @@ dependencies {
 
   if (useLocalPulsarAndroid) {
     implementation "androidx.core:core-ktx:1.17.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
   } else {
     implementation "com.swmansion:pulsar:$pulsarAndroidVersion"
   }


### PR DESCRIPTION
## Problem

Building the RN Android module against the local `Android/Pulsar` sources (`USE_LOCAL_PULSAR_ANDROID=1`) fails to compile:

```
e: Android/Pulsar/.../bundle/BundleLoader.kt:6:16 Unresolved reference 'serialization'
e: Android/Pulsar/.../bundle/BundleLoader.kt:11:24 Unresolved reference 'Json'
e: Android/Pulsar/.../bundle/BundleManifest.kt:11:2 Illegal annotation class 'Serializable'
```

This surfaces as an opaque `Execution failed for task ':react-native-pulsar:compileReleaseKotlin' > Compilation error` in EAS local builds.

## Cause

`BundleLoader.kt` and `BundleManifest.kt` decode `.pulsar` archives with kotlinx.serialization, but this module declared neither half of it:

- **Runtime missing** — `import kotlinx.serialization.Serializable` failed to resolve, so the bare name fell through to `kotlin.io.Serializable`, the internal stdlib typealias for `java.io.Serializable`. A marker interface isn't an annotation class, hence `Illegal annotation class`.
- **Compiler plugin missing** — `@Serializable` only generates the `serializer()` implementations when the plugin is applied, so `BundleManifest.serializer()` never exists.

The published-artifact path was unaffected because the AAR ships these classes already compiled and pulls the runtime transitively.

## Fix

Three lines, mirroring what `Android/Pulsar/build.gradle.kts` declares for its own build:

- `kotlin-serialization` on the buildscript classpath, pinned to the same `kotlinVersion` the module already resolves
- `apply plugin: "org.jetbrains.kotlin.plugin.serialization"`
- `kotlinx-serialization-json:1.7.3`

The plugin and dependency are scoped to the local-sources branch, so the published-artifact path is untouched.

## Notes

- A floating version (`+`) is not viable here: it resolves to 1.11.0, which is built for Kotlin 2.3 and fails with `binary version of its metadata is 2.3.0, expected version is 2.1.0`. The serialization runtime is coupled to the compiler version.
- The plugin alone is not sufficient — it does not add the runtime to the classpath; removing the dependency reproduces the original error exactly.

## Test plan

- `USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :react-native-pulsar:assembleRelease` — passes
- `USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :app:compileReleaseKotlin` — passes
- `./gradlew :Pulsar:assembleDebug` (native SDK, `Android/PulsarApp`) — unaffected, passes