### PR TITLE
feat(docs): collect cookieless analytics across docs, landing and Studio pages

### DIFF
--- a/docs/config.ts
+++ b/docs/config.ts
@@ -1,8 +1,13 @@
 export const BASE_PATH = '/pulsar';
 
+// Also imported by vite.web-app.config.ts, which runs in Node without import.meta.env.
+const env: Record<string, string | undefined> =
+  (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {};
+
+// Public, write-only key — see src/analytics/README.md.
 export const POSTHOG_CONFIG = {
-  apiKey: 'phc_im7iDRXp3hg6VQ2teOcYCLVsUddGtNOn2ntKdgGk9J0',
-  apiHost: 'https://us.i.posthog.com',
+  apiKey: env.PUBLIC_POSTHOG_KEY || 'phc_im7iDRXp3hg6VQ2teOcYCLVsUddGtNOn2ntKdgGk9J0',
+  apiHost: env.PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
 } as const;
 
 export const GTM_CONFIG = {

--- a/docs/src/analytics/README.md
+++ b/docs/src/analytics/README.md
@@ -1,0 +1,205 @@
+# Analytics — what the site measures, and why it needs no cookie banner
+
+The Pulsar site reports **which pages are read and which things are used** to
+PostHog, across its three surfaces:
+
+| `surface`        | Pages                        |
+| ---------------- | ---------------------------- |
+| `landing`        | `/pulsar/`                   |
+| `studio-landing` | `/pulsar/studio/`            |
+| `docs`           | everything Starlight renders |
+
+The standalone Pulsar Web App under `/pulsar/web-app/` is a separate Vite bundle
+that does not include this component, so it reports nothing.
+
+Files: [`events.ts`](./events.ts) (**the catalogue**), [`analytics.ts`](./analytics.ts)
+(the wrapper), [`../components/posthog.astro`](../components/posthog.astro)
+(init), [`../components/site-analytics.astro`](../components/site-analytics.astro)
+(the delegated, site-wide listeners).
+
+---
+
+## Cookieless, and why that means no banner
+
+The banner requirement (**ePrivacy Directive Art. 5(3)**, the rule the GDPR
+usually gets blamed for) is about _storing information on, or gaining access to
+information stored in, a user's terminal equipment_ — cookies, `localStorage`,
+`sessionStorage`, device fingerprints. It is not about analytics as such. Remove
+the storage and the consent requirement goes with it.
+
+So `posthog.init` is configured:
+
+| Option                                         | Effect                                                                                                                                                |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cookieless_mode: 'always'`                    | No cookie, no local or session storage. Identity is a salted hash PostHog derives **server-side** from the request, rotated daily and not reversible. |
+| `persistence: 'memory'`                        | The belt to that brace — SDK state lives in a variable that dies with the tab.                                                                        |
+| `person_profiles: 'never'`                     | Events never accumulate against a person profile.                                                                                                     |
+| `autocapture: false`                           | We send named events from the catalogue, never every DOM click and its text.                                                                          |
+| `disable_session_recording`, `disable_surveys` | No replay, no injected UI.                                                                                                                            |
+| `property_denylist`                            | Drops everything the SDK reads _from the device_ — see below.                                                                                         |
+| `sanitize_properties`                          | Every URL PostHog attaches is reduced to origin + path.                                                                                               |
+| no `identify()`                                | Events are anonymous.                                                                                                                                 |
+
+Verified in a browser against a stubbed ingestion host (see below): after loading
+the landing page, the Studio landing page and a docs page, and exercising the
+waitlist form, `document.cookie` held nothing from PostHog and neither storage
+held a PostHog key. Every event carried `$cookieless_mode: true`,
+`distinct_id: "$posthog_cookieless"`, `$device_id: null` and
+`$process_person_profile: false`, and **no denylisted property at all** — no
+screen or viewport size, no timezone, no raw user agent.
+
+This puts the site in the same position as Plausible, Fathom and a
+CNIL-exempt Matomo configuration: an audience measurement that produces only
+aggregate statistics, does not follow anyone across sites, and holds no
+persistent identifier.
+
+> ⚠️ **Cookieless mode must also be enabled in the PostHog project**
+> (Settings → Project → _Cookieless server hash mode_). Until it is, PostHog
+> **drops cookieless events on ingestion** — the client works, the dashboards
+> stay empty. This is the first thing to check if no data appears.
+
+### What consent-exempt does _not_ mean
+
+Consent is not required; **transparency still is**. GDPR Art. 13 applies to this
+processing regardless of the ePrivacy question, and the legal basis is legitimate
+interest in understanding how the site is used. Two things must therefore stay
+true:
+
+1. The privacy/cookie policy the footer links to must say that anonymous,
+   cookieless usage statistics are collected, and name PostHog as the processor.
+2. Nothing a visitor typed may ever be sent (see below).
+
+PostHog computes the cookieless hash at ingestion from
+`hash(team_id, daily_salt, ip, user_agent, hostname)` — all of it from the
+request, none of it from the client — so the denylist below cannot break it.
+GeoIP enrichment is unavailable in cookieless mode anyway, which leaves the stored
+`$ip` as the last identifier-shaped field; **Discard client IP data** in the
+project settings removes it, though it is worth confirming with PostHog that the
+setting runs after the hash rather than before.
+
+### What is deliberately NOT sent
+
+- **No identity.** No email, no name, no `identify()`, no person profiles.
+- **Nothing typed.** Not the waitlist form's name / email / company / position,
+  and not the docs search query — `docs_search_opened` counts the _act_ of
+  searching, and the waitlist reports only the shape of the submission
+  (`newsletter: true|false`, and an HTTP status when it fails).
+- **No query strings.** `sanitize_properties` strips them from `$current_url`,
+  `$initial_current_url`, `$referrer` and `$initial_referrer`. `$current_url`
+  rides on _every_ event, not just pageviews, and the playground's share links
+  carry a preset payload. Campaign parameters still arrive as PostHog's own
+  `$utm_*` properties, so attribution is unaffected.
+- **No copied code, no link URLs.** `code_copied` sends the language;
+  `outbound_link_clicked` sends the destination _host_.
+- **Nothing the script asks the device for.** `property_denylist` drops
+  `$screen_width/height`, `$viewport_width/height`, `$timezone` and
+  `$timezone_offset`. This is the sharpest line in the design: Art. 5(3) bites on
+  _gaining access to information stored in the terminal equipment_, and these are
+  the only properties the SDK obtains by interrogating the device rather than by
+  reading what the browser already sent. Without them, nothing in the payload
+  comes from the device at all.
+- **Nothing the request already carried.** `$raw_user_agent` and
+  `$browser_language` are dropped as redundant — the UA and `Accept-Language`
+  reach PostHog as headers regardless, and `$browser`, `$os`, `$device_type` and
+  `$browser_language_prefix` carry the same answers at a fraction of the entropy.
+
+What is left is `$browser` / `$browser_version` / `$os` / `$os_version` /
+`$device_type` / `$browser_language_prefix`, the referrer host and the sanitized
+URL — low-cardinality buckets derived from headers the browser sends in the
+ordinary course of the request. "Which browsers and devices read the docs?" stays
+answerable; "which visitor is this?" does not.
+
+---
+
+## The catalogue is the point
+
+[`events.ts`](./events.ts) lists **every** event with a one-line description, and
+`track()` only accepts an `EventName` — a typo is a compile error, so the
+vocabulary in the dashboard cannot drift from the code.
+
+It is also the only way to answer **"what is nobody using?"** PostHog can show
+the names that _arrived_; it cannot show the ones that never did. Diff a
+breakdown of received events against `EVENT_NAMES`.
+
+### Adding an event
+
+Add its name + description to `EVENTS`, then call `track('name')` at the one
+place the visitor actually triggers it.
+
+---
+
+## Two ways to fire an event, and when to use which
+
+Most of the landing sections are **not hydrated** — Astro renders them to HTML
+and ships no JavaScript for them. An `onClick` on such a section is dropped at
+build time and its event silently never fires. (`sdk_section_viewed`,
+`sdk_logo_clicked` and `connect_phone_cta_clicked` were in exactly that state
+before this was written down.)
+
+| The element lives in…                                 | Use                                                         |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| a hydrated island (`client:load` / `client:visible`)  | `track('name', props)`                                      |
+| static markup, or markup you would rather not hydrate | `trackingAttributes('name', props)` spread onto the element |
+
+`trackingAttributes` renders `data-ph-event` / `data-ph-<prop>` attributes, which the
+delegated listener in `site-analytics.astro` picks up on any click. No hydration,
+no extra JavaScript per section.
+
+---
+
+## Volume
+
+Everything here is click- or navigation-driven, so there is nothing to coalesce.
+The two exceptions are guarded:
+
+- **Scroll depth** reports each of 25 / 50 / 75 / 100% once per page load, from a
+  fixed 250 ms window (not a debounce — a long scroll would otherwise keep
+  resetting the timer and never report). Pages with less than 400 px of scroll
+  are skipped: every threshold would be crossed on load and the number would mean
+  nothing.
+- **Demo video progress** uses `trackFirstTimeOnly`, so a looping video reports each
+  quartile once.
+
+`autocapture` stays off. It is the one setting that would turn traffic into
+volume, and everything it would buy is already in the catalogue.
+
+---
+
+## Configuration
+
+| Where       | Value                                                                                                                                                 |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project key | Defaulted in [`config.ts`](../../config.ts) (public, write-only — the same key Pulsar Studio and PulsarApp use). Override with `PUBLIC_POSTHOG_KEY`.  |
+| Host        | `https://us.i.posthog.com`. Override with `PUBLIC_POSTHOG_HOST`.                                                                                      |
+| Dev         | **Off.** `posthog.astro` renders nothing unless `import.meta.env.PROD`, so `astro dev` never moves the numbers and `window.posthog` is simply absent. |
+
+### Telling the surfaces apart
+
+Every event carries `app: 'pulsar-docs'` and one of the three `surface` values.
+Pulsar Studio (the application) sets `app: 'pulsar-studio'`; PulsarApp sets
+neither, so `app is not set` isolates it.
+
+---
+
+## Checking it end to end
+
+Analytics is off in `astro dev`, so a real check needs a production build pointed
+at a host you can watch:
+
+```bash
+PUBLIC_POSTHOG_HOST=http://localhost:9999 PUBLIC_POSTHOG_KEY=phc_stub npm run build
+```
+
+Serve `dist/` under `/pulsar` from the same host and have it answer
+`/static/array.js` with a copy of PostHog's real `array.js` (otherwise the SDK
+never loads and nothing is exercised). Log the POSTs to `/e/`: each body is
+base64'd gzip JSON with a `batch` of events. Then confirm in the console that
+`document.cookie` holds no PostHog key and that both storages are empty.
+
+Two things will bite during a manual check:
+
+- PostHog defers its initial `$pageview` until `document.visibilityState` is
+  `visible`. A headless or backgrounded tab sends `$pageleave` but no
+  `$pageview`.
+- The waitlist form posts to the real server. Stub `window.fetch` before
+  submitting, or a test run becomes a real subscriber.

--- a/docs/src/analytics/analytics.ts
+++ b/docs/src/analytics/analytics.ts
@@ -1,0 +1,32 @@
+import type { EventName } from './events';
+
+export type EventProps = Record<string, string | number | boolean | null | undefined>;
+
+export function track(event: EventName, props: EventProps = {}): void {
+  window.posthog?.capture(event, props);
+}
+
+export function trackError(error: unknown): void {
+  if (error instanceof Error) window.posthog?.captureException?.(error);
+}
+
+const alreadyTracked = new Set<string>();
+
+export function trackFirstTimeOnly(event: EventName, props: EventProps = {}): void {
+  const key = `${event}:${JSON.stringify(props)}`;
+  if (alreadyTracked.has(key)) return;
+  alreadyTracked.add(key);
+  track(event, props);
+}
+
+/** For sections Astro renders without hydration, where an onClick would be dropped. */
+export function trackingAttributes(
+  event: EventName,
+  props: Record<string, string | number> = {},
+): Record<string, string> {
+  const attributes: Record<string, string> = { 'data-ph-event': event };
+  for (const [key, value] of Object.entries(props)) attributes[`data-ph-${key}`] = String(value);
+  return attributes;
+}
+
+export type { EventName };

--- a/docs/src/analytics/events.ts
+++ b/docs/src/analytics/events.ts
@@ -1,0 +1,57 @@
+/** The only events this site sends. See ./README.md. */
+export const EVENTS = {
+  // --- site-wide -----------------------------------------------------------
+  page_scroll_depth: 'A page was scrolled past 25 / 50 / 75 / 100% for the first time',
+  outbound_link_clicked: 'A link to another host was clicked (host only, never the full URL)',
+  nav_link_clicked: 'A top-bar or mobile-menu destination was chosen',
+  code_copied: 'A code block was copied with the copy button',
+  docs_search_opened: 'The docs search dialog was opened (the query itself is never sent)',
+
+  // --- landing page --------------------------------------------------------
+  see_all_presets_clicked: 'The "See all presets" button under the preset teaser was clicked',
+  preset_playground_cta_clicked: 'The hero CTA into the presets playground was clicked',
+  docs_cta_clicked: 'The hero CTA into the docs was clicked',
+  haptics_demo_interacted: 'A preset in the hero demo was played',
+  connect_phone_cta_clicked: 'The "connect your phone" CTA was clicked',
+  sdk_section_viewed: 'The SDK section was expanded',
+  sdk_logo_clicked: 'A platform logo in the SDK section was clicked',
+  app_showcase_store_clicked: 'An App Store / Google Play badge was clicked',
+  studio_section_waitlist_clicked: 'The Studio teaser on the landing page led to the waitlist',
+
+  // --- Studio landing page (/studio/) --------------------------------------
+  studio_landing_cta_clicked: 'A "Join the waitlist" CTA was clicked',
+  studio_landing_haptic_played: 'A hero emoji tile played its haptic',
+  studio_landing_demo_played: 'The product demo video started playing',
+  studio_landing_demo_progress: 'The demo video passed 25 / 50 / 75 / 100% for the first time',
+  studio_landing_docs_link_clicked: 'The "Why Pulsar" section sent the visitor into the docs',
+  studio_landing_waitlist_started: 'The first waitlist field was filled in',
+  studio_landing_waitlist_submitted: 'The waitlist form was submitted',
+  studio_landing_waitlist_succeeded: 'The waitlist submission was accepted by the server',
+  studio_landing_waitlist_failed: 'The waitlist submission was rejected or threw',
+  studio_landing_waitlist_consent_blocked: 'Submission was blocked by the unchecked consent box',
+
+  // --- presets playground (docs) -------------------------------------------
+  preset_played: 'A preset was previewed in the browser',
+  preset_played_on_device: 'A preset was sent to a connected phone',
+  preset_code_copied: "A preset's code snippet was copied",
+  preset_edit_in_studio: 'A preset was opened in Pulsar Studio',
+  preset_favourited: 'A preset was added to favourites',
+  preset_unfavourited: 'A preset was removed from favourites',
+  preset_filter_applied: 'The preset list was filtered',
+  preset_sound_enabled: 'Preview sound was turned on',
+  preset_sound_disabled: 'Preview sound was turned off',
+
+  // --- web presets playground (docs) ---------------------------------------
+  web_preset_played: 'A web preset was previewed',
+  web_preset_sound_enabled: 'Web preview sound was turned on',
+  web_preset_sound_disabled: 'Web preview sound was turned off',
+
+  // --- phone connection (docs) ---------------------------------------------
+  device_connected: 'A phone paired with the playground',
+  device_disconnected: 'A paired phone disconnected',
+  reset_connection: 'The pairing was reset from the UI',
+} as const;
+
+export type EventName = keyof typeof EVENTS;
+
+export const EVENT_NAMES = Object.keys(EVENTS) as EventName[];

--- a/docs/src/analytics/posthog.d.ts
+++ b/docs/src/analytics/posthog.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface Window {
+    posthog?: {
+      capture: (event: string, properties?: Record<string, unknown>) => void;
+      captureException?: (error: Error, properties?: Record<string, unknown>) => void;
+    };
+  }
+}
+
+export {};

