### PR TITLE
fix(docs): link Pulsar's own terms and privacy policy from the footer

### DIFF
--- a/docs/src/components/landing/SwmSection/SwmSection.tsx
+++ b/docs/src/components/landing/SwmSection/SwmSection.tsx
@@ -39,12 +39,20 @@ export function SwmSection({ className }: { className?: string }) {
             <a href="https://swmansion.com/" target="_blank" rel="noopener">
               Software Mansion
             </a>
-            . Read about our{' '}
-            <a href="https://swmansion.com/privacy/policy/ " target="_blank" rel="noopener">
+            . Read the Pulsar{' '}
+            <a href="https://pulsar.swmansion.com/terms/" target="_blank" rel="noopener">
+              Terms of Use
+            </a>{' '}
+            and{' '}
+            <a href="https://pulsar.swmansion.com/privacy/" target="_blank" rel="noopener">
               Privacy Policy
             </a>
-            . We collect anonymous, cookieless usage statistics — no cookies, no tracking
-            across sites.
+            , or Software Mansion&rsquo;s{' '}
+            <a href="https://swmansion.com/privacy/policy/" target="_blank" rel="noopener">
+              company privacy policy
+            </a>
+            . We collect anonymous, cookieless usage statistics — no cookies, no tracking across
+            sites.
           </p>
         </div>
       </BasicLayout>


### PR DESCRIPTION
The landing footer offered a single legal link, to Software Mansion's company privacy policy. Pulsar now has its own **Terms of Use** and **Privacy Policy** — covering Studio, the Figma plugin, the live preview, the mobile app and this site — and both consumer and data protection law want them reachable from the page that markets the product, not only from inside the app.

`SwmSection` is shared by `/` and `/studio/`, so one edit covers both marketing pages.

## What changed

Before:

> © 2026 Software Mansion. Read about our **Privacy Policy**. We collect anonymous, cookieless usage statistics — no cookies, no tracking across sites.

After:

> © 2026 Software Mansion. Read the Pulsar **Terms of Use** and **Privacy Policy**, or Software Mansion's **company privacy policy**. We collect anonymous, cookieless usage statistics — no cookies, no tracking across sites.

The company policy stays — it still governs Software Mansion as the controller — but the Pulsar pair leads, because those are the documents that describe this product.

Also drops a stray trailing space inside the existing href (`"https://swmansion.com/privacy/policy/ "`), which some clients carried into the request.

## Merge ordering — worth reading

**This depends on the Studio deploy that publishes `/terms/`.** Until that ships, the path falls through nginx's SPA rewrite:

```
$ curl -s https://pulsar.swmansion.com/terms/ | grep -o '<title>[^<]*</title>'
<title>Pulsar Studio</title>          # same as any unmatched path — a blank page
$ curl -s https://pulsar.swmansion.com/privacy/ | grep -o '<title>[^<]*</title>'
<title>Privacy Policy — Pulsar</title>
```

It answers **200**, so a link checker will not flag it. `/privacy/` is already live and unaffected.

## Notes

- No styling changes — the existing `.footerText` rules already handle the extra links, and the footer stays a single quiet line.
- `prettier --check` passes.
