### PR TITLE
feat(tools): render presets playground audio to wav/mp3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "install:all": "tools/scripts/install.sh",
     "sync:versions": "node tools/scripts/sync-sdk-versions.mjs",
     "bootstrap": "node tools/scripts/bootstrap-app.mjs",
+    "render:preset-audio": "node tools/preset-audio/src/cli.mjs",
     "lint": "tools/scripts/lint.sh",
     "lint:js": "tools/scripts/lint-js.sh",
     "lint:kotlin": "tools/scripts/lint-kotlin.sh",

--- a/tools/preset-audio/.gitignore
+++ b/tools/preset-audio/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/preset-audio/README.md
+++ b/tools/preset-audio/README.md
@@ -1,0 +1,41 @@
+# preset-audio
+
+Renders the audio simulation of a Pulsar preset — the same sound the
+[presets playground](https://docs.swmansion.com/pulsar/presets-playground/) plays in the browser —
+to a WAV or MP3 file.
+
+Nothing about the synth is reimplemented here. The CLI imports the website's own
+`AudioPatternUtility` (`docs/src/content/docs/components/Preset/audio-player.ts`) as-is and gives it
+the two browser globals it reaches for: `OfflineAudioContext`, backed by `node-web-audio-api`, and a
+stub `window.AudioContext` standing in for the playback context the CLI never uses. The rendered
+buffer is then written to disk. If the playground's sound changes, so does this output.
+
+## Setup
+
+```bash
+npm --prefix tools/preset-audio install
+```
+
+MP3 output shells out to `ffmpeg` (or `lame`); WAV output has no external dependency.
+
+## Usage
+
+```bash
+node tools/preset-audio/src/cli.mjs Gavel
+node tools/preset-audio/src/cli.mjs Gavel Anvil --out ./preset-audio --format wav
+node tools/preset-audio/src/cli.mjs --all --bitrate 320k
+node tools/preset-audio/src/cli.mjs --list
+```
+
+A preset is named (`Gavel`, resolved against `docs/src/content/docs/assets/presets`) or given as a
+path to any preset `.json`.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `--all` | — | render every preset in the docs assets folder |
+| `--out <dir>` | `preset-audio` | output directory, created if missing |
+| `--format <fmt>` | `mp3` | `mp3` or `wav` |
+| `--bitrate <rate>` | `192k` | MP3 bitrate |
+| `--list` | — | print available preset names |
+
+Requires Node 23.6+ — the docs module is TypeScript, run through Node's type stripping.

--- a/tools/preset-audio/package-lock.json
+++ b/tools/preset-audio/package-lock.json
@@ -1,0 +1,142 @@
+{
+  "name": "@swmansion/preset-audio",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@swmansion/preset-audio",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-web-audio-api": "^2.2.0"
+      },
+      "bin": {
+        "preset-audio": "src/cli.mjs"
+      },
+      "engines": {
+        "node": ">=23.6"
+      }
+    },
+    "node_modules/caller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-1.1.0.tgz",
+      "integrity": "sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-web-audio-api": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-web-audio-api/-/node-web-audio-api-2.2.0.tgz",
+      "integrity": "sha512-qM3dW3Z5HIz+O+++Uiia8x0OSNHcfJGUlexpCTdAkw8JlM17Ru1nV9a94wlxNRXqxT0Lr/ewwEnBXUwGMt24AA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "caller": "^1.1.0",
+        "node-fetch": "^3.3.2",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tools/preset-audio/package.json
+++ b/tools/preset-audio/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@swmansion/preset-audio",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Render the presets playground audio simulation of a Pulsar preset to WAV/MP3.",
+  "type": "module",
+  "engines": { "node": ">=23.6" },
+  "bin": { "preset-audio": "src/cli.mjs" },
+  "scripts": {
+    "render": "node src/cli.mjs"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "node-web-audio-api": "^2.2.0"
+  }
+}

