### PR TITLE
chore(app): refresh PulsarApp lockfile after lottie package rename

### DIFF
--- a/PulsarApp/package-lock.json
+++ b/PulsarApp/package-lock.json
@@ -59,32 +59,6 @@
         "typescript": "~6.0.3"
       }
     },
-    "../react-native/react-native-pulsar-lottie": {
-      "name": "react-native-pulsar-lottie",
-      "version": "0.1.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/react": "^19.2.0",
-        "del-cli": "^6.0.0",
-        "lottie-react-native": "~7.3.8",
-        "prettier": "^3.6.2",
-        "react": "19.2.3",
-        "react-native": "0.86.3",
-        "react-native-builder-bob": "^0.40.13",
-        "react-native-pulsar": "^1.6.1",
-        "react-native-reanimated": "4.5.1",
-        "react-native-worklets": "0.10.1",
-        "typescript": "^5.9.2"
-      },
-      "peerDependencies": {
-        "lottie-react-native": ">=7.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-pulsar": ">=1.6.0",
-        "react-native-reanimated": ">=4.0.0",
-        "react-native-worklets": "*"
-      }
-    },
     "../react-native/react-native-pulsar": {
       "version": "1.7.0",
       "license": "MIT",
@@ -123,6 +97,31 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
+        "react-native-worklets": "*"
+      }
+    },
+    "../react-native/react-native-pulsar-lottie": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/react": "^19.2.0",
+        "del-cli": "^6.0.0",
+        "lottie-react-native": "~7.3.8",
+        "prettier": "^3.6.2",
+        "react": "19.2.3",
+        "react-native": "0.86.3",
+        "react-native-builder-bob": "^0.40.13",
+        "react-native-pulsar": "^1.6.1",
+        "react-native-reanimated": "4.5.1",
+        "react-native-worklets": "0.10.1",
+        "typescript": "^5.9.2"
+      },
+      "peerDependencies": {
+        "lottie-react-native": ">=7.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-pulsar": ">=1.6.0",
+        "react-native-reanimated": ">=4.0.0",
         "react-native-worklets": "*"
       }
     },


### PR DESCRIPTION
## Summary

The `PulsarLottie` → `react-native-pulsar-lottie` directory rename (#261) left `PulsarApp/package-lock.json` stale: the linked-package entry was still keyed under the old sort position and carried a redundant `"name"` field. This commits the regenerated lockfile so a fresh `npm install` in `PulsarApp` no longer leaves a dirty working tree.

No dependency versions change — only the entry's position and the dropped `name` key.

## Test plan

- [x] `npm install` in `PulsarApp` produces no further lockfile diff