--- a/docs/src/components/PageFrame.astro
+++ b/docs/src/components/PageFrame.astro
@@ -18,7 +18,8 @@ const currentYear = new Date().getFullYear();
     Read about our
     <a href="https://swmansion.com/privacy/policy/" target="_blank" rel="noopener"
       >Privacy Policy</a
-    >.
+    >. We collect anonymous, cookieless usage statistics — no cookies, no tracking across
+    sites.
   </p>
 </footer>
 

--- a/docs/src/components/landing/AppShowcase/AppShowcase.tsx
+++ b/docs/src/components/landing/AppShowcase/AppShowcase.tsx
@@ -3,19 +3,13 @@ import { PhoneCarousel } from './PhoneCarousel';
 import styles from './AppShowcase.module.scss';
 import appleBadge from '../../../assets/landing-page/apple-store-badge.svg';
 import googleBadge from '../../../assets/landing-page/google-play-badge.png';
+import { track } from '../../../analytics/analytics';
 
 const APP_STORE_URL =
   'https://apps.apple.com/pl/app/haptics-presets-pulsar/id6761362104';
 const PLAY_STORE_URL =
   'https://play.google.com/store/apps/details?id=com.swmansion.pulsar.app';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 export function AppShowcase({ className }: { className?: string }) {
   return (
@@ -32,7 +26,7 @@ export function AppShowcase({ className }: { className?: string }) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() =>
-              window.posthog?.capture('app_showcase_store_clicked', {
+              track('app_showcase_store_clicked', {
                 store: 'app_store',
               })
             }
@@ -48,7 +42,7 @@ export function AppShowcase({ className }: { className?: string }) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() =>
-              window.posthog?.capture('app_showcase_store_clicked', {
+              track('app_showcase_store_clicked', {
                 store: 'google_play',
               })
             }

--- a/docs/src/components/landing/Button/Button.tsx
+++ b/docs/src/components/landing/Button/Button.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   variant?: 'filled' | 'unfilled';
   className?: string;
   onClick?: () => void;
+  analytics?: Record<string, string>;
 }
 
 export function Button({
@@ -16,6 +17,7 @@ export function Button({
   variant = 'unfilled',
   className = '',
   onClick,
+  analytics,
 }: ButtonProps) {
   const classes = [
     styles.innerHolder,
@@ -25,12 +27,12 @@ export function Button({
   return (
     <div className={`${styles.background} ${className}`}>
       {url ? (
-        <a className={classes} href={url} onClick={onClick}>
+        <a className={classes} href={url} onClick={onClick} {...analytics}>
           {label}
           <img src={arrowIcon.src} alt="arrow" />
         </a>
       ) : (
-        <button className={classes} type="button" onClick={onClick}>
+        <button className={classes} type="button" onClick={onClick} {...analytics}>
           {label}
           <img src={arrowIcon.src} alt="arrow" />
         </button>

--- a/docs/src/components/landing/SdkSection/SdkSection.tsx
+++ b/docs/src/components/landing/SdkSection/SdkSection.tsx
@@ -2,6 +2,7 @@ import { Button } from '../Button/Button';
 import { SectionHeader } from '../SectionHeader/SectionHeader';
 import styles from './SdkSection.module.scss';
 import { BASE_PATH } from '../../../../config';
+import { trackingAttributes } from '../../../analytics/analytics';
 
 type Platform = {
   name: string;
@@ -57,13 +58,6 @@ const platforms: Platform[] = [
   },
 ];
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 export function SdkSection({ className }: { className?: string }) {
   return (
@@ -77,7 +71,7 @@ export function SdkSection({ className }: { className?: string }) {
         <Button
           label="See all of them"
           url={`${BASE_PATH}/sdk/overview/`}
-          onClick={() => window.posthog?.capture('sdk_section_viewed')}
+          analytics={trackingAttributes('sdk_section_viewed')}
         />
       </div>
       <div className={styles.right}>
@@ -88,9 +82,7 @@ export function SdkSection({ className }: { className?: string }) {
               className={styles.card}
               href={`${BASE_PATH}/sdk/${slug}/`}
               aria-label={`${name} SDK documentation`}
-              onClick={() =>
-                window.posthog?.capture('sdk_logo_clicked', { sdk: name })
-              }
+              {...trackingAttributes('sdk_logo_clicked', { sdk: name })}
             >
               <svg
                 viewBox="0 0 24 24"

--- a/docs/src/components/landing/StudioSection/StudioSection.tsx
+++ b/docs/src/components/landing/StudioSection/StudioSection.tsx
@@ -2,6 +2,7 @@ import { Button } from '../Button/Button';
 import { SectionHeader } from '../SectionHeader/SectionHeader';
 import styles from './StudioSection.module.scss';
 import { BASE_PATH } from '../../../../config';
+import { track } from '../../../analytics/analytics';
 
 // What Studio lets you do — short labels echoing the Studio landing feature grid.
 const highlights = [
@@ -59,7 +60,7 @@ export function StudioSection({ className }: { className?: string }) {
             label="Join the waitlist"
             variant="filled"
             url={`${BASE_PATH}/studio/#waitlist`}
-            onClick={() => window.posthog?.capture('studio_section_waitlist_clicked')}
+            onClick={() => track('studio_section_waitlist_clicked')}
           />
         </div>
       </div>

--- a/docs/src/components/landing/SwmSection/SwmSection.tsx
+++ b/docs/src/components/landing/SwmSection/SwmSection.tsx
@@ -43,7 +43,8 @@ export function SwmSection({ className }: { className?: string }) {
             <a href="https://swmansion.com/privacy/policy/ " target="_blank" rel="noopener">
               Privacy Policy
             </a>
-            .
+            . We collect anonymous, cookieless usage statistics — no cookies, no tracking
+            across sites.
           </p>
         </div>
       </BasicLayout>

--- a/docs/src/components/landing/TopBanner/TopBanner.tsx
+++ b/docs/src/components/landing/TopBanner/TopBanner.tsx
@@ -11,14 +11,8 @@ import { EmojiButton } from '../EmojiButton/EmojiButton';
 import { SoundBar } from '../SoundBar/SoundBar';
 import { Presets } from 'pulsar-haptics';
 import { useRef, useState } from 'react';
+import { track } from '../../../analytics/analytics';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 export function TopBanner() {
   const [colorClass, setColorClass] = useState('');
@@ -90,14 +84,14 @@ export function TopBanner() {
             label="Preset playground"
             url={`${BASE_PATH}/presets-playground/`}
             className={styles.fullWidth}
-            onClick={() => window.posthog?.capture('preset_playground_cta_clicked')}
+            onClick={() => track('preset_playground_cta_clicked')}
           />
           <Button
             label="Read the docs"
             variant="filled"
             url={`${BASE_PATH}/getting-started/`}
             className={styles.fullWidth}
-            onClick={() => window.posthog?.capture('docs_cta_clicked')}
+            onClick={() => track('docs_cta_clicked')}
           />
         </div>
       </div>
@@ -133,7 +127,7 @@ export function TopBanner() {
                     setColorClass('');
                     setBackgroundAnimation(styles.wave);
                     handleAnimationEffect('');
-                    window.posthog?.capture('haptics_demo_interacted', {
+                    track('haptics_demo_interacted', {
                       emoji: 'emoji1',
                       effect: 'wave',
                     });
@@ -147,7 +141,7 @@ export function TopBanner() {
                     setColorClass(styles.yellow);
                     setBackgroundAnimation(styles.sonar);
                     handleAnimationEffect('stars');
-                    window.posthog?.capture('haptics_demo_interacted', {
+                    track('haptics_demo_interacted', {
                       emoji: 'emoji2',
                       effect: 'stars',
                     });
@@ -164,7 +158,7 @@ export function TopBanner() {
                     setColorClass(styles.red);
                     setBackgroundAnimation(styles.quake);
                     handleAnimationEffect('confetti');
-                    window.posthog?.capture('haptics_demo_interacted', {
+                    track('haptics_demo_interacted', {
                       emoji: 'emoji3',
                       effect: 'confetti',
                     });
@@ -178,7 +172,7 @@ export function TopBanner() {
                     setColorClass(styles.green);
                     setBackgroundAnimation(styles.heartbeat);
                     handleAnimationEffect('angels');
-                    window.posthog?.capture('haptics_demo_interacted', {
+                    track('haptics_demo_interacted', {
                       emoji: 'emoji4',
                       effect: 'angels',
                     });

--- a/docs/src/components/landing/TopBar/TopBar.tsx
+++ b/docs/src/components/landing/TopBar/TopBar.tsx
@@ -6,6 +6,10 @@ import logoGitHub from '../../../assets/landing-page/logo-github.png';
 import menuIcon from '../../../assets/landing-page/menu.svg';
 import closeIcon from '../../../assets/landing-page/x.svg';
 import { BASE_PATH } from '../../../../config';
+import { trackingAttributes } from '../../../analytics/analytics';
+
+const nav = (target: string, location: 'topbar' | 'mobile-menu') =>
+  trackingAttributes('nav_link_clicked', { target, location });
 
 export function TopBar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -26,13 +30,23 @@ export function TopBar() {
           <span>Pulsar</span>
         </a>
         <div className={styles.menuItems}>
-          <a className={styles.studioLink} href={`${BASE_PATH}/studio/`}>
+          <a
+            className={styles.studioLink}
+            href={`${BASE_PATH}/studio/`}
+            {...nav('studio', 'topbar')}
+          >
             Studio
             <span className={styles.newDot} aria-hidden="true" />
           </a>
-          <a href={`${BASE_PATH}/presets-playground/`}>Presets</a>
-          <a href={`${BASE_PATH}/getting-started/`}>Getting started</a>
-          <a href={`${BASE_PATH}/sdk/overview/`}>Docs</a>
+          <a href={`${BASE_PATH}/presets-playground/`} {...nav('presets', 'topbar')}>
+            Presets
+          </a>
+          <a href={`${BASE_PATH}/getting-started/`} {...nav('getting-started', 'topbar')}>
+            Getting started
+          </a>
+          <a href={`${BASE_PATH}/sdk/overview/`} {...nav('docs', 'topbar')}>
+            Docs
+          </a>
         </div>
         <a href="https://github.com/software-mansion/pulsar" target="_blank">
           <img className={styles.gitLogo} src={logoGitHub.src} alt="GitHub" />
@@ -59,17 +73,34 @@ export function TopBar() {
               />
             </div>
             <nav className={styles.mobileMenuItems}>
-              <a className={styles.studioLink} href={`${BASE_PATH}/studio/`} onClick={closeMenu}>
+              <a
+                className={styles.studioLink}
+                href={`${BASE_PATH}/studio/`}
+                onClick={closeMenu}
+                {...nav('studio', 'mobile-menu')}
+              >
                 Studio
                 <span className={styles.newDot} aria-hidden="true" />
               </a>
-              <a href={`${BASE_PATH}/presets-playground/`} onClick={closeMenu}>
+              <a
+                href={`${BASE_PATH}/presets-playground/`}
+                onClick={closeMenu}
+                {...nav('presets', 'mobile-menu')}
+              >
                 Presets
               </a>
-              <a href={`${BASE_PATH}/getting-started/`} onClick={closeMenu}>
+              <a
+                href={`${BASE_PATH}/getting-started/`}
+                onClick={closeMenu}
+                {...nav('getting-started', 'mobile-menu')}
+              >
                 Getting started
               </a>
-              <a href={`${BASE_PATH}/sdk/overview/`} onClick={closeMenu}>
+              <a
+                href={`${BASE_PATH}/sdk/overview/`}
+                onClick={closeMenu}
+                {...nav('docs', 'mobile-menu')}
+              >
                 Docs
               </a>
             </nav>

--- a/docs/src/components/landing/VisitPlayground/VisitPlayground.tsx
+++ b/docs/src/components/landing/VisitPlayground/VisitPlayground.tsx
@@ -4,14 +4,7 @@ import styles from './VisitPlayground.module.scss';
 import { BASE_PATH } from '../../../../config';
 import commonStyles from '../common.module.scss';
 import { EmojiButton } from '../EmojiButton/EmojiButton';
-
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
+import { trackingAttributes } from '../../../analytics/analytics';
 
 export function VisitPlayground({ className }: { className?: string }) {
   return (
@@ -31,7 +24,7 @@ export function VisitPlayground({ className }: { className?: string }) {
           label="Connect your phone"
           url={`${BASE_PATH}/presets-playground/`}
           className={commonStyles.spaceTopSmall}
-          onClick={() => window.posthog?.capture('connect_phone_cta_clicked')}
+          analytics={trackingAttributes('connect_phone_cta_clicked')}
         />
       </div>
     </div>

--- a/docs/src/components/posthog.astro
+++ b/docs/src/components/posthog.astro
@@ -1,164 +1,77 @@
 ---
-// PostHog analytics snippet
-// Uses is:inline to prevent Astro from processing the script
-import { POSTHOG_CONFIG } from '../../config';
+// Cookieless — nothing is stored on the device, hence no consent banner.
+// See src/analytics/README.md.
+import { POSTHOG_CONFIG, BASE_PATH } from '../../config';
+import SiteAnalytics from './site-analytics.astro';
+
+const enabledForThisBuild = import.meta.env.PROD && Boolean(POSTHOG_CONFIG.apiKey);
 ---
-<script is:inline define:vars={{ apiKey: POSTHOG_CONFIG.apiKey, apiHost: POSTHOG_CONFIG.apiHost }}>
-  if (!apiKey) {
-    console.warn('PostHog disabled: apiKey is not configured.');
-  } else {
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init(apiKey, {
-      api_host: apiHost || 'https://us.i.posthog.com',
-      defaults: '2026-01-30',
-      opt_out_capturing_by_default: true,
-      persistence: 'localStorage+cookie'
-    });
 
-    const consentState = { lastValue: null };
+{
+  enabledForThisBuild && (
+    <script
+      is:inline
+      define:vars={{
+        apiKey: POSTHOG_CONFIG.apiKey,
+        apiHost: POSTHOG_CONFIG.apiHost,
+        basePath: BASE_PATH,
+      }}
+    >
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 
-    function readCookie(name) {
-      const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const match = document.cookie.match(new RegExp(`(?:^|; )${escapedName}=([^;]*)`));
-      return match ? decodeURIComponent(match[1]) : null;
-    }
-
-    function readGoogleConsent() {
-      const consentEntries = window.google_tag_data?.ics?.entries;
-      if (!consentEntries) {
-        return null;
-      }
-
-      const analyticsEntry = consentEntries.analytics_storage;
-      const candidateValues = [analyticsEntry?.update, analyticsEntry?.default];
-
-      if (candidateValues.some((value) => value === 'granted')) {
-        return true;
-      }
-
-      if (candidateValues.some((value) => value === 'denied')) {
-        return false;
-      }
-
-      return null;
-    }
-
-    function readCookiebotConsent() {
-      const cookieConsent = readCookie('CookieConsent');
-      if (!cookieConsent) {
-        return null;
-      }
-
-      try {
-        const parsed = JSON.parse(cookieConsent);
-        if (typeof parsed.statistics === 'boolean') {
-          return parsed.statistics;
-        }
-      } catch {
-        return null;
-      }
-
-      return null;
-    }
-
-    function readCookieScriptConsent() {
-      const cookieScript =
-        window.CookieScript?.instance ??
-        window.CookieScript?.Instance ??
-        window.CookieScript ??
-        null;
-
-      const currentState =
-        typeof cookieScript?.currentState === 'function' ? cookieScript.currentState() : null;
-
-      if (!currentState) {
-        return null;
-      }
-
-      if (currentState.action === 'reject') {
-        return false;
-      }
-
-      if (Array.isArray(currentState.categories)) {
-        return currentState.categories.includes('performance');
-      }
-
-      return currentState.action === 'accept' ? true : null;
-    }
-
-    function readCookieYesConsent() {
-      const cookieConsent = readCookie('cookieyes-consent');
-      if (!cookieConsent) {
-        return null;
-      }
-
-      const analyticsMatch = cookieConsent.match(/(?:^|,)analytics:(yes|no)(?:,|$)/i);
-      if (!analyticsMatch) {
-        return null;
-      }
-
-      return analyticsMatch[1].toLowerCase() === 'yes';
-    }
-
-    function readConsentDecision() {
-      const readers = [
-        readGoogleConsent,
-        readCookieScriptConsent,
-        readCookiebotConsent,
-        readCookieYesConsent,
+      // Read from the device by script rather than sent with the request — the
+      // distinction the consent exemption rests on. See src/analytics/README.md.
+      var PROPERTIES_READ_FROM_THE_DEVICE = [
+        '$screen_height',
+        '$screen_width',
+        '$viewport_height',
+        '$viewport_width',
+        '$timezone',
+        '$timezone_offset',
       ];
 
-      for (const readConsent of readers) {
-        const decision = readConsent();
-        if (typeof decision === 'boolean') {
-          return decision;
-        }
+      // Already carried by the request, or already covered by $browser / $os /
+      // $device_type and $browser_language_prefix.
+      var PROPERTIES_ALREADY_KNOWN = ['$raw_user_agent', '$browser_language'];
+
+      function currentSurface() {
+        var path = location.pathname.replace(/\/+$/, '');
+        var root = basePath.replace(/\/+$/, '');
+        if (path === root) return 'landing';
+        if (path === root + '/studio') return 'studio-landing';
+        return 'docs';
       }
 
-      return null;
-    }
-
-    function syncPostHogConsent() {
-      const hasAnalyticsConsent = readConsentDecision();
-
-      if (hasAnalyticsConsent === consentState.lastValue || typeof hasAnalyticsConsent !== 'boolean') {
-        return;
+      function withoutQueryStrings(properties) {
+        ['$current_url', '$initial_current_url', '$referrer', '$initial_referrer'].forEach(
+          function (key) {
+            var value = properties[key];
+            if (typeof value !== 'string') return;
+            try {
+              var url = new URL(value);
+              properties[key] = url.origin + url.pathname;
+            } catch {}
+          },
+        );
+        return properties;
       }
 
-      consentState.lastValue = hasAnalyticsConsent;
+      posthog.init(apiKey, {
+        api_host: apiHost || 'https://us.i.posthog.com',
+        defaults: '2026-01-30',
+        cookieless_mode: 'always',
+        persistence: 'memory',
+        person_profiles: 'never',
+        autocapture: false,
+        property_denylist: PROPERTIES_READ_FROM_THE_DEVICE.concat(PROPERTIES_ALREADY_KNOWN),
+        disable_session_recording: true,
+        disable_surveys: true,
+        sanitize_properties: withoutQueryStrings,
+      });
 
-      if (hasAnalyticsConsent) {
-        posthog.opt_in_capturing();
-      } else {
-        posthog.opt_out_capturing();
-      }
-    }
+      posthog.register({ app: 'pulsar-docs', surface: currentSurface() });
+    </script>
+  )
+}
 
-    const originalDataLayerPush = window.dataLayer?.push;
-    if (typeof originalDataLayerPush === 'function') {
-      window.dataLayer.push = function (...args) {
-        const result = originalDataLayerPush.apply(this, args);
-        queueMicrotask(syncPostHogConsent);
-        return result;
-      };
-    }
-
-    [
-      'CookieScriptLoaded',
-      'CookieScriptAccept',
-      'CookieScriptAcceptAll',
-      'CookieScriptReject',
-      'CookieScriptCategory-performance',
-      'CookiebotOnConsentReady',
-      'CookiebotOnAccept',
-      'CookiebotOnDecline',
-      'cookieyes_consent_update',
-      'OneTrustGroupsUpdated',
-      'consentChanged',
-    ].forEach((eventName) => {
-      window.addEventListener(eventName, syncPostHogConsent);
-    });
-
-    syncPostHogConsent();
-  }
-</script>
+{enabledForThisBuild && <SiteAnalytics />}

--- a/docs/src/components/site-analytics.astro
+++ b/docs/src/components/site-analytics.astro
@@ -1,0 +1,86 @@
+---
+// Delegated from `document`, so it covers Starlight's markup and islands that
+// hydrate later. Event names must exist in src/analytics/events.ts.
+---
+
+<script>
+  const track = (event: string, props: Record<string, unknown> = {}) =>
+    window.posthog?.capture(event, props);
+
+  const SCROLL_DEPTHS = [25, 50, 75, 100];
+  const SCROLL_REPORT_WINDOW_MS = 250;
+  const IGNORE_PAGES_SHORTER_THAN_PX = 400;
+
+  const depthsReported = new Set<number>();
+  let pendingDepthReport: ReturnType<typeof setTimeout> | null = null;
+
+  function reportScrollDepth() {
+    pendingDepthReport = null;
+
+    const pageHeight = document.documentElement.scrollHeight;
+    if (pageHeight - window.innerHeight < IGNORE_PAGES_SHORTER_THAN_PX) return;
+
+    const readTo = ((window.scrollY + window.innerHeight) / pageHeight) * 100;
+    for (const depth of SCROLL_DEPTHS) {
+      if (readTo >= depth && !depthsReported.has(depth)) {
+        depthsReported.add(depth);
+        track('page_scroll_depth', { depth });
+      }
+    }
+  }
+
+  window.addEventListener(
+    'scroll',
+    () => {
+      pendingDepthReport ??= setTimeout(reportScrollDepth, SCROLL_REPORT_WINDOW_MS);
+    },
+    { passive: true },
+  );
+
+  function trackMarkedElement(element: HTMLElement) {
+    const { phEvent, ...rest } = element.dataset;
+    const props: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(rest)) {
+      if (key.startsWith('ph')) props[key.slice(2).toLowerCase()] = value;
+    }
+    track(phEvent as string, props);
+  }
+
+  function hostOf(link: HTMLAnchorElement): string | null {
+    try {
+      const url = new URL(link.href, location.href);
+      const isExternal = /^https?:$/.test(url.protocol) && url.host !== location.host;
+      return isExternal ? url.host : null;
+    } catch {
+      return null;
+    }
+  }
+
+  document.addEventListener(
+    'click',
+    (event) => {
+      const target = event.target as Element | null;
+      if (!target?.closest) return;
+
+      const copyButton = target.closest('button[data-code]');
+      if (copyButton) {
+        const code = copyButton.closest('figure')?.querySelector('pre[data-language]');
+        track('code_copied', { language: code?.getAttribute('data-language') ?? 'unknown' });
+        return;
+      }
+
+      if (target.closest('site-search [data-open-modal]')) {
+        track('docs_search_opened');
+        return;
+      }
+
+      const marked = target.closest<HTMLElement>('[data-ph-event]');
+      if (marked) trackMarkedElement(marked);
+
+      const link = target.closest<HTMLAnchorElement>('a[href]');
+      const outboundHost = link && hostOf(link);
+      if (outboundHost) track('outbound_link_clicked', { host: outboundHost });
+    },
+    { capture: true },
+  );
+</script>

--- a/docs/src/components/studio/StudioDemo/StudioDemo.tsx
+++ b/docs/src/components/studio/StudioDemo/StudioDemo.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import styles from './StudioDemo.module.scss';
 import { BasicLayout } from '../../landing/Layouts/BasicLayout';
 import { BASE_PATH } from '../../../../config';
+import { track, trackFirstTimeOnly } from '../../../analytics/analytics';
 
 // A looping product demo, framed in the Pulsar "window" card. Sits right above
 // the waitlist so visitors can see Studio in action before signing up.
@@ -28,8 +29,24 @@ export function StudioDemo() {
       { threshold: 0.4 },
     );
 
+    const onPlay = () => track('studio_landing_demo_played');
+    const onTimeUpdate = () => {
+      if (!video.duration) return;
+      const percent = (video.currentTime / video.duration) * 100;
+      for (const quartile of [25, 50, 75, 100]) {
+        if (percent >= quartile)
+          trackFirstTimeOnly('studio_landing_demo_progress', { percent: quartile });
+      }
+    };
+
+    video.addEventListener('play', onPlay);
+    video.addEventListener('timeupdate', onTimeUpdate);
     observer.observe(video);
-    return () => observer.disconnect();
+    return () => {
+      video.removeEventListener('play', onPlay);
+      video.removeEventListener('timeupdate', onTimeUpdate);
+      observer.disconnect();
+    };
   }, []);
 
   return (

--- a/docs/src/components/studio/StudioHero/StudioHero.tsx
+++ b/docs/src/components/studio/StudioHero/StudioHero.tsx
@@ -17,6 +17,7 @@ import applausePreset from '../../../content/docs/assets/presets/Applause.json';
 import powerDownPreset from '../../../content/docs/assets/presets/PowerDown.json';
 import bloomPreset from '../../../content/docs/assets/presets/Bloom.json';
 import heartbeatPreset from '../../../content/docs/assets/presets/Heartbeat.json';
+import { track } from '../../../analytics/analytics';
 
 const CHART_POINTS = 9;
 
@@ -192,6 +193,7 @@ export function StudioHero() {
   const handleEmojiClick = async (index: number) => {
     setActiveIndex(index);
     setHasInteracted(true);
+    track('studio_landing_haptic_played', { preset: emojiTiles[index].label });
 
     // Real device haptics where supported.
     if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
@@ -239,7 +241,11 @@ export function StudioHero() {
           </p>
 
           <div className={styles.ctaRow}>
-            <Button label="Join the waitlist" url="#waitlist" />
+            <Button
+              label="Join the waitlist"
+              url="#waitlist"
+              onClick={() => track('studio_landing_cta_clicked', { location: 'hero' })}
+            />
             <span className={styles.priceHint}>with pricing starting from <b style={{ fontSize: '22px' }}>9$</b>/month</span>
           </div>
         </div>

--- a/docs/src/components/studio/StudioWaitlist/StudioWaitlist.tsx
+++ b/docs/src/components/studio/StudioWaitlist/StudioWaitlist.tsx
@@ -5,6 +5,7 @@ import { API_SERVER_URL } from '../../../content/docs/components/config';
 import star from '../../../assets/landing-page/star.svg';
 import arrowIcon from '../../../assets/landing-page/arrow-icon.svg';
 import wavePattern from '../../../assets/landing-page/pattern.svg';
+import { track } from '../../../analytics/analytics';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -16,6 +17,13 @@ export function StudioWaitlist() {
   const [consent, setConsent] = useState(false);
   const [consentError, setConsentError] = useState(false);
   const [newsletter, setNewsletter] = useState(false);
+  const [hasStarted, setHasStarted] = useState(false);
+
+  const trackFirstFieldFilled = () => {
+    if (hasStarted) return;
+    setHasStarted(true);
+    track('studio_landing_waitlist_started');
+  };
 
   // Posts to the server's public /waitlist route, which adds the subscriber to the
   // MailerLite "Pulsar Studio" group (and, when opted in, the "SWM newsletter"
@@ -29,13 +37,16 @@ export function StudioWaitlist() {
     // message instead of silently sending nothing.
     if (!consent) {
       setConsentError(true);
+      track('studio_landing_waitlist_consent_blocked');
       return;
     }
 
     const form = e.currentTarget;
     const data = new FormData(form);
     setStatus('loading');
+    track('studio_landing_waitlist_submitted', { newsletter });
 
+    let failureReported = false;
     try {
       const res = await fetch(`${API_SERVER_URL}/waitlist`, {
         method: 'POST',
@@ -48,12 +59,18 @@ export function StudioWaitlist() {
           newsletter,
         }),
       });
-      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      if (!res.ok) {
+        failureReported = true;
+        track('studio_landing_waitlist_failed', { reason: 'http', status: res.status });
+        throw new Error(`Request failed (${res.status})`);
+      }
+      track('studio_landing_waitlist_succeeded', { newsletter });
       setStatus('success');
       setConsent(false);
       setNewsletter(false);
       form.reset();
     } catch {
+      if (!failureReported) track('studio_landing_waitlist_failed', { reason: 'network' });
       setStatus('error');
     }
   };
@@ -76,7 +93,7 @@ export function StudioWaitlist() {
           you know as soon as early access is available.
         </p>
 
-        <form className={styles.form} onSubmit={handleSubmit}>
+        <form className={styles.form} onSubmit={handleSubmit} onFocusCapture={trackFirstFieldFilled}>
           <input className={styles.input} type="text" name="name" placeholder="Name" aria-label="Name" required />
           <input
             className={styles.input}

--- a/docs/src/components/studio/StudioWhyPulsar/StudioWhyPulsar.tsx
+++ b/docs/src/components/studio/StudioWhyPulsar/StudioWhyPulsar.tsx
@@ -5,6 +5,7 @@ import { BASE_PATH } from '../../../../config';
 import emojiStar from '../../../assets/landing-page/emoji2.svg';
 import emojiSad from '../../../assets/landing-page/emoji3.svg';
 import emojiNeutral from '../../../assets/landing-page/emoji_neutral.svg';
+import { trackingAttributes } from '../../../analytics/analytics';
 
 // A short base sequence, duplicated so the column can loop seamlessly: the CSS
 // marquee scrolls up by exactly one copy's height (translateY -50%), landing the
@@ -29,7 +30,11 @@ export function StudioWhyPulsar() {
             <p className={styles.paragraph}>
               All to make haptics easy to build, ship, and maintain across platforms.
             </p>
-            <a className={styles.link} href={`${BASE_PATH}/getting-started/`}>
+            <a
+              className={styles.link}
+              href={`${BASE_PATH}/getting-started/`}
+              {...trackingAttributes('studio_landing_docs_link_clicked')}
+            >
               Learn more about Pulsar
             </a>
           </div>

--- a/docs/src/content/docs/components/Connection/Connection.tsx
+++ b/docs/src/content/docs/components/Connection/Connection.tsx
@@ -9,13 +9,11 @@ import appleStoreBadge from '../../assets/interactive-playground/apple.svg';
 import googlePlayBadge from '../../assets/interactive-playground/google.png';
 import { Accordion } from '../Accordion/Accordion';
 import { Point } from '../Point/Point';
+import { track } from '../../../../analytics/analytics';
 
 declare global {
   interface Window {
     connectionChannel: number;
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
   }
 }
 
@@ -114,19 +112,19 @@ export default function Connection() {
             localStorage.setItem('hapticsToken', data.token);
             setStatus(true);
             setPaired(true);
-            window.posthog?.capture('device_connected', { connection_type: 'new' });
+            track('device_connected', { connection_type: 'new' });
           }
           break;
         case 'connection_restored':
           {
             setStatus(true);
-            window.posthog?.capture('device_connected', { connection_type: 'restored' });
+            track('device_connected', { connection_type: 'restored' });
           }
           break;
         case 'peer_disconnected':
           {
             setStatus(false);
-            window.posthog?.capture('device_disconnected');
+            track('device_disconnected');
           }
           break;
       }
@@ -152,7 +150,7 @@ export default function Connection() {
     setStatus(false);
     createChannel();
     setPaired(false);
-    window.posthog?.capture('reset_connection');
+    track('reset_connection');
   }
 
   return (

--- a/docs/src/content/docs/components/Preset/Preset.tsx
+++ b/docs/src/content/docs/components/Preset/Preset.tsx
@@ -16,18 +16,12 @@ import heartFillIcon from '../../assets/new_assets/heart-fill.svg';
 import { AudioPatternUtility } from './audio-player';
 import { API_SERVER_URL } from '../config';
 import { openInStudio } from '../studioLink';
+import { track } from '../../../../analytics/analytics';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 /** Open this preset in Pulsar Studio for editing (new tab). */
 function editInStudio(data: PatternData) {
-  window.posthog?.capture('preset_edit_in_studio', { preset_name: data.name });
+  track('preset_edit_in_studio', { preset_name: data.name });
   openInStudio(data);
 }
 
@@ -104,7 +98,7 @@ function CompactPreset({ preset, anchorId, definitionJson, handleCopy, definitio
       setIsPlaying(false);
     } else {
       setIsPlaying(true);
-      window.posthog?.capture('preset_played', { preset_name: data.name });
+      track('preset_played', { preset_name: data.name });
       const token = localStorage.getItem('hapticsToken');
       if (token) {
         fetch(`${API_SERVER_URL}/broadcast`, {
@@ -186,7 +180,7 @@ export function Preset(preset: PresetProps) {
 
   function handleUsageToggle() {
     if (!usageViewed) {
-      window.posthog?.capture('preset_code_copied', { preset_name: data.name });
+      track('preset_code_copied', { preset_name: data.name });
       setUsageViewed(true);
     }
   }

--- a/docs/src/content/docs/components/PresetsList/PresetsList.tsx
+++ b/docs/src/content/docs/components/PresetsList/PresetsList.tsx
@@ -14,18 +14,12 @@ import {
 } from '../../assets/systemPresets/SystemPresetsConfig';
 import { NoResult } from '../NoResult/NoResult';
 import { ChartModal } from '../ChartModal/ChartModal';
+import { track } from '../../../../analytics/analytics';
 
 const COMPACT_LAYOUT_KEY = 'presets_compact_layout';
 const FAVOURITES_KEY = 'presets_favourites';
 const SOUND_ENABLED_KEY = 'presets_sound_enabled';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 export function PresetsList() {
   const headerRef = useRef<HTMLDivElement>(null);
@@ -77,7 +71,7 @@ export function PresetsList() {
     const value = e.target.checked;
     setSoundEnabled(value);
     localStorage.setItem(SOUND_ENABLED_KEY, String(value));
-    window.posthog?.capture(value ? 'preset_sound_enabled' : 'preset_sound_disabled');
+    track(value ? 'preset_sound_enabled' : 'preset_sound_disabled');
   }
 
   function handleToggleFavourite(presetName: string) {
@@ -85,10 +79,10 @@ export function PresetsList() {
       const next = new Set(prev);
       if (next.has(presetName)) {
         next.delete(presetName);
-        window.posthog?.capture('preset_unfavourited', { preset_name: presetName });
+        track('preset_unfavourited', { preset_name: presetName });
       } else {
         next.add(presetName);
-        window.posthog?.capture('preset_favourited', { preset_name: presetName });
+        track('preset_favourited', { preset_name: presetName });
       }
       localStorage.setItem(FAVOURITES_KEY, JSON.stringify(Array.from(next)));
       return next;
@@ -131,8 +125,8 @@ export function PresetsList() {
     } else {
       setSelectedTags(tags);
       if (tags.length > 0) {
-        window.posthog?.capture('preset_filter_applied', {
-          selected_tags: tags,
+        track('preset_filter_applied', {
+          selected_tags: [...tags].sort().join(','),
           tag_count: tags.length,
         });
       }

--- a/docs/src/content/docs/components/VisualizationPanel/VisualizationPanel.tsx
+++ b/docs/src/content/docs/components/VisualizationPanel/VisualizationPanel.tsx
@@ -5,11 +5,7 @@ import { useState, useRef } from 'react';
 import { AudioPatternUtility } from '../Preset/audio-player';
 import type { PresetConfig } from '../Preset/types';
 import { API_SERVER_URL } from '../config';
-
-type PosthogWithException = {
-  capture: (event: string, properties?: Record<string, unknown>) => void;
-  captureException?: (error: Error) => void;
-};
+import { track, trackError } from '../../../../analytics/analytics';
 
 interface VisualizationPanelProps {
   visualization: PresetConfig;
@@ -103,10 +99,10 @@ export function VisualizationPanel({
 
       const data = await response.json();
       console.log('Broadcast response:', data);
-      window.posthog?.capture('preset_played_on_device', { preset_name: presetName });
+      track('preset_played_on_device', { preset_name: presetName });
     } catch (error) {
       console.error('Error broadcasting to device:', error);
-      (window.posthog as PosthogWithException | undefined)?.captureException?.(error as Error);
+      trackError(error);
     }
   };
 
@@ -120,7 +116,7 @@ export function VisualizationPanel({
     } else {
       setIsPlaying(true);
       handlePlayOnDevice();
-      window.posthog?.capture('preset_played', { preset_name: presetName });
+      track('preset_played', { preset_name: presetName });
       try {
         if (!isParsed.current) {
           await audioPlayer.parsePattern(visualization.data);
@@ -131,7 +127,7 @@ export function VisualizationPanel({
         }
       } catch (error) {
         console.error('Error playing audio:', error);
-        (window.posthog as PosthogWithException | undefined)?.captureException?.(error as Error);
+        trackError(error);
       }
       startAnimation();
     }

--- a/docs/src/content/docs/components/WebPreset/WebPreset.tsx
+++ b/docs/src/content/docs/components/WebPreset/WebPreset.tsx
@@ -13,14 +13,8 @@ import playIcon from '../../assets/new_assets/play.svg';
 import pauseIcon from '../../assets/new_assets/pause.svg';
 import heartIcon from '../../assets/new_assets/heart.svg';
 import heartFillIcon from '../../assets/new_assets/heart-fill.svg';
+import { track } from '../../../../analytics/analytics';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 function toAnchorId(name: string) {
   return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
@@ -60,7 +54,7 @@ function useWebPlayer(data: WebPresetConfig['data'], soundEnabled: boolean) {
       return;
     }
     setIsPlaying(true);
-    window.posthog?.capture('web_preset_played', { preset_name: data.name });
+    track('web_preset_played', { preset_name: data.name });
     try {
       const { Preset, Settings } = await import('pulsar-haptics');
       Settings.enableSound(soundEnabled);

--- a/docs/src/content/docs/components/WebPreset/WebVisualizationPanel.tsx
+++ b/docs/src/content/docs/components/WebPreset/WebVisualizationPanel.tsx
@@ -4,6 +4,7 @@ import pauseIcon from '../../assets/new_assets/pause.svg';
 import { useEffect, useRef, useState } from 'react';
 import type { HapticPattern } from 'pulsar-haptics';
 import type { WebPresetConfig } from './types';
+import { track } from '../../../../analytics/analytics';
 
 // Mirror the generator constants in web/Pulsar/scripts/generate-images.ts so the play
 // indicator lines up with the rendered bars regardless of the image's display scale.
@@ -11,13 +12,6 @@ const PX_PER_MS = 0.3;
 const PAD_X = 14;
 const RIGHT_MARGIN = 24; // keep the playhead this far inside the right edge when scrolling
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 interface Props {
   visualization: WebPresetConfig;
@@ -106,7 +100,7 @@ export function WebVisualizationPanel({ visualization, soundEnabled = true, clas
 
     setIsPlaying(true);
     startAnimation();
-    window.posthog?.capture('web_preset_played', { preset_name: data.name });
+    track('web_preset_played', { preset_name: data.name });
 
     try {
       // Loaded lazily so the haptics library never runs during SSR.

--- a/docs/src/content/docs/components/WebPresetsList/WebPresetsList.tsx
+++ b/docs/src/content/docs/components/WebPresetsList/WebPresetsList.tsx
@@ -10,18 +10,12 @@ import { TagsInfo } from '../PresetsList/Tags';
 import { WebPresetsConfig } from '../../assets/webPresets/WebPresetsConfig';
 import { NoResult } from '../NoResult/NoResult';
 import { WebChartModal } from '../WebPreset/WebChartModal';
+import { track } from '../../../../analytics/analytics';
 
 const COMPACT_LAYOUT_KEY = 'web_presets_compact_layout';
 const FAVOURITES_KEY = 'web_presets_favourites';
 const SOUND_ENABLED_KEY = 'web_presets_sound_enabled';
 
-declare global {
-  interface Window {
-    posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
-    };
-  }
-}
 
 export function WebPresetsList() {
   const headerRef = useRef<HTMLDivElement>(null);
@@ -65,7 +59,7 @@ export function WebPresetsList() {
     const value = e.target.checked;
     setSoundEnabled(value);
     localStorage.setItem(SOUND_ENABLED_KEY, String(value));
-    window.posthog?.capture(value ? 'web_preset_sound_enabled' : 'web_preset_sound_disabled');
+    track(value ? 'web_preset_sound_enabled' : 'web_preset_sound_disabled');
   }
 
   function handleToggleFavourite(presetName: string) {

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -4,6 +4,7 @@ import { TopBar } from '../components/landing/TopBar/TopBar';
 import { TopBanner } from '../components/landing/TopBanner/TopBanner';
 import { SectionHeader } from '../components/landing/SectionHeader/SectionHeader';
 import { Button } from '../components/landing/Button/Button';
+import { trackingAttributes } from '../analytics/analytics';
 import { VisitComposer } from '../components/landing/VisitComposer/VisitComposer';
 import '../styles/index.css';
 import commonStyle from '../components/landing/common.module.scss';
@@ -85,7 +86,11 @@ Presets that you can hear and feel with Live Preview." />
         subtitle="Don't spend time creating your own patterns. Just use ours and enjoy the benefits of having haptics in your app by using presets."
       />
       <PresetsList client:load />
-      <Button label="See all presets" url={`${BASE_PATH}/presets-playground/`} />
+      <Button
+        label="See all presets"
+        url={`${BASE_PATH}/presets-playground/`}
+        analytics={trackingAttributes('see_all_presets_clicked')}
+      />
       <VisitComposer client:load className={commonStyle.spaceTopMedium} />
     </BasicLayout>
 
@@ -112,14 +117,3 @@ Presets that you can hear and feel with Live Preview." />
     <SwmSection className={commonStyle.spaceTopLarge} />
   </body>
 </html>
-
-<script is:inline define:vars={{ basePath: BASE_PATH }}>
-  document.addEventListener('DOMContentLoaded', function () {
-    var seeAllBtn = document.querySelector(`a[href="${basePath}/presets-playground/"]`);
-    if (seeAllBtn) {
-      seeAllBtn.addEventListener('click', function () {
-        window.posthog?.capture('see_all_presets_clicked');
-      });
-    }
-  });
-</script>


### PR DESCRIPTION
## The problem

PostHog on this site has **never collected anything**. `posthog.astro` initialised it with `opt_out_capturing_by_default: true` behind ~150 lines that read consent from Cookiebot, CookieScript, CookieYes, OneTrust and Google Consent Mode — and no consent manager ever grants it. That includes the ~25 `posthog.capture` calls already written across the presets playground and the landing page.

Three of those calls could never have fired even with consent: `SdkSection`, `VisitPlayground` and `StudioWhyPulsar` render without a `client:` directive, so Astro ships no JS for them and their `onClick` handlers are dropped at build time. The Studio landing page had no instrumentation at all — not even on the waitlist form, which is its only conversion.

## The approach: cookieless, so no banner is needed

ePrivacy Art. 5(3) — the rule that actually requires the banner — is about *storing on, or gaining access to information stored in, terminal equipment*. It is not about analytics as such. Remove the storage and the consent trigger goes with it.

| Option | Effect |
|---|---|
| `cookieless_mode: 'always'` | No cookie, no local or session storage. Identity is a salted hash PostHog derives **server-side** from the request, rotated daily, not reversible. |
| `persistence: 'memory'` | SDK state dies with the tab. |
| `person_profiles: 'never'` | Events never accumulate against a person. |
| `autocapture: false` | Named events from a catalogue, never every DOM click and its text. |
| `property_denylist` | Drops `$screen_*`, `$viewport_*`, `$timezone*` — everything the SDK obtains by **interrogating the device** — plus `$raw_user_agent` and `$browser_language`, which the request already carried. |
| `sanitize_properties` | Every URL reduced to origin + path. |

The denylist is the sharpest line here. With it, **nothing in a payload comes from the device at all**; what remains (`$browser`, `$os`, `$device_type`, `$browser_language_prefix`, referrer host, sanitized URL) is low-cardinality buckets derived from headers the browser sends in the ordinary course of the request. "Which browsers and devices read the docs?" stays answerable; "which visitor is this?" does not.

PostHog computes the cookieless hash at ingestion as `hash(team_id, daily_salt, ip, user_agent, hostname)` — all of it server-side from the request — so the denylist cannot break identity.

Consent is not required; **transparency still is**, so both footers now say anonymous cookieless statistics are collected.

## What is measured

New `src/analytics/events.ts` is the catalogue: every event with a one-line description. `track()` accepts nothing else, so a typo is a compile error, and "what does nobody use?" is a diff of received events against `EVENT_NAMES`.

- **Site-wide** — scroll depth (25/50/75/100), `code_copied` (language only), `outbound_link_clicked` (host only), `docs_search_opened` (the act, never the query), `nav_link_clicked`.
- **Studio landing** — the full waitlist funnel (started → submitted → succeeded / failed / consent-blocked), hero CTA, hero haptic plays, demo video play and quartiles.
- **Landing / playground** — the existing events, now actually firing, including the three dead ones.

Two ways to fire, because most landing sections are not hydrated: `track()` inside islands, `trackingAttributes()` (rendering `data-ph-*`, read by a delegated listener) for static markup. Picking the wrong one is what silently killed the three events above, so it is written down in the README.

## Verification

Production build pointed at a local stub ingestion host serving PostHog's real `array.js`. Across the landing page, the Studio landing page and docs pages:

- `document.cookie` held **no PostHog key**; `localStorage` and `sessionStorage` held none either. (The only storage on the site is Starlight's theme and the playground's own settings — functional, consent-exempt.)
- Events carried `$cookieless_mode: true`, `distinct_id: "$posthog_cookieless"`, `$device_id: null`, `$process_person_profile: false`, and **no denylisted property**.
- `?utm_source=…&token=secret-value` was stripped from `$current_url`; UTM params still arrive as PostHog's own `$utm_*`, so attribution is unaffected.
- Ran the waitlist form with a stubbed `fetch` and typed values — the name and email appear in **no** event payload.

`npm run build` and `tsc --noEmit` are clean (the only `tsc` errors are pre-existing, in `audio-player.ts`, `web-app/` and `astro.config.mjs`).

## Before this ships

1. **Enable *Cookieless server hash mode*** in the PostHog project (Settings → Project). Until then PostHog **drops cookieless events at ingestion** — the client works, the dashboards stay empty.
2. **The privacy/cookie policy should name PostHog** and say the statistics are cookieless. Consent-exempt is not notice-exempt; the footer line is a stopgap, not the notice.
3. ⚠️ **Unrelated but live: GTM is setting `_ga` cookies with no consent.** I observed this in the production build, on every page, with no banner present. That *is* the Art. 5(3) problem this PR's approach avoids — but it sits in `gtm-head.astro` and is untouched here. Being handled separately; this PR neither fixes nor worsens it.

## Reviewer notes

- The diff is semantic only — no reformatting churn. Most touched files are not Prettier-clean at `HEAD` (repo-wide `format:check` fails on ~292 files), so they were deliberately left as they are apart from the lines this change needs.
- `preset_filter_applied.selected_tags` changes from an array to a sorted joined string, for a stable dashboard breakdown. That event has never fired, so there is no history to break.
- Both footers gain one sentence of visible copy.
- The standalone Pulsar Web App under `/pulsar/web-app/` is a separate bundle and reports nothing.
- Design, legal reasoning and a manual-verification recipe: `docs/src/analytics/README.md`.