### PR TITLE
fix(app): keep Studio-sent clips playable offline

### DIFF
--- a/PulsarApp/app/mediaLibraryModal.tsx
+++ b/PulsarApp/app/mediaLibraryModal.tsx
@@ -94,6 +94,19 @@ export default function MediaLibraryModal() {
           <>
             {active && (
               <Card>
+                {/* A clip file can go missing — cleared storage, a restore onto a new phone —
+                    while its index row and pattern survive. Say so instead of showing a
+                    blank canvas or a player that stays mute. */}
+                {active.clipMissing && (
+                  <View style={styles.notice}>
+                    <ThemedText style={styles.noticeText}>
+                      {active.kind === 'audio' ? 'The audio clip' : 'The animation'} is no longer
+                      on this device — the haptics still play. Send it from Studio again to
+                      restore it.
+                    </ThemedText>
+                  </View>
+                )}
+
                 {/* The Lottie canvas for a downloaded animation — its playhead runs off the
                     same clock as the haptics. */}
                 {active.kind === 'animation' && active.localUri && (
@@ -246,6 +259,18 @@ const styles = StyleSheet.create({
     paddingBottom: 40,
   },
   meta: {
+    fontSize: 14,
+    color: '#496695',
+  },
+  notice: {
+    borderRadius: 4,
+    backgroundColor: '#E1F3FA',
+    borderWidth: 2,
+    borderColor: '#B5E1F1',
+    padding: 12,
+    marginBottom: 12,
+  },
+  noticeText: {
     fontSize: 14,
     color: '#496695',
   },

--- a/PulsarApp/app/mediaLibraryModal.tsx
+++ b/PulsarApp/app/mediaLibraryModal.tsx
@@ -94,18 +94,7 @@ export default function MediaLibraryModal() {
           <>
             {active && (
               <Card>
-                {/* A clip file can go missing — cleared storage, a restore onto a new phone —
-                    while its index row and pattern survive. Say so instead of showing a
-                    blank canvas or a player that stays mute. */}
-                {active.clipMissing && (
-                  <View style={styles.notice}>
-                    <ThemedText style={styles.noticeText}>
-                      {active.kind === 'audio' ? 'The audio clip' : 'The animation'} is no longer
-                      on this device — the haptics still play. Send it from Studio again to
-                      restore it.
-                    </ThemedText>
-                  </View>
-                )}
+                {active.clipMissing && <ClipMissingNotice kind={active.kind} />}
 
                 {/* The Lottie canvas for a downloaded animation — its playhead runs off the
                     same clock as the haptics. */}
@@ -188,6 +177,17 @@ export default function MediaLibraryModal() {
         )}
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function ClipMissingNotice({ kind }: { kind: MediaKind }) {
+  return (
+    <View style={styles.notice}>
+      <ThemedText style={styles.noticeText}>
+        {kind === 'audio' ? 'The audio clip' : 'The animation'} is no longer on this device — the
+        haptics still play. Send it from Studio again to restore it.
+      </ThemedText>
+    </View>
   );
 }
 

--- a/PulsarApp/components/media/LottieCanvas.tsx
+++ b/PulsarApp/components/media/LottieCanvas.tsx
@@ -18,13 +18,8 @@ try {
   LottieView = null;
 }
 
-/**
- * How each platform's Lottie recognises a clip sitting in the app's own storage:
- * Android takes the `sourceURL` as a plain path (anything with a scheme falls through to
- * its NETWORK loader, which renders an empty canvas without an error), while iOS resolves
- * a path with no scheme against the app bundle and needs the `file://` form.
- */
-function sourceFor(uri: string): { uri: string } {
+// Android reads a local clip only as a bare path, iOS only as a file:// url.
+function localFileSource(uri: string): { uri: string } {
   return { uri: Platform.OS === 'android' ? uri.replace('file://', '') : uri };
 }
 
@@ -46,7 +41,7 @@ export default function LottieCanvas({ uri, progress }: { uri: string; progress:
   return (
     <View style={styles.canvas}>
       <LottieView
-        source={sourceFor(uri)}
+        source={localFileSource(uri)}
         progress={Math.max(0, Math.min(1, progress))}
         resizeMode="contain"
         style={styles.lottie}

--- a/PulsarApp/components/media/LottieCanvas.tsx
+++ b/PulsarApp/components/media/LottieCanvas.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
 
@@ -19,6 +19,16 @@ try {
 }
 
 /**
+ * How each platform's Lottie recognises a clip sitting in the app's own storage:
+ * Android takes the `sourceURL` as a plain path (anything with a scheme falls through to
+ * its NETWORK loader, which renders an empty canvas without an error), while iOS resolves
+ * a path with no scheme against the app bundle and needs the `file://` form.
+ */
+function sourceFor(uri: string): { uri: string } {
+  return { uri: Platform.OS === 'android' ? uri.replace('file://', '') : uri };
+}
+
+/**
  * Renders a downloaded Lottie clip, its playhead driven by `progress` (0..1) — the SAME
  * clock the haptics run on (see MediaSessionContext), so animation and haptics stay in
  * lockstep. `repeat` restarts both because the clock resets to 0.
@@ -36,7 +46,7 @@ export default function LottieCanvas({ uri, progress }: { uri: string; progress:
   return (
     <View style={styles.canvas}>
       <LottieView
-        source={{ uri }}
+        source={sourceFor(uri)}
         progress={Math.max(0, Math.min(1, progress))}
         resizeMode="contain"
         style={styles.lottie}

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -36,10 +36,7 @@ import {
 
 /** Plays the haptics a producer pushes on its own composer, off its own clock. */
 
-/**
- * Only audio scores the pattern with a sound; a pattern or animation plays it alone.
- * A clip that is no longer on disk is left off too — the haptics still play, silently.
- */
+/** Only audio scores the pattern with a sound; everything else plays it alone. */
 function patternFor(record: ResourceRecord, clipMissing: boolean): Pattern {
   if (record.kind !== 'audio' || !record.localUri || clipMissing) return record.pattern;
   return {
@@ -65,9 +62,8 @@ export interface MediaSession {
   status: SessionStatus;
   /** The haptics being played — drawn as the waveform for a `pattern` session. */
   pattern: Pattern;
-  /** `file://` uri of the downloaded clip, once ready. Absent while the clip is missing. */
+  /** `file://` uri of the downloaded clip, once ready. */
   localUri?: string;
-  /** The record expects a clip, but the file is not on this device (any more). */
   clipMissing?: boolean;
   error?: string;
 }
@@ -347,8 +343,6 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     async (connectionId: string, resourceId: string) => {
       const record = await getResource(connectionId, resourceId);
       if (!record) return;
-      // The index outlives the files: a clip can be gone (cleared storage, a restore onto
-      // a new phone). Say so rather than showing a blank canvas or a mute player.
       const clipMissing = record.kind !== 'pattern' && !(await clipIsOnDisk(record));
       setOpenConnectionId(connectionId);
       playRecord(connectionId, record, 0, clipMissing);

--- a/PulsarApp/contexts/MediaSessionContext.tsx
+++ b/PulsarApp/contexts/MediaSessionContext.tsx
@@ -16,6 +16,8 @@ import type {
   PatternHapticsBroadcast,
 } from '@/src/connections/serverMessages';
 import {
+  clipIsOnDisk,
+  clipUri,
   downloadClip,
   extForContentType,
   getResource,
@@ -34,9 +36,12 @@ import {
 
 /** Plays the haptics a producer pushes on its own composer, off its own clock. */
 
-/** Only audio scores the pattern with a sound; a pattern or animation plays it alone. */
-function patternFor(record: ResourceRecord): Pattern {
-  if (record.kind !== 'audio' || !record.localUri) return record.pattern;
+/**
+ * Only audio scores the pattern with a sound; a pattern or animation plays it alone.
+ * A clip that is no longer on disk is left off too — the haptics still play, silently.
+ */
+function patternFor(record: ResourceRecord, clipMissing: boolean): Pattern {
+  if (record.kind !== 'audio' || !record.localUri || clipMissing) return record.pattern;
   return {
     ...record.pattern,
     sound: {
@@ -60,8 +65,10 @@ export interface MediaSession {
   status: SessionStatus;
   /** The haptics being played — drawn as the waveform for a `pattern` session. */
   pattern: Pattern;
-  /** `file://` uri of the downloaded clip, once ready. */
+  /** `file://` uri of the downloaded clip, once ready. Absent while the clip is missing. */
   localUri?: string;
+  /** The record expects a clip, but the file is not on this device (any more). */
+  clipMissing?: boolean;
   error?: string;
 }
 
@@ -110,6 +117,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   const sessionRef = useRef<MediaSession | null>(null);
   sessionRef.current = session;
   const currentRecordRef = useRef<ResourceRecord | null>(null);
+  const clipMissingRef = useRef(false);
   const positionRef = useRef(0);
   positionRef.current = positionMs;
   const rafRef = useRef<number | null>(null);
@@ -158,11 +166,12 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const playRecord = useCallback(
-    (connectionId: string, record: ResourceRecord, fromMs = 0) => {
+    (connectionId: string, record: ResourceRecord, fromMs = 0, clipMissing = false) => {
       currentRecordRef.current = record;
+      clipMissingRef.current = clipMissing;
       try {
         composerRef.current.stop();
-        composerRef.current.parse(patternStartingAt(patternFor(record), fromMs));
+        composerRef.current.parse(patternStartingAt(patternFor(record, clipMissing), fromMs));
         composerRef.current.play();
       } catch {
         // An unsupported device still gets the media and the clock.
@@ -175,7 +184,8 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         durationMs: record.durationMs,
         status: 'playing',
         pattern: record.pattern,
-        localUri: record.localUri,
+        localUri: clipMissing ? undefined : record.localUri,
+        clipMissing,
       });
       setPositionMs(fromMs);
       positionRef.current = fromMs;
@@ -213,7 +223,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
         const ext = extForContentType(media.contentType);
         // downloadClip skips the network when the clip file already exists — so an
         // unchanged resend (same clipId) plays straight from disk.
-        const localUri = await downloadClip(
+        const clipPath = await downloadClip(
           connectionId,
           media.clipId,
           ext,
@@ -228,7 +238,8 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
           kind,
           version,
           clipId: media.clipId,
-          localUri,
+          clipPath,
+          localUri: clipUri(clipPath),
           contentType: media.contentType,
           sizeBytes: media.size,
           durationMs,
@@ -336,8 +347,11 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     async (connectionId: string, resourceId: string) => {
       const record = await getResource(connectionId, resourceId);
       if (!record) return;
+      // The index outlives the files: a clip can be gone (cleared storage, a restore onto
+      // a new phone). Say so rather than showing a blank canvas or a mute player.
+      const clipMissing = record.kind !== 'pattern' && !(await clipIsOnDisk(record));
       setOpenConnectionId(connectionId);
-      playRecord(connectionId, record);
+      playRecord(connectionId, record, 0, clipMissing);
     },
     [playRecord],
   );
@@ -347,7 +361,12 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
     const active = sessionRef.current;
     if (!record || !active) return;
     const hasRunToTheEnd = positionRef.current >= record.durationMs;
-    playRecord(active.connectionId, record, hasRunToTheEnd ? 0 : positionRef.current);
+    playRecord(
+      active.connectionId,
+      record,
+      hasRunToTheEnd ? 0 : positionRef.current,
+      clipMissingRef.current,
+    );
   }, [playRecord]);
 
   const seek = useCallback(
@@ -359,7 +378,7 @@ export function MediaSessionProvider({ children }: { children: ReactNode }) {
       // `session.status` is state read back through a ref, so it still reads 'stopped'
       // for the render after a play; the clock handle is written synchronously.
       if (isClockRunning()) {
-        playRecord(active.connectionId, record, target);
+        playRecord(active.connectionId, record, target, clipMissingRef.current);
       } else {
         setPositionMs(target);
         positionRef.current = target;

--- a/PulsarApp/src/connections/mediaLibrary.ts
+++ b/PulsarApp/src/connections/mediaLibrary.ts
@@ -13,6 +13,11 @@ import type { Pattern } from 'react-native-pulsar';
  *   - the CLIP FILES under documentDirectory (persistent — survives restarts, unlike the
  *     cache directory the OS may evict).
  *
+ * The index stores each clip's path RELATIVE to the media root, never an absolute one:
+ * iOS hands the app a new container directory on reinstall/update while keeping its data,
+ * so an absolute uri saved yesterday points nowhere today — the clip would be on disk yet
+ * unplayable. The absolute uri is rebuilt on every read instead.
+ *
  * Retention is scoped to the connection: a connection's clips live as long as the
  * connection row does (`purgeConnection` on remove), plus a per-resource manual delete.
  */
@@ -29,7 +34,9 @@ export interface ResourceRecord {
   version: string;
   /** Addresses the delivered bytes (content hash / source id) — the on-disk filename. */
   clipId?: string;
-  /** `file://` path to the downloaded clip. */
+  /** The clip's path relative to the media root, e.g. `conn-1/abc123.json`. Persisted. */
+  clipPath?: string;
+  /** Absolute `file://` uri for this install — DERIVED from `clipPath`, never persisted. */
   localUri?: string;
   contentType?: string;
   sizeBytes?: number;
@@ -45,9 +52,34 @@ export interface ResourceRecord {
 }
 
 const STORAGE_KEY = 'pulsar:media-library';
-const MEDIA_ROOT = `${FileSystem.documentDirectory ?? ''}pulsar-media/`;
+const MEDIA_DIR = 'pulsar-media/';
+
+const mediaRoot = () => `${FileSystem.documentDirectory ?? ''}${MEDIA_DIR}`;
 
 type LibraryIndex = Record<string, ResourceRecord[]>;
+
+/**
+ * Records written before the index went relative kept an absolute uri. Everything after
+ * `pulsar-media/` is still valid — only the container prefix ahead of it went stale.
+ */
+function migratedClipPath(record: ResourceRecord): string | undefined {
+  if (record.clipPath) return record.clipPath;
+  const at = record.localUri?.indexOf(MEDIA_DIR);
+  if (record.localUri && at != null && at >= 0) return record.localUri.slice(at + MEDIA_DIR.length);
+  return undefined;
+}
+
+/** Attach the absolute uri this install would use for the record's clip. */
+function resolved(record: ResourceRecord): ResourceRecord {
+  const clipPath = migratedClipPath(record);
+  return clipPath ? { ...record, clipPath, localUri: clipUri(clipPath) } : { ...record, localUri: undefined };
+}
+
+/** Drop the derived uri so a stale container path can never make it back onto disk. */
+function forStorage(record: ResourceRecord): ResourceRecord {
+  const { localUri: _derived, ...persisted } = record;
+  return persisted;
+}
 
 async function readIndex(): Promise<LibraryIndex> {
   try {
@@ -77,15 +109,18 @@ export function extForContentType(contentType: string): string {
   return 'bin';
 }
 
-const connectionDir = (connectionId: string) => `${MEDIA_ROOT}${connectionId}/`;
+export function clipPathFor(connectionId: string, clipId: string, ext: string): string {
+  return `${connectionId}/${clipId}.${ext}`;
+}
 
-export function localPathFor(connectionId: string, clipId: string, ext: string): string {
-  return `${connectionDir(connectionId)}${clipId}.${ext}`;
+/** The absolute uri a relative clip path resolves to in THIS install. */
+export function clipUri(clipPath: string): string {
+  return `${mediaRoot()}${clipPath}`;
 }
 
 /** Create a connection's media directory if it isn't there yet. Idempotent. */
 async function ensureConnectionDir(connectionId: string): Promise<void> {
-  const dir = connectionDir(connectionId);
+  const dir = `${mediaRoot()}${connectionId}/`;
   const info = await FileSystem.getInfoAsync(dir);
   if (!info.exists) await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
 }
@@ -96,6 +131,12 @@ async function fileExists(uri: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/** Whether the record's clip is actually on this device — false for a haptics-only record. */
+export async function clipIsOnDisk(record: ResourceRecord): Promise<boolean> {
+  const clipPath = migratedClipPath(record);
+  return clipPath ? fileExists(clipUri(clipPath)) : false;
 }
 
 async function deleteFile(uri: string): Promise<void> {
@@ -109,7 +150,7 @@ async function deleteFile(uri: string): Promise<void> {
 /** The resources cached for a connection, most-recent first. */
 export async function listResources(connectionId: string): Promise<ResourceRecord[]> {
   const index = await readIndex();
-  return [...(index[connectionId] ?? [])].sort((a, b) => b.receivedAt - a.receivedAt);
+  return [...(index[connectionId] ?? [])].sort((a, b) => b.receivedAt - a.receivedAt).map(resolved);
 }
 
 /** The cached record for a resource, or undefined. */
@@ -118,12 +159,14 @@ export async function getResource(
   resourceId: string,
 ): Promise<ResourceRecord | undefined> {
   const index = await readIndex();
-  return (index[connectionId] ?? []).find((r) => r.resourceId === resourceId);
+  const record = (index[connectionId] ?? []).find((r) => r.resourceId === resourceId);
+  return record && resolved(record);
 }
 
 /**
- * Download a clip to its persistent path, reporting progress, and return the local uri.
- * Skips the network entirely when a file for this exact clip already exists on disk.
+ * Download a clip to its persistent path, reporting progress, and return the path relative
+ * to the media root. Skips the network entirely when a file for this exact clip already
+ * exists on disk.
  */
 export async function downloadClip(
   connectionId: string,
@@ -133,10 +176,11 @@ export async function downloadClip(
   onProgress?: (fraction: number) => void,
 ): Promise<string> {
   await ensureConnectionDir(connectionId);
-  const dest = localPathFor(connectionId, clipId, ext);
+  const clipPath = clipPathFor(connectionId, clipId, ext);
+  const dest = clipUri(clipPath);
   if (await fileExists(dest)) {
     onProgress?.(1);
-    return dest;
+    return clipPath;
   }
   const task = FileSystem.createDownloadResumable(url, dest, {}, (p) => {
     if (p.totalBytesExpectedToWrite > 0) {
@@ -145,7 +189,7 @@ export async function downloadClip(
   });
   const result = await task.downloadAsync();
   if (!result) throw new Error('Download did not complete');
-  return result.uri;
+  return clipPath;
 }
 
 /**
@@ -160,10 +204,14 @@ export async function upsertResource(
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const previous = list.find((r) => r.resourceId === record.resourceId);
-  if (previous?.localUri && previous.localUri !== record.localUri) {
-    await deleteFile(previous.localUri);
+  const previousClipPath = previous && migratedClipPath(previous);
+  if (previousClipPath && previousClipPath !== record.clipPath) {
+    await deleteFile(clipUri(previousClipPath));
   }
-  index[connectionId] = [...list.filter((r) => r.resourceId !== record.resourceId), record];
+  index[connectionId] = [
+    ...list.filter((r) => r.resourceId !== record.resourceId),
+    forStorage(record),
+  ];
   await writeIndex(index);
 }
 
@@ -172,14 +220,15 @@ export async function removeResource(connectionId: string, resourceId: string): 
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const target = list.find((r) => r.resourceId === resourceId);
-  if (target?.localUri) await deleteFile(target.localUri);
+  const targetClipPath = target && migratedClipPath(target);
+  if (targetClipPath) await deleteFile(clipUri(targetClipPath));
   index[connectionId] = list.filter((r) => r.resourceId !== resourceId);
   await writeIndex(index);
 }
 
 /** Drop everything for a connection — its whole directory and all its index entries. */
 export async function purgeConnection(connectionId: string): Promise<void> {
-  await deleteFile(connectionDir(connectionId));
+  await deleteFile(`${mediaRoot()}${connectionId}/`);
   const index = await readIndex();
   if (index[connectionId]) {
     delete index[connectionId];

--- a/PulsarApp/src/connections/mediaLibrary.ts
+++ b/PulsarApp/src/connections/mediaLibrary.ts
@@ -13,10 +13,8 @@ import type { Pattern } from 'react-native-pulsar';
  *   - the CLIP FILES under documentDirectory (persistent — survives restarts, unlike the
  *     cache directory the OS may evict).
  *
- * The index stores each clip's path RELATIVE to the media root, never an absolute one:
- * iOS hands the app a new container directory on reinstall/update while keeping its data,
- * so an absolute uri saved yesterday points nowhere today — the clip would be on disk yet
- * unplayable. The absolute uri is rebuilt on every read instead.
+ * Clip paths are stored relative to the media root because iOS moves the app container
+ * between installs, which strands every absolute uri written before the move.
  *
  * Retention is scoped to the connection: a connection's clips live as long as the
  * connection row does (`purgeConnection` on remove), plus a per-resource manual delete.
@@ -34,9 +32,9 @@ export interface ResourceRecord {
   version: string;
   /** Addresses the delivered bytes (content hash / source id) — the on-disk filename. */
   clipId?: string;
-  /** The clip's path relative to the media root, e.g. `conn-1/abc123.json`. Persisted. */
+  /** Relative to the media root, e.g. `conn-1/abc123.json`. */
   clipPath?: string;
-  /** Absolute `file://` uri for this install — DERIVED from `clipPath`, never persisted. */
+  /** Derived from `clipPath` on read, never stored. */
   localUri?: string;
   contentType?: string;
   sizeBytes?: number;
@@ -58,27 +56,25 @@ const mediaRoot = () => `${FileSystem.documentDirectory ?? ''}${MEDIA_DIR}`;
 
 type LibraryIndex = Record<string, ResourceRecord[]>;
 
-/**
- * Records written before the index went relative kept an absolute uri. Everything after
- * `pulsar-media/` is still valid — only the container prefix ahead of it went stale.
- */
-function migratedClipPath(record: ResourceRecord): string | undefined {
-  if (record.clipPath) return record.clipPath;
-  const at = record.localUri?.indexOf(MEDIA_DIR);
-  if (record.localUri && at != null && at >= 0) return record.localUri.slice(at + MEDIA_DIR.length);
-  return undefined;
+function clipPathWithinAbsoluteUri(uri: string | undefined): string | undefined {
+  const at = uri?.indexOf(MEDIA_DIR);
+  return uri != null && at != null && at >= 0 ? uri.slice(at + MEDIA_DIR.length) : undefined;
 }
 
-/** Attach the absolute uri this install would use for the record's clip. */
-function resolved(record: ResourceRecord): ResourceRecord {
-  const clipPath = migratedClipPath(record);
-  return clipPath ? { ...record, clipPath, localUri: clipUri(clipPath) } : { ...record, localUri: undefined };
+function clipPathOf(record: ResourceRecord): string | undefined {
+  return record.clipPath ?? clipPathWithinAbsoluteUri(record.localUri);
 }
 
-/** Drop the derived uri so a stale container path can never make it back onto disk. */
-function forStorage(record: ResourceRecord): ResourceRecord {
-  const { localUri: _derived, ...persisted } = record;
-  return persisted;
+function withUriForThisInstall(record: ResourceRecord): ResourceRecord {
+  const clipPath = clipPathOf(record);
+  return clipPath
+    ? { ...record, clipPath, localUri: clipUri(clipPath) }
+    : { ...record, localUri: undefined };
+}
+
+function withoutDerivedUri(record: ResourceRecord): ResourceRecord {
+  const { localUri: _derived, ...stored } = record;
+  return stored;
 }
 
 async function readIndex(): Promise<LibraryIndex> {
@@ -113,7 +109,6 @@ export function clipPathFor(connectionId: string, clipId: string, ext: string): 
   return `${connectionId}/${clipId}.${ext}`;
 }
 
-/** The absolute uri a relative clip path resolves to in THIS install. */
 export function clipUri(clipPath: string): string {
   return `${mediaRoot()}${clipPath}`;
 }
@@ -133,9 +128,8 @@ async function fileExists(uri: string): Promise<boolean> {
   }
 }
 
-/** Whether the record's clip is actually on this device — false for a haptics-only record. */
 export async function clipIsOnDisk(record: ResourceRecord): Promise<boolean> {
-  const clipPath = migratedClipPath(record);
+  const clipPath = clipPathOf(record);
   return clipPath ? fileExists(clipUri(clipPath)) : false;
 }
 
@@ -150,7 +144,9 @@ async function deleteFile(uri: string): Promise<void> {
 /** The resources cached for a connection, most-recent first. */
 export async function listResources(connectionId: string): Promise<ResourceRecord[]> {
   const index = await readIndex();
-  return [...(index[connectionId] ?? [])].sort((a, b) => b.receivedAt - a.receivedAt).map(resolved);
+  return [...(index[connectionId] ?? [])]
+    .sort((a, b) => b.receivedAt - a.receivedAt)
+    .map(withUriForThisInstall);
 }
 
 /** The cached record for a resource, or undefined. */
@@ -160,14 +156,10 @@ export async function getResource(
 ): Promise<ResourceRecord | undefined> {
   const index = await readIndex();
   const record = (index[connectionId] ?? []).find((r) => r.resourceId === resourceId);
-  return record && resolved(record);
+  return record && withUriForThisInstall(record);
 }
 
-/**
- * Download a clip to its persistent path, reporting progress, and return the path relative
- * to the media root. Skips the network entirely when a file for this exact clip already
- * exists on disk.
- */
+/** Downloads to the clip's persistent path, or reuses the file already there. */
 export async function downloadClip(
   connectionId: string,
   clipId: string,
@@ -204,13 +196,13 @@ export async function upsertResource(
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const previous = list.find((r) => r.resourceId === record.resourceId);
-  const previousClipPath = previous && migratedClipPath(previous);
+  const previousClipPath = previous && clipPathOf(previous);
   if (previousClipPath && previousClipPath !== record.clipPath) {
     await deleteFile(clipUri(previousClipPath));
   }
   index[connectionId] = [
     ...list.filter((r) => r.resourceId !== record.resourceId),
-    forStorage(record),
+    withoutDerivedUri(record),
   ];
   await writeIndex(index);
 }
@@ -220,7 +212,7 @@ export async function removeResource(connectionId: string, resourceId: string): 
   const index = await readIndex();
   const list = index[connectionId] ?? [];
   const target = list.find((r) => r.resourceId === resourceId);
-  const targetClipPath = target && migratedClipPath(target);
+  const targetClipPath = target && clipPathOf(target);
   if (targetClipPath) await deleteFile(clipUri(targetClipPath));
   index[connectionId] = list.filter((r) => r.resourceId !== resourceId);
   await writeIndex(index);


### PR DESCRIPTION
A clip received from Studio replays later with its haptics only — no animation, no sound — while the pattern itself plays fine. Two independent causes, both silent failures.

## 1. The clip path went stale, not the file

`mediaLibrary.ts` persisted the **absolute** uri `file:///…/Application/<container-uuid>/Documents/pulsar-media/…`. iOS hands the app a **new Data-container directory** on reinstall/update while keeping its contents, so the pattern (AsyncStorage) survives and the clip — still on disk — becomes unreachable. Neither consumer complains: Lottie renders an empty canvas, and `Pattern.sound` simply doesn't sound.

The index now stores `clipPath` **relative** to the media root and rebuilds `localUri` on every read (`clipUri()`); records written by the old build migrate by slicing after `pulsar-media/`, so an existing library keeps working without a re-download. `downloadClip` returns the relative path, and upsert/remove resolve before deleting.

Audio had the identical bug and is fixed by the same change — the SDK's players take `file://` on both platforms, so once the path resolves the sound is back.

## 2. Android never rendered a local Lottie at all

`{ uri }` becomes lottie's `sourceURL`. Android's `LottieAnimationViewPropertyManager` does `File(uri).exists()` and otherwise falls back to `setAnimationFromUrl` — a **network** fetch — so `file://…` renders nothing, with no error. iOS resolves a scheme-less path against the app bundle and needs the `file://` form. `LottieCanvas.sourceFor()` strips the scheme on Android only.

Note for reviewers: handing lottie the parsed JSON as an object looks like the tidier fix, but `parsePossibleSources` re-`JSON.stringify`s the source on **every** render and this canvas re-renders once per animation frame. Deliberately not done.

## 3. A missing clip now says so

The index outlives the files (cleared storage, a restore onto a new phone). `clipIsOnDisk` is checked before playing; the broken `sound` is left out of the pattern so the haptics still play, and the player shows a notice to send it from Studio again instead of showing a blank canvas or a mute transport.

## Testing

The `mediaLibrary` module was exercised in Node against stubbed AsyncStorage/FileSystem — download → persist → container move → re-read. Seven checks pass: relative persistence (no absolute uri reaches storage), resolution after a container move, legacy-record migration, missing-clip detection, stale-clip cleanup on re-push with a new `clipId`, and delete. Typecheck and lint are clean on the touched files.

Not verified end-to-end: that needs a Studio push to a paired device. The case to hit manually is replaying a saved animation and a saved audio clip with Studio disconnected, ideally after an app reinstall.