### PR TITLE
feat(app): toggle the Figma preview's floating buttons from the preview header

### DIFF
--- a/PulsarApp/app/(tabs)/figma.tsx
+++ b/PulsarApp/app/(tabs)/figma.tsx
@@ -114,6 +114,23 @@ function FigmaPreviewWebView({ token }: { token: string }) {
   // never trap a tap even if it lingers.
   const [loading, setLoading] = useState(true);
 
+  // The preview's own floating buttons can cover the design underneath them.
+  const [controlsHidden, setControlsHidden] = useState(false);
+  const sendControlsVisibility = useCallback((hidden: boolean) => {
+    webRef.current?.injectJavaScript(
+      buildPreviewInjection({ type: 'pulsar-haptics-update', kind: 'preview-controls', hidden })
+    );
+  }, []);
+  const toggleControls = useCallback(() => {
+    const hidden = !controlsHidden;
+    setControlsHidden(hidden);
+    sendControlsVisibility(hidden);
+  }, [controlsHidden, sendControlsVisibility]);
+
+  const reapplyControlsVisibility = useCallback(() => {
+    if (controlsHidden) sendControlsVisibility(true);
+  }, [controlsHidden, sendControlsVisibility]);
+
   const [webViewGeneration, setWebViewGeneration] = useState(0);
   const [gaveUpRestarting, setGaveUpRestarting] = useState(false);
   const restartTimesRef = useRef<number[]>([]);
@@ -123,6 +140,7 @@ function FigmaPreviewWebView({ token }: { token: string }) {
     setLoading(true);
     // The replacement page starts with its nav-bar toggle off.
     setTabBarHidden(false);
+    setControlsHidden(false);
     setResumeFrame(lastFocusedFrameRef.current ?? '');
     embedMountsRef.current = 0;
     setWebViewGeneration((generation) => generation + 1);
@@ -235,16 +253,34 @@ function FigmaPreviewWebView({ token }: { token: string }) {
               Close preview
             </ThemedText>
           </TouchableOpacity>
-          {/* Figma's embed can report itself loaded and still paint nothing,
-              which the page cannot detect across origins. */}
-          <TouchableOpacity
-            onPress={remountWebView}
-            style={styles.closeBtn}
-            hitSlop={8}
-            accessibilityLabel="Reload preview"
-          >
-            <Icon name="refresh-cw" size={18} color="#001A72" />
-          </TouchableOpacity>
+          <View style={styles.previewBarActions}>
+            <TouchableOpacity
+              onPress={toggleControls}
+              style={styles.closeBtn}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityState={{ selected: controlsHidden }}
+              accessibilityLabel={
+                controlsHidden ? 'Show preview buttons' : 'Hide preview buttons'
+              }
+            >
+              <Icon
+                name="sliders"
+                size={18}
+                color={controlsHidden ? '#8EA0C4' : '#001A72'}
+              />
+            </TouchableOpacity>
+            {/* Figma's embed can report itself loaded and still paint nothing,
+                which the page cannot detect across origins. */}
+            <TouchableOpacity
+              onPress={remountWebView}
+              style={styles.closeBtn}
+              hitSlop={8}
+              accessibilityLabel="Reload preview"
+            >
+              <Icon name="refresh-cw" size={18} color="#001A72" />
+            </TouchableOpacity>
+          </View>
         </View>
       )}
       <View style={styles.webContainer}>
@@ -270,7 +306,10 @@ function FigmaPreviewWebView({ token }: { token: string }) {
             javaScriptEnabled
             domStorageEnabled
             onMessage={onMessage}
-            onLoadEnd={() => setLoading(false)}
+            onLoadEnd={() => {
+              setLoading(false);
+              reapplyControlsVisibility();
+            }}
             onContentProcessDidTerminate={onRendererGone}
             onRenderProcessGone={onRendererGone}
             style={styles.webview}
@@ -395,6 +434,11 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: '#E1F3FA',
     backgroundColor: '#fff',
+  },
+  previewBarActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
   },
   closeBtn: {
     flexDirection: 'row',


### PR DESCRIPTION
## Why

The Figma live preview draws its own floating controls on top of the design — reload, hide-tab-bar, and (new, in the companion preview PR) the **screen picker** that finally exposes the "screens with haptics" list on mobile. They're fixed overlays, so on some frames they land right on the element the viewer wants to tap.

The preview side gained a grip that walks the cluster between corners; this is the other half of the answer — take them off screen entirely, without leaving the preview.

## What changed

A toggle in the preview header (next to Close / Reload) injects the preview's new `preview-controls` update:

```js
buildPreviewInjection({ type: 'pulsar-haptics-update', kind: 'preview-controls', hidden })
```

which hides the whole dock plus the screen-name pill, and restores them on the next press. The icon dims while they're hidden, and the accessibility label flips between "Hide preview buttons" / "Show preview buttons".

Two bits of state hygiene:

- a replacement WebView (renderer restart) starts with the controls shown, so the toggle resets with it;
- a navigation inside the preview loads a fresh document with its controls back, so `onLoadEnd` re-asserts the toggle when we're holding it hidden.

## Companion PR

Preview side: software-mansion-labs/pulsar-private#148 — the screen picker, the movable dock, and the `preview-controls` handler this injects. **That one has to ship first**; until it's deployed this toggle is a no-op.

## Verification

Typecheck and lint on `app/(tabs)/figma.tsx` are clean (no new findings against the file's pre-existing three). The injection path itself is the one already used for live haptics-diff relays, and I verified the receiving end in the preview app against a stubbed payload: posting the envelope hides the dock and the screen pill, posting it again brings them back. Not yet exercised on a device build — it needs the deployed preview to answer.