### PR TITLE
fix(docs): remove the redirect and 404 links Search Console flags

### DIFF
--- a/Android/Pulsar/README.md
+++ b/Android/Pulsar/README.md
@@ -108,10 +108,10 @@ realtime.stop()
 
 ## Documentation
 
-Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar).
+Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar/).
 
-- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview) - Core concepts: types of haptics, preloading, and caching
-- [Android SDK](https://docs.swmansion.com/pulsar/sdk/android) - Kotlin API reference
+- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview/) - Core concepts: types of haptics, preloading, and caching
+- [Android SDK](https://docs.swmansion.com/pulsar/sdk/android/) - Kotlin API reference
 
 ## AI Skills
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ A haptic feedback SDK for iOS, Android, React Native, Kotlin Multiplatform, Flut
 
 | Platform | Package | Documentation |
 |----------|---------|---------------|
-| React Native | [![npm](https://img.shields.io/npm/v/react-native-pulsar)](https://www.npmjs.com/package/react-native-pulsar) | [React Native SDK](https://docs.swmansion.com/pulsar/sdk/react-native) |
-| iOS | [![Swift Package](https://img.shields.io/github/v/release/software-mansion-labs/pulsar-ios?label=swift%20package)](https://github.com/software-mansion-labs/pulsar-ios) | [iOS SDK](https://docs.swmansion.com/pulsar/sdk/ios) |
-| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion/pulsar)](https://central.sonatype.com/artifact/com.swmansion/pulsar) | [Android SDK](https://docs.swmansion.com/pulsar/sdk/android) |
-| Kotlin Multiplatform | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion/pulsar-kmp)](https://central.sonatype.com/artifact/com.swmansion/pulsar-kmp) | [Kotlin Multiplatform SDK](https://docs.swmansion.com/pulsar/sdk/kmp) |
-| Flutter | [![pub.dev](https://img.shields.io/pub/v/pulsar_haptics)](https://pub.dev/packages/pulsar_haptics) | [Flutter SDK](https://docs.swmansion.com/pulsar/sdk/flutter) |
+| React Native | [![npm](https://img.shields.io/npm/v/react-native-pulsar)](https://www.npmjs.com/package/react-native-pulsar) | [React Native SDK](https://docs.swmansion.com/pulsar/sdk/react-native/) |
+| iOS | [![Swift Package](https://img.shields.io/github/v/release/software-mansion-labs/pulsar-ios?label=swift%20package)](https://github.com/software-mansion-labs/pulsar-ios) | [iOS SDK](https://docs.swmansion.com/pulsar/sdk/ios/) |
+| Android | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion/pulsar)](https://central.sonatype.com/artifact/com.swmansion/pulsar) | [Android SDK](https://docs.swmansion.com/pulsar/sdk/android/) |
+| Kotlin Multiplatform | [![Maven Central](https://img.shields.io/maven-central/v/com.swmansion/pulsar-kmp)](https://central.sonatype.com/artifact/com.swmansion/pulsar-kmp) | [Kotlin Multiplatform SDK](https://docs.swmansion.com/pulsar/sdk/kmp/) |
+| Flutter | [![pub.dev](https://img.shields.io/pub/v/pulsar_haptics)](https://pub.dev/packages/pulsar_haptics) | [Flutter SDK](https://docs.swmansion.com/pulsar/sdk/flutter/) |
 | Web | [![npm](https://img.shields.io/npm/v/pulsar-haptics)](https://www.npmjs.com/package/pulsar-haptics) | [Web SDK](https://docs.swmansion.com/pulsar/sdk/web/) |
 
-Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar). Start with the [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview) for core concepts: types of haptics, preloading, and caching.
+Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar/). Start with the [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview/) for core concepts: types of haptics, preloading, and caching.
 
 ## Quick start
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -191,6 +191,10 @@ export default defineConfig({
       // deployment that actually serves the preview — keep it out of the
       // sitemap so we don't invite Google to index a bounce page.
       filter: (page) => !page.includes('/figma-preview'),
+      // The web app is a standalone Vite bundle emitted into public/web-app/,
+      // so it never passes through Astro's page pipeline and the integration
+      // cannot discover it. It is a real, linked destination — list it here.
+      customPages: ['https://docs.swmansion.com/pulsar/web-app/'],
     }),
   ],
 });

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -318,7 +318,7 @@ await presets.play('hammer');
 await presets.play('dogBark');
 ```
 
-For per-preset descriptions, see the [iOS](/sdk/ios) and [Android](/sdk/android) reference pages — the underlying patterns are shared.
+For per-preset descriptions, see the [iOS](/pulsar/sdk/ios/) and [Android](/pulsar/sdk/android/) reference pages — the underlying patterns are shared.
 
 ### Preloading and caching
 

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -309,7 +309,7 @@ presets.play("Hammer")
 presets.play("DogBark")
 ```
 
-For per-preset descriptions, see the [iOS](/sdk/ios) and [Android](/sdk/android) reference pages — the underlying patterns are shared.
+For per-preset descriptions, see the [iOS](/pulsar/sdk/ios/) and [Android](/pulsar/sdk/android/) reference pages — the underlying patterns are shared.
 
 ### Preloading and caching
 

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Core concepts behind the Pulsar haptics SDK.
 ---
 
-This page covers concepts that apply across all Pulsar SDKs: types of haptics, preloading, and caching. Read this page before the platform-specific guides for [iOS](/sdk/ios), [Android](/sdk/android), [React Native](/sdk/react-native), [Kotlin Multiplatform](/sdk/kmp), [Flutter](/sdk/flutter), or [Web](/sdk/web).
+This page covers concepts that apply across all Pulsar SDKs: types of haptics, preloading, and caching. Read this page before the platform-specific guides for [iOS](/pulsar/sdk/ios/), [Android](/pulsar/sdk/android/), [React Native](/pulsar/sdk/react-native/), [Kotlin Multiplatform](/pulsar/sdk/kmp/), [Flutter](/pulsar/sdk/flutter/), or [Web](/pulsar/sdk/web/).
 
 {/* GENERATED:SDK_OVERVIEW_VERSIONS_START */}
 ## Latest available version

--- a/docs/src/content/docs/sdk/web.mdx
+++ b/docs/src/content/docs/sdk/web.mdx
@@ -179,7 +179,7 @@ Every preset method returns a `Promise<PresetPlaybackResult>` describing whether
   code
 />
 
-Want to hear and feel every preset? Browse the full gallery on the [Web preset playground](/web-presets-playground).
+Want to hear and feel every preset? Browse the full gallery on the [Web preset playground](/pulsar/web-presets-playground/).
 
 ---
 
@@ -392,7 +392,7 @@ if (!pulsar.isHapticsSupported()) {
 
 `navigator.vibrate` is required for real haptic output and is available in **Chrome, Edge, Firefox, and Chromium-based mobile browsers**. Use `pulsar.isHapticsSupported()` (or `useHapticsSupport()` in React) to feature-detect at runtime.
 
-Where the Vibration API is missing - most notably **Safari on iOS and iPadOS**, where Apple does not implement it (see the note at the top of this page), and on desktop browsers with no vibration motor - Pulsar can play an **audio simulation** of the pattern instead. Enable it with `pulsar.enableSound(true)` so users can still hear the shape of a haptic. For real haptics on Apple hardware, reach for the native [iOS](/sdk/ios) or [React Native](/sdk/react-native) SDKs.
+Where the Vibration API is missing - most notably **Safari on iOS and iPadOS**, where Apple does not implement it (see the note at the top of this page), and on desktop browsers with no vibration motor - Pulsar can play an **audio simulation** of the pattern instead. Enable it with `pulsar.enableSound(true)` so users can still hear the shape of a haptic. For real haptics on Apple hardware, reach for the native [iOS](/pulsar/sdk/ios/) or [React Native](/pulsar/sdk/react-native/) SDKs.
 
 ---
 

--- a/docs/web-app/index.html
+++ b/docs/web-app/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="A web clone of the Pulsar mobile app. Browse haptic presets, record your own patterns in the playground and feel real-world haptic demos — straight in the browser."
     />
+    <link rel="canonical" href="https://docs.swmansion.com/pulsar/web-app/" />
     <link rel="icon" type="image/svg+xml" href="/pulsar/logo.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/flutter/pulsar/README.md
+++ b/flutter/pulsar/README.md
@@ -128,10 +128,10 @@ await haptics.play();
 
 ## Documentation
 
-Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar).
+Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar/).
 
-- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview) – Core concepts: types of haptics, preloading, and caching
-- [Flutter SDK](https://docs.swmansion.com/pulsar/sdk/flutter) – Dart API reference
+- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview/) – Core concepts: types of haptics, preloading, and caching
+- [Flutter SDK](https://docs.swmansion.com/pulsar/sdk/flutter/) – Dart API reference
 
 ## Try the Pulsar App
 

--- a/iOS/Pulsar/README.md
+++ b/iOS/Pulsar/README.md
@@ -116,10 +116,10 @@ realtime.stop()
 
 ## Documentation
 
-Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar).
+Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar/).
 
-- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview) - Core concepts: types of haptics, preloading, and caching
-- [iOS SDK](https://docs.swmansion.com/pulsar/sdk/ios) - Swift API reference
+- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview/) - Core concepts: types of haptics, preloading, and caching
+- [iOS SDK](https://docs.swmansion.com/pulsar/sdk/ios/) - Swift API reference
 
 ## AI Skills
 

--- a/react-native/react-native-pulsar/README.md
+++ b/react-native/react-native-pulsar/README.md
@@ -77,10 +77,10 @@ stop();
 
 ## Documentation
 
-Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar).
+Full API reference and guides are available at the [documentation site](https://docs.swmansion.com/pulsar/).
 
-- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview) - Core concepts: types of haptics, preloading, and caching
-- [React Native SDK](https://docs.swmansion.com/pulsar/sdk/react-native) - TypeScript API reference
+- [SDK Overview](https://docs.swmansion.com/pulsar/sdk/overview/) - Core concepts: types of haptics, preloading, and caching
+- [React Native SDK](https://docs.swmansion.com/pulsar/sdk/react-native/) - TypeScript API reference
 
 <!-- ## AI Skills
 


### PR DESCRIPTION
## Why

The Page Indexing report for `docs.swmansion.com/pulsar` (2026-09-04) shows **13 not-indexed pages against 16 indexed**:

| Reason | Pages |
|---|---|
| Page with redirect | **7** |
| Alternate page with proper canonical tag | 2 |
| Crawled – currently not indexed | 2 |
| Excluded by `noindex` | 1 |
| Not found (404) | 1 |

The largest bucket maps **exactly** onto the seven docs URLs our READMEs link to without a trailing slash. The site sets `trailingSlash: 'always'`, so every one of them 301s:

```
/pulsar                    301 -> /pulsar/
/pulsar/sdk/overview       301 -> /pulsar/sdk/overview/
/pulsar/sdk/ios            301 -> /pulsar/sdk/ios/
/pulsar/sdk/android        301 -> /pulsar/sdk/android/
/pulsar/sdk/react-native   301 -> /pulsar/sdk/react-native/
/pulsar/sdk/kmp            301 -> /pulsar/sdk/kmp/
/pulsar/sdk/flutter        301 -> /pulsar/sdk/flutter/
```

Those READMEs are mirrored to npm, Maven Central, pub.dev and GitHub, which makes them the highest-authority inbound links we control — and each one lands Google on a redirect instead of the page.

## What changed

**1. Trailing slashes in all five READMEs** (root, React Native, iOS, Flutter, Android) — clears the 7-page redirect bucket at its source.

**2. Six SDK doc pages linked off-site.** `overview`, `kmp`, `flutter` and `web` linked to `/sdk/<platform>` and `/web-presets-playground` **without the `/pulsar` base**. These are not redirects — they are live 404s pointing off the Pulsar site entirely:

```
https://docs.swmansion.com/sdk/ios   404
```

`/sdk/ios` has been 404ing for every reader who clicked it from the SDK overview. Now `/pulsar/sdk/ios/`.

**3. `/pulsar/web-app/` had nothing anchoring it.** It is a standalone Vite bundle emitted into `public/`, so it never passes through Astro's page pipeline: no canonical, and `@astrojs/sitemap` could not discover it. It is linked from the sidebar, so Google crawls a client-rendered page with an empty `<div id="root">` and no canonical — the shape that lands in "Crawled – currently not indexed". Added the canonical and listed it via `customPages`.

## Verification

Against a real `npm run build`:

- Sitemap now carries **19 URLs** including `https://docs.swmansion.com/pulsar/web-app/`
- `<link rel="canonical" href="https://docs.swmansion.com/pulsar/web-app/" />` present in `dist/web-app/index.html`
- **All 623 distinct internal links in `dist` resolve to a real file** — no base-less links remain
- `prettier --check` output on the touched files is byte-identical before and after (the 4 pre-existing `.mdx` warnings are untouched)

## Notes / not addressed

The GSC export only carries aggregate counts per reason, not the URL list, so the remaining small buckets are inferred rather than confirmed:

- **Excluded by `noindex` (1)** is `/pulsar/figma-preview/` — intentional, already excluded from the sitemap.
- **Alternate page with proper canonical (2)** is most likely `/pulsar/index.html` and the `/pulsar/pulsar-studio/` redirect stub. Both already carry a correct canonical, so this bucket is working as designed, not a defect.
- `/pulsar/figma/` is in the sitemap but has no internal links — its sidebar entry is deliberately commented out because the page is a deep-link target for the Figma plugin annotation. Left as-is; worth a follow-up if it stays unindexed.
