### PR TITLE
docs: credit Meta Haptics Studio as an inspiration for Studio's editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,7 @@ Download the Pulsar companion app to feel haptic presets directly on your device
 ## Pulsar is created by Software Mansion
 
 Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=reanimated&utm_medium=readme).
+
+## Acknowledgements
+
+Pulsar Studio's editor was shaped by [Meta Haptics Studio](https://developers.meta.com/horizon/resources/haptics-studio/), which showed what a dedicated tool for designing haptics can be. Pulsar is not affiliated with or endorsed by Meta.


### PR DESCRIPTION
## What

Adds an `Acknowledgements` section at the end of the README:

> Pulsar Studio's editor was shaped by [Meta Haptics Studio](https://developers.meta.com/horizon/resources/haptics-studio/), which showed what a dedicated tool for designing haptics can be. Pulsar is not affiliated with or endorsed by Meta.

## Why

The influence is real and there was nowhere in the repo saying so. A README `Acknowledgements` section is the convention people already know to look for, so it needs no new page or sidebar entry.

## Notes for review

- The non-affiliation sentence is deliberate: "Meta Haptics Studio" is Meta's trademark, and the README reads as the project's official voice. It is worth keeping even though the surrounding tone is informal.
- Placement is literally the end of the file, after "Pulsar is created by Software Mansion". Happy to move it above `## License` instead if you'd rather the agency section stay the closing note.
- The link points at Meta's canonical resource page for the tool (not the Windows download or the Unity getting-started guide).
- Docs-only, one file, four added lines. No code paths touched.
