### PR TITLE
fix(docs): set Consent Mode v2 default before GTM loads

### DIFF
--- a/docs/src/components/gtm-head.astro
+++ b/docs/src/components/gtm-head.astro
@@ -5,17 +5,35 @@ const isProduction = import.meta.env.PROD;
 
 {
   isProduction && (
-    <script is:inline define:vars={{ gtmId: GTM_CONFIG.id }}>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', gtmId);
-    </script>
+    <>
+      <script is:inline>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          window.dataLayer.push(arguments);
+        }
+        gtag('consent', 'default', {
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          analytics_storage: 'denied',
+          functionality_storage: 'denied',
+          personalization_storage: 'denied',
+          security_storage: 'denied',
+          wait_for_update: 2000,
+        });
+      </script>
+      <script is:inline define:vars={{ gtmId: GTM_CONFIG.id }}>
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', gtmId);
+      </script>
+    </>
   )
 }


### PR DESCRIPTION
## What

Sets the Google Consent Mode v2 denied default in a synchronous inline script **before** the GTM container snippet, in `docs/src/components/gtm-head.astro`.

One file. All three surfaces (landing page, Studio landing page, every docs page) render `<GTMHead />`, so they are all covered.

## Why

The docs site was writing GA4 cookies before any consent decision on cold-cache loads.

The site **does** already have a CMP — CookieScript, injected by the GTM container itself, not by this repo — and Consent Mode v2 is configured with `analytics_storage` defaulting to `denied`. The banner renders with a genuine reject option. None of that was missing.

The problem is ordering. The consent default is pushed *from inside the GTM container*, as a Custom HTML tag that loads CookieScript over the network. The GA4 tag is loaded by that **same container**. Whichever wins the network race decides whether `_ga` gets written.

Measured on one identical page, varying only HTTP cache state:

| | cookie-script ready | gtag/js ready | `_ga` written |
|---|---|---|---|
| Cold cache | 472 ms | 348 ms | **yes** |
| Warm cache | 34 ms | 35 ms | no |

So a genuine first-time visitor on a cold cache — precisely the person who has not consented yet — hits the failing path. Analytics cookies set before consent are an ePrivacy Directive Art. 5(3) issue (the rule that actually requires the banner; not a GDPR legal-basis question).

The production dataLayer showed the same broken ordering, with `consent default` arriving at index 3, *after* `gtm.dom`. Consent Mode requires the default to be set before any Google tag loads, which a container-delivered default cannot guarantee by construction.

## Approach

Fixing the ordering was preferred over the alternatives:

- **Adding a CMP** — unnecessary, one already exists and is owned by SWM marketing.
- **Gating the GTM snippet on our own consent state** — would mean building a second consent mechanism competing with the CMP already in the container.
- **Dropping GA** — not this repo's call; the container may carry ads/conversion tracking.

The default mirrors CookieScript's existing default set exactly, so only the *timing* changes, not the policy. `wait_for_update: 2000` lets a returning visitor's stored consent land without dropping the pageview.

## Verification

`cd docs && npm run build` passes. `consent default` is now `dataLayer[0]` on all three surfaces (previously index 3).

| Scenario | `_ga` |
|---|---|
| Pre-consent, all 3 surfaces | absent |
| CMP blocked entirely via CSP (worst case) | absent |
| Control: same CSP, this fix reverted | **`_ga`, `_ga_QB27614WVW`** |
| "Accept all" → `consent update: granted` | present |
| "Strictly necessary only" | absent |

The control row is the one that matters — it isolates this change as the cause rather than the test setup.

## Notes for the reviewer

- **PostHog is untouched and is deliberately not behind this gate.** On this branch it still writes a `ph_*` cookie and self-gates on Google consent state; the cookieless PostHog work is separate. This change lives only in `gtm-head.astro`, so there is no file conflict with it, and it will not re-gate PostHog once that self-gating block is removed.
- **`gtm-body.astro`'s `<noscript>` iframe has no consent path** and is left as-is. Nothing can gate it without JS — CookieScript cannot render a banner there either — so removing it is a measurement decision for whoever owns the container.
- **The GTM container is unchanged.** This is Software Mansion marketing infrastructure; the fix is entirely on the site side. Worth confirming with the container owner that adding an earlier default does not conflict with anything configured there — it should not, since Consent Mode ignores later `default` calls for signals already set, and CookieScript's `update` on accept still applies (verified above).
