### PR TITLE
fix(android): unblock the PulsarLottie Maven Central publish

### DIFF
--- a/Android/Pulsar/build.gradle.kts
+++ b/Android/Pulsar/build.gradle.kts
@@ -3,7 +3,7 @@ import java.util.Base64
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21"
+    alias(libs.plugins.kotlin.serialization)
     `maven-publish`
     signing
     alias(libs.plugins.nmcp)

--- a/Android/PulsarApp/build.gradle.kts
+++ b/Android/PulsarApp/build.gradle.kts
@@ -4,4 +4,9 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
+    // Declared here (unapplied) so :Pulsar and :PulsarLottie resolve them from the same
+    // buildscript classloader; otherwise nmcp's shared build service is loaded twice and
+    // the second module's publish task fails to resolve it.
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.nmcp) apply false
 }

--- a/Android/PulsarApp/gradle/libs.versions.toml
+++ b/Android/PulsarApp/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ lottie = { group = "com.airbnb.android", name = "lottie", version.ref = "lottie"
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 nmcp = { id = "com.gradleup.nmcp", version.ref = "nmcp" }
 


### PR DESCRIPTION
## What

`publish-android-lottie.yml` fails at the **Publish to Maven Central** step ([run 33970942142](https://github.com/software-mansion/pulsar/actions/runs/33970942142/job/101319222657)):

```
A problem was found with the configuration of task ':PulsarLottie:cleanupDirectory' (type 'CleanupDirectoryTask').
  - In plugin 'nmcp.internal.DefaultNmcpExtensionPlugin_Decorated' type 'nmcp.internal.task.CleanupDirectoryTask'
    property 'gratatouilleBuildService' doesn't have a configured value.
```

## Why it happened

The failure is in the `nmcp` publish plugin, not in our sources.

nmcp's tasks receive that build service through `@ServiceReference("gratatouille2")`, which Gradle auto-injects by matching **name *and* type**. Gradle keys buildscript classloaders by the *set of plugins a project declares*, and the two published modules declared different sets:

- `Android/Pulsar` also declared `org.jetbrains.kotlin.plugin.serialization`
- `Android/PulsarLottie` did not

So each module loaded its **own** `gratatouille.GratatouilleBuildService` class. `:Pulsar` is configured first and wins `registerIfAbsent("gratatouille2")`; `:PulsarLottie` then finds a registration whose type its own classloader rejects, the property is left unset, and the task fails validation. Upstream: [gradle/gradle#17559](https://github.com/gradle/gradle/issues/17559).

This also explains why `publish-android-library.yml` kept going green — `:Pulsar` happens to be the module that registers first, and PulsarLottie only landed the day after that workflow's last successful run.

## The fix

Declare the differing plugins in the root build with `apply false`, so they live on the shared root classpath and every subproject resolves them from one classloader:

- `Android/PulsarApp/build.gradle.kts` — add `kotlin.serialization` and `nmcp`, both `apply false`
- `Android/PulsarApp/gradle/libs.versions.toml` — add the `kotlin-serialization` plugin alias
- `Android/Pulsar/build.gradle.kts` — use that alias instead of an inline `version "2.0.21"` (same version, taken from the existing `kotlin` version ref)

## Verification

A probe init script reading the task's service property, before and after:

| | `:Pulsar:cleanupDirectory` | `:PulsarLottie:cleanupDirectory` |
|---|---|---|
| before | `servicePresent=true` | `servicePresent=false` |
| after | `servicePresent=true` | `servicePresent=true` |

Before the fix the two modules resolved distinct service classes (identity `158667252` vs `994276716`); after, both share one classloader and one class.

Builds run locally and pass: `:PulsarLottie:build`, `:Pulsar:assembleRelease`, `:app:assembleDebug`.

## For the reviewer

I did **not** run `nmcpPublishAllPublicationsToCentralPortal` locally — it uploads to Maven Central. The remaining confirmation is dispatching `publish-android-lottie.yml` once this is on `main`.

Unrelated, left alone: `.gitignore` only covers `kmp/**/.kotlin/`, but `tools/pulsar-gen-gradle/` also generates a `.kotlin/errors/` directory. A broader `**/.kotlin/` rule would prevent it from being committed by accident.