### PR TITLE
fix(app): resume the Figma preview where the killed renderer left off

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -80,12 +80,21 @@ export default function FigmaScreen() {
 }
 
 function FigmaPreviewWebView({ token }: { token: string }) {
+  // A replacement WebView restarts on the payload's frame unless we hand this back.
+  const lastFocusedFrameRef = useRef<string | null>(null);
+  // Figma embeds the preview has mounted in this WebView document. The renderer
+  // dies without warning, taking the preview's own Sentry breadcrumbs with it,
+  // so this side has to carry the count onto the crash report.
+  const embedMountsRef = useRef(0);
+  const [resumeFrame, setResumeFrame] = useState('');
+
   const previewUrl = useMemo(() => {
     // Strip any pre-existing query/hash so we don't accidentally double-append.
     const base = FIGMA_PREVIEW_URL.replace(/[?#].*$/, '');
     const search = new URLSearchParams({ host: 'app', token });
+    if (resumeFrame) search.set('frame', resumeFrame);
     return `${base}?${search.toString()}`;
-  }, [token]);
+  }, [token, resumeFrame]);
 
   const webRef = useRef<WebView>(null);
   const playFromHost = usePlayPatternFromHost();
@@ -116,6 +125,8 @@ function FigmaPreviewWebView({ token }: { token: string }) {
     setLoading(true);
     // The replacement page starts with its nav-bar toggle off.
     setTabBarHidden(false);
+    setResumeFrame(lastFocusedFrameRef.current ?? '');
+    embedMountsRef.current = 0;
     setWebViewGeneration((generation) => generation + 1);
   }, []);
 
@@ -133,7 +144,10 @@ function FigmaPreviewWebView({ token }: { token: string }) {
     // The JS inside the dead renderer is gone, so the preview cannot report this itself.
     Sentry.captureMessage('figma-preview: webview renderer terminated', {
       level: 'warning',
-      extra: { restartsInWindow: restartTimesRef.current.length },
+      extra: {
+        restartsInWindow: restartTimesRef.current.length,
+        embedMounts: embedMountsRef.current,
+      },
     });
     if (restartTimesRef.current.length > MAX_RENDERER_RESTARTS) {
       setLoading(false);
@@ -160,6 +174,9 @@ function FigmaPreviewWebView({ token }: { token: string }) {
     handledNonceRef.current = update.nonce;
     // Ignore updates targeting a different preview than the one we're showing.
     if (update.previewToken && update.previewToken !== token) return;
+    if (update.kind === 'preview-frame-focus' && update.nodeId) {
+      lastFocusedFrameRef.current = update.nodeId;
+    }
     webRef.current?.injectJavaScript(
       buildPreviewInjection({
         type: 'pulsar-haptics-update',
@@ -191,11 +208,18 @@ function FigmaPreviewWebView({ token }: { token: string }) {
           presetName?: string;
           pattern?: Pattern;
           hidden?: boolean;
+          nodeId?: string;
+          embedMounts?: number;
         };
         if (data.type === 'play-preset' && typeof data.presetName === 'string') {
           playFromHost(data.presetName, data.pattern);
         } else if (data.type === 'set-tab-bar-hidden' && typeof data.hidden === 'boolean') {
           setTabBarHidden(data.hidden);
+        } else if (data.type === 'preview-frame-shown' && typeof data.nodeId === 'string') {
+          // Where the user actually is, including navigation inside the prototype
+          // that the plugin never sees - handed back as ?frame= on a remount.
+          lastFocusedFrameRef.current = data.nodeId;
+          if (typeof data.embedMounts === 'number') embedMountsRef.current = data.embedMounts;
         }
       } catch {
         // Non-JSON messages aren't ours; swallow.

--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -82,9 +82,7 @@ export default function FigmaScreen() {
 function FigmaPreviewWebView({ token }: { token: string }) {
   // A replacement WebView restarts on the payload's frame unless we hand this back.
   const lastFocusedFrameRef = useRef<string | null>(null);
-  // Figma embeds the preview has mounted in this WebView document. The renderer
-  // dies without warning, taking the preview's own Sentry breadcrumbs with it,
-  // so this side has to carry the count onto the crash report.
+  // The renderer dies before the preview can report this itself.
   const embedMountsRef = useRef(0);
   const [resumeFrame, setResumeFrame] = useState('');
 
@@ -216,8 +214,7 @@ function FigmaPreviewWebView({ token }: { token: string }) {
         } else if (data.type === 'set-tab-bar-hidden' && typeof data.hidden === 'boolean') {
           setTabBarHidden(data.hidden);
         } else if (data.type === 'preview-frame-shown' && typeof data.nodeId === 'string') {
-          // Where the user actually is, including navigation inside the prototype
-          // that the plugin never sees - handed back as ?frame= on a remount.
+          // Unlike the plugin's relay, this follows navigation inside the prototype.
           lastFocusedFrameRef.current = data.nodeId;
           if (typeof data.embedMounts === 'number') embedMountsRef.current = data.embedMounts;
         }


### PR DESCRIPTION
## What

A dead WebView renderer paints white forever, so the only cure is to remount the whole WebView — which reloads the preview from scratch and lands it on the payload's own frame, not the screen the user was actually looking at.

- Hand the frame back on the replacement URL as `?frame=`.
- Track it from two sources: the plugin's existing `preview-frame-focus` relay, and a new `preview-frame-shown` message the preview posts whenever the frame on screen changes. The second matters because the plugin only reports frames the *designer* focuses in Figma — it never sees the user tapping through the prototype on their phone.
- Carry the preview's embed-mount count on that same message and attach it to the `figma-preview: webview renderer terminated` Sentry event.

## Why the mount count

Memory pressure from accumulated Figma embeds is the suspected cause of these renderer kills. The renderer dies without warning and takes the preview's own Sentry breadcrumbs with it, so this side is the only party left to report how many embeds preceded the kill.

That number is currently unknown, and the desktop measurement did not settle it. Benchmarking the preview's eviction policy over 10 runs × 40 real embed mounts, dropping the frame cache from 2 to 1 measured slightly *worse* than the status quo, and blanking evicted iframes before removal was indistinguishable from baseline — within-policy spread was about half the entire between-policy range. Production data from this field is the way to size it properly before anyone rewrites the embed cache.

## Reviewer notes

- **Depends on the preview half: software-mansion-labs/pulsar-private#140**, which reads `?frame=` and posts `preview-frame-shown`. Without it this side is inert — it listens for a message nobody sends, and `?frame=` is ignored by the page. Safe to land in either order.
- `embedMountsRef` resets on remount, so the count is per-WebView-document rather than cumulative across restarts. `restartsInWindow` already covers the restart dimension.
- The new message is handled in the same `onMessage` chain as `play-preset` / `set-tab-bar-hidden`, and non-matching messages still fall through to the existing swallow.

## Verification

`tsc --noEmit` reports no new errors (the 17 in this repo are pre-existing — `global` not found in `hooks/*`, and a Sentry `enableTombstone` option in `app/_layout.tsx` — none in this file). The resume path has **not** been exercised on a device yet.