--- a/tools/preset-audio/src/cli.mjs
+++ b/tools/preset-audio/src/cli.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { OfflineAudioContext } from 'node-web-audio-api';
+
+// AudioPatternUtility renders into an OfflineAudioContext taken from the global
+// scope, and keeps a live AudioContext around for playback we never use here.
+globalThis.OfflineAudioContext = OfflineAudioContext;
+globalThis.window = {
+  AudioContext: class {
+    state = 'running';
+    async resume() {}
+  },
+};
+
+const { AudioPatternUtility } = await import(
+  '../../../docs/src/content/docs/components/Preset/audio-player.ts'
+);
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const PRESETS_DIR = path.join(ROOT, 'docs/src/content/docs/assets/presets');
+
+const USAGE = `Usage: node tools/preset-audio/src/cli.mjs <preset...> [options]
+
+  <preset>            preset name (Gavel) or path to a preset .json file
+  --all               render every preset in docs/src/content/docs/assets/presets
+  --out <dir>         output directory (default: ./preset-audio)
+  --format <fmt>      mp3 (default) or wav
+  --bitrate <rate>    mp3 bitrate (default: 192k)
+  --list              print available preset names and exit
+`;
+
+function parseArgs(argv) {
+  const options = { presets: [], all: false, out: 'preset-audio', format: 'mp3', bitrate: '192k' };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--all':
+        options.all = true;
+        break;
+      case '--out':
+        options.out = argv[++i];
+        break;
+      case '--format':
+        options.format = argv[++i];
+        break;
+      case '--bitrate':
+        options.bitrate = argv[++i];
+        break;
+      case '--list':
+        options.list = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        options.presets.push(arg);
+    }
+  }
+
+  return options;
+}
+
+function availablePresets() {
+  return fs
+    .readdirSync(PRESETS_DIR)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => path.basename(file, '.json'))
+    .sort();
+}
+
+function resolvePreset(preset) {
+  if (preset.endsWith('.json')) {
+    const asPath = path.resolve(preset);
+    if (!fs.existsSync(asPath)) {
+      throw new Error(`No preset file at ${asPath}`);
+    }
+    return asPath;
+  }
+
+  const byName = path.join(PRESETS_DIR, `${preset}.json`);
+  if (fs.existsSync(byName)) {
+    return byName;
+  }
+
+  throw new Error(`Unknown preset "${preset}". Run with --list to see available names.`);
+}
+
+function encodeWav(buffer) {
+  const samples = buffer.getChannelData(0);
+  const bytes = Buffer.alloc(44 + samples.length * 2);
+
+  bytes.write('RIFF', 0);
+  bytes.writeUInt32LE(36 + samples.length * 2, 4);
+  bytes.write('WAVE', 8);
+  bytes.write('fmt ', 12);
+  bytes.writeUInt32LE(16, 16);
+  bytes.writeUInt16LE(1, 20); // PCM
+  bytes.writeUInt16LE(1, 22); // mono
+  bytes.writeUInt32LE(buffer.sampleRate, 24);
+  bytes.writeUInt32LE(buffer.sampleRate * 2, 28);
+  bytes.writeUInt16LE(2, 32);
+  bytes.writeUInt16LE(16, 34);
+  bytes.write('data', 36);
+  bytes.writeUInt32LE(samples.length * 2, 40);
+
+  for (let i = 0; i < samples.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[i]));
+    bytes.writeInt16LE(Math.round(sample * 32767), 44 + i * 2);
+  }
+
+  return bytes;
+}
+
+function findEncoder() {
+  for (const command of ['ffmpeg', 'lame']) {
+    if (spawnSync(command, ['-version'], { stdio: 'ignore' }).status === 0) {
+      return command;
+    }
+  }
+  return null;
+}
+
+function encodeMp3(wav, outPath, bitrate, encoder) {
+  const tmpWav = path.join(os.tmpdir(), `preset-audio-${process.pid}-${path.basename(outPath)}.wav`);
+  fs.writeFileSync(tmpWav, wav);
+
+  const args =
+    encoder === 'ffmpeg'
+      ? ['-hide_banner', '-loglevel', 'error', '-y', '-i', tmpWav, '-codec:a', 'libmp3lame', '-b:a', bitrate, outPath]
+      : ['--quiet', '-b', parseInt(bitrate, 10).toString(), tmpWav, outPath];
+
+  try {
+    const result = spawnSync(encoder, args, { stdio: 'inherit' });
+    if (result.status !== 0) {
+      throw new Error(`${encoder} failed to encode ${outPath}`);
+    }
+  } finally {
+    fs.rmSync(tmpWav, { force: true });
+  }
+}
+
+async function renderPreset(presetPath, options, encoder) {
+  const pattern = JSON.parse(fs.readFileSync(presetPath, 'utf8'));
+
+  const player = new AudioPatternUtility();
+  await player.parsePattern(pattern);
+  const buffer = player.getBufferInfo()?.renderedBuffer;
+
+  if (!buffer) {
+    throw new Error(`${path.basename(presetPath)} produced no audio`);
+  }
+
+  const wav = encodeWav(buffer);
+  const name = pattern.name ?? path.basename(presetPath, '.json');
+  const outPath = path.join(options.out, `${name}.${options.format}`);
+
+  if (options.format === 'wav') {
+    fs.writeFileSync(outPath, wav);
+  } else {
+    encodeMp3(wav, outPath, options.bitrate, encoder);
+  }
+
+  console.log(`${outPath} (${buffer.duration.toFixed(3)}s)`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(USAGE);
+    return;
+  }
+
+  if (options.list) {
+    console.log(availablePresets().join('\n'));
+    return;
+  }
+
+  if (options.format !== 'mp3' && options.format !== 'wav') {
+    throw new Error(`Unsupported format "${options.format}". Use mp3 or wav.`);
+  }
+
+  const presets = options.all
+    ? availablePresets().map((name) => path.join(PRESETS_DIR, `${name}.json`))
+    : options.presets.map(resolvePreset);
+
+  if (presets.length === 0) {
+    console.log(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+
+  let encoder = null;
+  if (options.format === 'mp3') {
+    encoder = findEncoder();
+    if (!encoder) {
+      throw new Error('mp3 output needs ffmpeg or lame on PATH. Install one, or pass --format wav.');
+    }
+  }
+
+  fs.mkdirSync(options.out, { recursive: true });
+
+  for (const presetPath of presets) {
+    await renderPreset(presetPath, options, encoder);
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Why

The presets playground synthesizes each preset's sound in the browser, so there was no way to get that audio as a file (for a demo, a slide, a video, or just to listen to a preset offline).

## What

`tools/preset-audio` — a small Node CLI that renders presets to WAV, or MP3 via `ffmpeg`/`lame`.

**No docs code is touched, and the synth is not reimplemented.** The CLI imports the website's own `AudioPatternUtility` (`docs/src/content/docs/components/Preset/audio-player.ts`) exactly as it ships and supplies the two browser globals it reaches for:

- `OfflineAudioContext`, backed by `node-web-audio-api` — this is what actually renders the buffer;
- a stub `window.AudioContext`, standing in for the playback context the CLI never uses.

So the output tracks the playground by construction: change the sound on the site and this follows.

```bash
npm --prefix tools/preset-audio install

node tools/preset-audio/src/cli.mjs Gavel
node tools/preset-audio/src/cli.mjs Gavel Anvil --out ./preset-audio --format wav
node tools/preset-audio/src/cli.mjs --all --bitrate 320k
node tools/preset-audio/src/cli.mjs --list
```

It is its own package (like `tools/pulsar-gen`) so the deployed docs' dependency tree is untouched — nothing new lands in the docs `npm ci`. Needs Node 23.6+, since the docs module is TypeScript run through Node's type stripping.

## Testing

- Rendered `Gavel` to both WAV and MP3; both are **byte-identical** (sha256) to the same preset rendered by a standalone transcription of the playground's synth, confirming the globals shim drives the real code path.
- Rendered `Alarm`, `Anvil`, `Applause` to exercise the continuous-pattern path (lowpass filter branch), and `Gavel` for the impulse-only path.
- `--list` (151 presets), `--help`, preset given as a `.json` path, unknown preset name, missing file, and an unsupported `--format` all behave and exit non-zero on error.
