### PR TITLE
docs(lottie): add the Pulsar Lottie SDK section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -123,6 +123,18 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Figma Plugin',
+          items: [
+            { label: 'Overview', slug: 'figma-plugin' },
+            { label: 'The preset library', slug: 'figma-plugin/presets' },
+            { label: 'Binding haptics', slug: 'figma-plugin/binding' },
+            { label: 'Live preview on a phone', slug: 'figma-plugin/live-preview' },
+            { label: 'Sharing & handoff', slug: 'figma-plugin/sharing' },
+            { label: 'Your own patterns', slug: 'figma-plugin/studio-patterns' },
+            { label: 'Account & settings', slug: 'figma-plugin/settings' },
+          ],
+        },
+        {
           label: 'Pulsar Studio',
           link: 'https://docs.swmansion.com/pulsar/studio/',
         },
@@ -143,6 +155,17 @@ export default defineConfig({
             { label: 'React Native', slug: 'sdk/react-native' },
             { label: 'Kotlin Multiplatform', slug: 'sdk/kmp' },
             { label: 'Flutter', slug: 'sdk/flutter' },
+          ],
+        },
+        {
+          label: 'Pulsar Lottie SDK',
+          items: [
+            { label: 'Overview', slug: 'lottie/overview' },
+            { label: 'iOS', slug: 'lottie/ios' },
+            { label: 'Android', slug: 'lottie/android' },
+            { label: 'React Native', slug: 'lottie/react-native' },
+            { label: 'Kotlin Multiplatform', slug: 'lottie/kmp' },
+            { label: 'Flutter', slug: 'lottie/flutter' },
           ],
         },
         {

--- a/docs/src/content/docs/lottie/android.mdx
+++ b/docs/src/content/docs/lottie/android.mdx
@@ -1,0 +1,277 @@
+---
+title: Android
+description: Play Pulsar haptics in sync with a Lottie animation on Android, with a drop-in LottieAnimationView subclass and a controller.
+head:
+  - tag: title
+    content: "Android Lottie Haptics: Sync Vibration to Animations | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK for Android - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "A LottieAnimationView subclass and a controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK for Android - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "A LottieAnimationView subclass and a controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`pulsar-lottie` plays a Pulsar haptic pattern locked to a Lottie animation on Android. It exposes two entry points: `HapticLottieView`, a drop-in `LottieAnimationView` subclass, and `HapticLottieController`, which attaches to a `LottieAnimationView` you already have.
+
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+
+## Requirements
+
+- Android API 24+ (Android 7.0)
+- Kotlin 1.9+, Java 11
+- [`com.airbnb.android:lottie`](https://github.com/airbnb/lottie-android)
+- The [Pulsar Android SDK](/pulsar/sdk/android/) (`com.swmansion:pulsar`), pulled in automatically
+
+## Installation
+
+{/* GENERATED:ANDROID_LOTTIE_VERSION_START */}
+Latest available version: `0.1.0`
+{/* GENERATED:ANDROID_LOTTIE_VERSION_END */}
+
+Add the dependency alongside Lottie itself:
+
+{/* GENERATED:ANDROID_LOTTIE_INSTALL_SNIPPET_START */}
+```kotlin
+dependencies {
+  implementation("com.swmansion:pulsar-lottie:0.1.0")
+}
+```
+{/* GENERATED:ANDROID_LOTTIE_INSTALL_SNIPPET_END */}
+
+```kotlin
+dependencies {
+  implementation("com.airbnb.android:lottie:6.6.0")
+}
+```
+
+The Pulsar core is exposed transitively, so `com.swmansion:pulsar` needs no separate entry — its `PatternData` types are part of this library's public API. Lottie is **not** exposed transitively: declare it yourself, since your code touches `LottieAnimationView` directly.
+
+Declare the vibration permission in your app's `AndroidManifest.xml`:
+
+```xml
+<manifest ...>
+  <uses-permission android:name="android.permission.VIBRATE" />
+
+  <application ...>
+    ...
+  </application>
+</manifest>
+```
+
+Without `android.permission.VIBRATE`, Android blocks vibration playback. Pulsar logs a warning and skips the vibration instead of crashing.
+
+---
+
+## HapticLottieView
+
+A `LottieAnimationView` subclass that plays haptics in sync. With no haptics set it behaves exactly like `LottieAnimationView`, so it is safe to swap in.
+
+```kotlin
+import com.swmansion.pulsar.Pulsar
+import com.swmansion.pulsar.lottie.HapticLottieView
+import com.swmansion.pulsar.types.ContinuousPattern
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.PatternData
+import com.swmansion.pulsar.types.ValuePoint
+
+val pattern = PatternData(
+  continuousPattern = ContinuousPattern(
+    amplitude = listOf(
+      ValuePoint(time = 0, value = 0f),
+      ValuePoint(time = 400, value = 1f),
+      ValuePoint(time = 800, value = 0f),
+    ),
+    frequency = listOf(
+      ValuePoint(time = 0, value = 0.3f),
+      ValuePoint(time = 800, value = 0.8f),
+    ),
+  ),
+  discretePattern = listOf(
+    ConfigPoint(time = 0, amplitude = 1f, frequency = 0.5f),
+  ),
+)
+
+val view = HapticLottieView(context).apply {
+  setAnimation(R.raw.success)
+  repeatCount = 0
+}
+val controller = view.setHaptics(pulsar, pattern)
+controller.play()
+```
+
+In XML it is used exactly like `LottieAnimationView`:
+
+```xml
+<com.swmansion.pulsar.lottie.HapticLottieView
+    android:id="@+id/success"
+    android:layout_width="200dp"
+    android:layout_height="200dp"
+    app:lottie_rawRes="@raw/success" />
+```
+
+### Methods
+
+| Method | Description |
+| --- | --- |
+| `setHaptics(pulsar, haptics, mode, offsetMs, enabled)` | Attach a pattern and return the [`HapticLottieController`](#hapticlottiecontroller) that steers animation and haptics. Releases any previously attached controller. |
+| `hapticController()` | The current controller, or `null` before `setHaptics` is called. |
+
+Every `LottieAnimationView` member — `setAnimation`, `progress`, `repeatCount`, `playAnimation` and the rest — is still available. Drive playback through the returned controller so the haptics stay in step.
+
+### From Compose
+
+Wrap the view with `AndroidView` and keep the controller across recompositions:
+
+```kotlin
+@Composable
+fun SuccessBadge(pulsar: Pulsar, pattern: PatternData) {
+  val controller = remember { arrayOfNulls<HapticLottieController>(1) }
+
+  AndroidView(
+    modifier = Modifier.size(220.dp),
+    factory = { ctx ->
+      HapticLottieView(ctx).apply {
+        setAnimation(R.raw.success)
+        repeatCount = 0
+        controller[0] = setHaptics(pulsar, pattern).also { it.play() }
+      }
+    },
+  )
+
+  DisposableEffect(Unit) {
+    onDispose { controller[0]?.release() }
+  }
+}
+```
+
+---
+
+## HapticLottieController
+
+Attaches haptics to a `LottieAnimationView` without swapping the view, and becomes the transport for both.
+
+```kotlin
+import com.swmansion.pulsar.lottie.bindHaptics
+
+val controller = animationView.bindHaptics(pulsar, pattern)
+
+controller.play()
+controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
+controller.pause()
+controller.release()          // when the view goes away
+```
+
+`bindHaptics` is an extension on `LottieAnimationView` and a convenience over the constructor. Construct the controller directly when the pattern is optional:
+
+```kotlin
+val controller = HapticLottieController(
+  lottieView = animationView,
+  pulsar = pulsar,
+  haptics = pattern,          // optional — null plays the animation alone
+  mode = HapticMode.REALTIME,
+  offsetMs = 0L,
+  enabled = true,
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `lottieView` | `LottieAnimationView` | – | The view to drive. |
+| `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. `null` leaves the animation without haptics. |
+| `mode` | `HapticMode` | `REALTIME` | Engine mode — see [Engine modes](#engine-modes). |
+| `offsetMs` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `enabled` | `Boolean` | `true` | When `false`, the animation plays and no haptics are emitted. |
+
+In `PATTERN` mode the pattern is parsed in the constructor, so the engine is warm and the first `play()` fires without the usual first-play latency.
+
+### Transport
+
+| Method | Description |
+| --- | --- |
+| `play()` | Rewind to the start and play animation and haptics together. |
+| `pause()` | Pause both. In `PATTERN` mode the haptic stops rather than suspending. |
+| `resume()` | Resume from the current position. |
+| `stop()` | Cancel the animation, rewind to the start, stop the haptics. |
+| `reset()` | Alias of `stop()`. |
+| `setTimestamp(ms: Long)` | Seek both animation and haptics to `ms` from the start. |
+| `setLoop(loop: Boolean, count: Int, reverse: Boolean)` | Loop the animation. `count` defaults to `LottieDrawable.INFINITE`; `reverse` plays a boomerang. |
+| `release()` | Detach the animator listener and stop the haptics. |
+
+<Aside type="caution" title="Always release">
+  `release()` removes the animator update listener the controller installed on the view and stops any running haptics. Call it from `onDestroyView`, `onDispose`, or wherever the view's lifetime ends — a controller left attached keeps sampling while the view animates.
+</Aside>
+
+### Duration
+
+The controller reads the composition duration from `addLottieOnCompositionLoadedListener`, so it is exact as soon as the animation has loaded. Until then it falls back to the pattern's own length. `setTimestamp(ms)` before the composition loads therefore maps against the pattern length rather than the animation's — seek after the animation is ready.
+
+---
+
+## Engine modes
+
+```kotlin
+enum class HapticMode { REALTIME, PATTERN }
+```
+
+- **`REALTIME`** (default) — the controller listens to the view's own animator, converts each update to milliseconds and samples the pattern into `RealtimeComposer.set` and `playDiscrete`. Honours pause, seek and loop. Because Android re-drives the vibrator every frame, continuous fidelity is coarser here than on iOS.
+- **`PATTERN`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
+
+Passing `REALTIME` without a pattern falls back to the pattern-mode path, because there is nothing to sample.
+
+Unlike iOS, the animation always plays through the view's own animator in both modes — realtime only *observes* it. Anything that moves the view's `progress`, including your own `playAnimation()` calls, keeps the haptics aligned.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Bundle presets
+
+A preset from a `.pulsar` bundle carries the Lottie bytes it was authored against, on `PresetHandle.animation`:
+
+```kotlin
+val animation = preset.animation
+if (animation != null) {
+  view.setAnimation(animation.data.inputStream(), preset.id)
+  // animation.frameRate and animation.totalFrames describe the authored timing
+}
+```
+
+`PresetHandle` plays its own haptics through `play()` and `stop()`, which is the aligned-start `PATTERN` behaviour. It does not expose its `PatternData`, so a bundle preset cannot currently drive `HapticLottieController` in `REALTIME` mode — pass the pattern yourself when you need per-frame sync.
+
+---
+
+## Testing on the emulator
+
+Android emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).

--- a/docs/src/content/docs/lottie/flutter.mdx
+++ b/docs/src/content/docs/lottie/flutter.mdx
@@ -1,0 +1,220 @@
+---
+title: Flutter
+description: Play Pulsar haptics in sync with a Lottie animation in Flutter, with a drop-in widget and an AnimationController-based controller.
+head:
+  - tag: title
+    content: "Flutter Lottie Haptics: Sync Vibration to Animations | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK for Flutter - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "A Flutter widget and controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK for Flutter - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "A Flutter widget and controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`pulsar_haptics_lottie` plays a Pulsar haptic pattern locked to a Lottie animation in Flutter. It exposes two entry points: the `HapticLottie` widget, and `HapticLottieController` for an `AnimationController` you already drive.
+
+It is a pure-Dart package — no native halves of its own. Both the haptics and the rendering come from packages you already have: [`pulsar_haptics`](https://pub.dev/packages/pulsar_haptics) and [`lottie`](https://pub.dev/packages/lottie).
+
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+
+## Requirements
+
+- Flutter 3.29+, Dart 3.7+
+- Android API 24+ (Android 7.0), iOS 13+
+- The [Pulsar Flutter SDK](/pulsar/sdk/flutter/) (`pulsar_haptics`) and [`lottie`](https://pub.dev/packages/lottie) 3.1+, both pulled in automatically
+
+## Installation
+
+{/* GENERATED:FLUTTER_LOTTIE_VERSION_START */}
+Latest available version: `0.1.0`
+{/* GENERATED:FLUTTER_LOTTIE_VERSION_END */}
+
+Add the package to your `pubspec.yaml`:
+
+{/* GENERATED:FLUTTER_LOTTIE_INSTALL_SNIPPET_START */}
+```yaml
+dependencies:
+  pulsar_haptics_lottie: ^0.1.0
+```
+{/* GENERATED:FLUTTER_LOTTIE_INSTALL_SNIPPET_END */}
+
+Or via the Flutter CLI:
+
+```bash
+flutter pub add pulsar_haptics_lottie
+```
+
+Declare the vibration permission in your Android app's `AndroidManifest.xml`:
+
+```xml
+<manifest ...>
+  <uses-permission android:name="android.permission.VIBRATE" />
+
+  <application ...>
+    ...
+  </application>
+</manifest>
+```
+
+Without `android.permission.VIBRATE`, Android blocks vibration playback. Pulsar logs a warning and skips the vibration instead of crashing. iOS needs nothing beyond `pod install`.
+
+---
+
+## HapticLottie
+
+A drop-in widget that owns its own `AnimationController` and plays a pattern locked to the animation:
+
+```dart
+import 'package:pulsar_haptics/pulsar.dart';
+import 'package:pulsar_haptics_lottie/pulsar_haptics_lottie.dart';
+
+final pattern = PatternData.fromArrays(
+  amplitude: [[0, 0], [400, 1], [800, 0]],
+  frequency: [[0, 0.3], [800, 0.8]],
+  discrete: [[0, 1, 0.5]],
+);
+
+HapticLottie.asset(
+  'assets/success.json',
+  haptics: pattern,
+  autoPlay: true,
+  width: 200,
+  height: 200,
+  onControllerCreated: (controller) => _haptic = controller,
+);
+```
+
+`HapticLottie.network(url, ...)` takes the same arguments and loads the animation from a URL instead.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `src` | `String` | – | Asset name or URL, passed positionally. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Omit for a plain animation. |
+| `mode` | `HapticMode` | `realtime` | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `double` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `bool` | `true` | Turn haptics off without touching the animation. |
+| `autoPlay` | `bool` | `false` | Start as soon as the animation loads. |
+| `repeat` | `bool` | `false` | Loop the animation, with `autoPlay`. |
+| `repeatCount` | `int?` | `null` | Limit the number of loops. `null` loops forever. |
+| `repeatReverse` | `bool` | `false` | Boomerang loop — forward, then reverse. |
+| `onControllerCreated` | `void Function(HapticLottieController)?` | `null` | Called once with the controller, so you can drive transport. |
+| `width` / `height` / `fit` / `alignment` | | | Forwarded to the underlying `Lottie` widget. |
+
+The widget sets the animation controller's duration from the loaded composition, disposes both the controller and the haptics on unmount, and — with `autoPlay` — starts either a single play or a loop depending on `repeat`.
+
+<Aside type="note" title="Grab the controller">
+  The widget has no imperative handle of its own. Capture the `HapticLottieController` from `onControllerCreated` when you need to replay, pause or seek later.
+</Aside>
+
+---
+
+## HapticLottieController
+
+Attaches haptics to an `AnimationController` you already pass to `Lottie`, and becomes the transport for both:
+
+```dart
+final anim = AnimationController(vsync: this);
+
+final haptic = HapticLottieController(
+  animationController: anim,
+  haptics: pattern,
+);
+
+Lottie.asset(
+  'assets/success.json',
+  controller: anim,
+  onLoaded: (composition) => anim.duration = composition.duration,
+);
+
+// transport steers both the animation and the haptics
+haptic.play();
+haptic.setTimestamp(1200);
+haptic.pause();
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `animationController` | `AnimationController` | – | The clock this controller follows and steers. Owned by you. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. `null` leaves the animation without haptics. |
+| `mode` | `HapticMode` | `realtime` | Engine mode. |
+| `offsetMs` | `double` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `enabled` | `bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `pulsar` | `Pulsar?` | `null` | Provide your own instance; one is created internally otherwise. |
+
+In `pattern` mode the pattern is pre-parsed at construction, so the engine is warm and the first `play()` fires without the usual first-play latency.
+
+### Transport
+
+| Method | Description |
+| --- | --- |
+| `play()` | Rewind to the start and play animation and haptics together. |
+| `pause()` | Pause both. In `pattern` mode the haptic stops rather than suspending. |
+| `resume()` | Resume from the current position. |
+| `stop()` | Reset the animation to the start and stop the haptics. |
+| `reset()` | Same as `stop()`. |
+| `setTimestamp(double ms)` | Seek both animation and haptics to `ms` from the start. |
+| `setLoop(bool loop, {int? count, bool reverse})` | Loop the animation. `count` limits iterations (`null` loops forever); `reverse` plays a boomerang. |
+| `durationMs` | Effective clock length: the composition duration once loaded, else the pattern's own length. |
+| `dispose()` | Detach from the animation and release the haptic resources. |
+
+The transport methods return `Future<void>` — `await` them when the ordering matters, ignore them otherwise.
+
+<Aside type="caution" title="Dispose, but not the AnimationController">
+  `dispose()` removes the listener the controller installed and releases its composers. It deliberately does **not** dispose `animationController` — that one is yours, so dispose it yourself in `State.dispose`, after the haptic controller.
+</Aside>
+
+In `pattern` mode `setLoop(true)` fires the pattern once at the start of the loop; it is not re-fired per iteration.
+
+---
+
+## Engine modes
+
+```dart
+enum HapticMode { realtime, pattern }
+```
+
+- **`realtime`** (default) — the `AnimationController` is the master clock and the pattern is sampled every frame into `RealtimeComposer.set` and `playDiscrete`. Honours pause, `setTimestamp` and loop. Continuous fidelity is realtime-grade, and coarser on Android than on iOS.
+- **`pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
+
+Passing `realtime` without a pattern leaves the animation without haptics, because there is nothing to sample.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Testing on simulators
+
+Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).

--- a/docs/src/content/docs/lottie/ios.mdx
+++ b/docs/src/content/docs/lottie/ios.mdx
@@ -1,0 +1,248 @@
+---
+title: iOS
+description: Play Pulsar haptics in sync with a Lottie animation on iOS, with a SwiftUI view and a UIKit controller built on lottie-ios.
+head:
+  - tag: title
+    content: "iOS Lottie Haptics: Sync Vibration to Animations | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK for iOS - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "A SwiftUI view and a UIKit controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK for iOS - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "A SwiftUI view and a UIKit controller that play Pulsar haptics in sync with a Lottie animation."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`PulsarLottie` plays a Pulsar haptic pattern locked to a Lottie animation on iOS. It exposes two entry points: `HapticLottieView` for SwiftUI, and `HapticLottieController` for a `LottieAnimationView` you already own.
+
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+
+## Requirements
+
+- iOS 13.0+
+- Swift 5.9+
+- [`lottie-ios`](https://github.com/airbnb/lottie-ios) 4.5+
+- The [Pulsar iOS SDK](/pulsar/sdk/ios/) (`PulsarHaptics`), pulled in automatically
+
+## Installation
+
+{/* GENERATED:IOS_LOTTIE_VERSION_START */}
+Latest available version: `0.1.0`
+{/* GENERATED:IOS_LOTTIE_VERSION_END */}
+
+Add the package in Xcode via **File > Add Package Dependencies...** and depend on the `PulsarLottie` library product, or declare it in `Package.swift`:
+
+{/* GENERATED:IOS_LOTTIE_INSTALL_SNIPPET_START */}
+```swift
+dependencies: [
+  .package(url: "https://github.com/software-mansion-labs/pulsar-lottie-ios", from: "0.1.0")
+]
+```
+{/* GENERATED:IOS_LOTTIE_INSTALL_SNIPPET_END */}
+
+With CocoaPods:
+
+{/* GENERATED:IOS_LOTTIE_COCOAPODS_INSTALL_SNIPPET_START */}
+```ruby
+pod 'PulsarLottie', '~> 0.1.0'
+```
+{/* GENERATED:IOS_LOTTIE_COCOAPODS_INSTALL_SNIPPET_END */}
+
+Both `PulsarHaptics` and `lottie-ios` come along as dependencies — you do not need to add them separately, though nothing stops you from pinning them yourself.
+
+---
+
+## HapticLottieView
+
+A SwiftUI view that renders a bundled Lottie animation and plays a pattern locked to its timeline.
+
+```swift
+import Pulsar
+import PulsarLottie
+
+let pattern = PatternData(
+  continuousPattern: ContinuousPattern(
+    amplitude: [
+      ValuePoint(time: 0, value: 0),
+      ValuePoint(time: 400, value: 1),
+      ValuePoint(time: 800, value: 0),
+    ],
+    frequency: [
+      ValuePoint(time: 0, value: 0.3),
+      ValuePoint(time: 800, value: 0.8),
+    ]
+  ),
+  discretePattern: [
+    DiscretePoint(time: 0, amplitude: 1, frequency: 0.5)
+  ]
+)
+
+struct SuccessBadge: View {
+  var body: some View {
+    HapticLottieView("success", haptics: pattern, autoPlay: true)
+      .frame(width: 200, height: 200)
+  }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | `String` | – | Name of the Lottie animation to load, passed positionally. |
+| `bundle` | `Bundle` | `.main` | Bundle the animation is loaded from. |
+| `haptics` | `PatternData?` | `nil` | Pattern to sync. `nil` renders a plain animation. |
+| `mode` | `HapticMode` | `.realtime` | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `Bool` | `true` | Turn haptics off without touching the animation. |
+| `autoPlay` | `Bool` | `true` | Play as soon as the view is created. |
+| `loopMode` | `LottieLoopMode` | `.playOnce` | Loop behaviour of the underlying `LottieAnimationView`. |
+
+The view creates and owns a `Pulsar` instance and a `HapticLottieController` for its lifetime, and sets `contentMode` to `.scaleAspectFit`.
+
+<Aside type="caution" title="Transport from SwiftUI">
+  The view does not expose its controller, so there is no way to call `play()` or `setTimestamp(_:)` on it from SwiftUI. To replay, force a remount by changing the view's identity:
+
+  ```swift
+  HapticLottieView("success", haptics: pattern, autoPlay: true)
+    .id(runId)
+  ```
+
+  When you need real transport control, use [`HapticLottieController`](#hapticlottiecontroller) with your own `LottieAnimationView` instead.
+</Aside>
+
+<Aside type="note" title="loopMode and realtime">
+  `loopMode` configures the underlying `LottieAnimationView`, which only drives its own playback in `.pattern` mode. In the default `.realtime` mode the controller advances the animation itself, so looping comes from `setLoop(_:count:reverse:)` on the controller — another reason to reach for the controller when the animation loops.
+</Aside>
+
+---
+
+## HapticLottieController
+
+Attaches haptics to a `LottieAnimationView` you already have, and becomes the transport for both.
+
+```swift
+import Lottie
+import Pulsar
+import PulsarLottie
+
+let pulsar = Pulsar()
+let animationView = LottieAnimationView(name: "success")
+
+let controller = PulsarLottie.bind(animationView, pulsar: pulsar, haptics: pattern)
+
+controller.play()
+controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
+controller.pause()
+```
+
+`PulsarLottie.bind(_:pulsar:haptics:mode:offsetMs:enabled:)` is a convenience over the initializer. Call the initializer directly when the pattern is optional:
+
+```swift
+let controller = HapticLottieController(
+  animationView: animationView,
+  pulsar: pulsar,
+  haptics: pattern,   // optional — nil plays the animation alone
+  mode: .realtime,
+  offsetMs: 0,
+  enabled: true
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `animationView` | `LottieAnimationView` | – | The view to drive. Held for the controller's lifetime. |
+| `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
+| `haptics` | `PatternData?` | `nil` | Pattern to sync. `nil` leaves the animation without haptics. |
+| `mode` | `HapticMode` | `.realtime` | Engine mode. |
+| `offsetMs` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `enabled` | `Bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+
+In `.pattern` mode the pattern is parsed in the initializer, so the engine is warm and the first `play()` fires without the usual first-play latency.
+
+### Transport
+
+| Method | Description |
+| --- | --- |
+| `play()` | Rewind to the start and play animation and haptics together. |
+| `pause()` | Pause both. In `.pattern` mode the haptic stops rather than suspending. |
+| `resume()` | Resume from the current position. |
+| `stop()` | Stop and rewind to the start. |
+| `reset()` | Alias of `stop()`. |
+| `setTimestamp(_ ms: Double)` | Seek both animation and haptics to `ms` from the start. |
+| `setLoop(_ loop: Bool, count: Int?, reverse: Bool)` | Loop the animation. `count` limits iterations (`nil` loops forever); `reverse` plays a boomerang. |
+
+`setTimestamp(_:)` clamps into `0 ... duration` and repositions the discrete-event window, so seeking backwards re-fires the events you seek past. In `.pattern` mode it moves the animation only — a buffered pattern cannot be repositioned mid-flight.
+
+### Lifetime
+
+The controller retains the animation view and installs a `CADisplayLink` on the main run loop while playing. The display link is invalidated when playback ends and on `deinit`, so the only thing you have to get right is **keeping a strong reference to the controller** for as long as the view is on screen. A controller that is deallocated stops driving the animation.
+
+---
+
+## Engine modes
+
+```swift
+public enum HapticMode {
+  case realtime
+  case pattern
+}
+```
+
+- **`.realtime`** (default) — a `CADisplayLink` makes the animation timeline the master clock, driving `currentProgress` and sampling the pattern into `RealtimeComposer.set` and `playDiscrete`. Honours pause, `setTimestamp(_:)` and loop.
+- **`.pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
+
+Passing `.realtime` without a pattern falls back to `.pattern` behaviour, because there is nothing to sample.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Bundle presets
+
+A preset from a `.pulsar` bundle carries the Lottie bytes it was authored against, on `PresetHandle.animation`:
+
+```swift
+if let animation = preset.animation {
+  let lottieAnimation = try? LottieAnimation.from(data: animation.data)
+  let animationView = LottieAnimationView(animation: lottieAnimation)
+  // animation.frameRate and animation.totalFrames describe the authored timing
+}
+```
+
+`PresetHandle` plays its own haptics through `play()` and `stop()`, which is the aligned-start `.pattern` behaviour. It does not expose its `PatternData`, so a bundle preset cannot currently drive `HapticLottieController` in `.realtime` mode — pass the pattern yourself when you need per-frame sync. See the [bundle format](/pulsar/sdk/ios/) notes on the iOS SDK page for how bundles are loaded.
+
+---
+
+## Testing on the simulator
+
+Core Haptics is unavailable on the iOS Simulator. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).

--- a/docs/src/content/docs/lottie/kmp.mdx
+++ b/docs/src/content/docs/lottie/kmp.mdx
@@ -1,0 +1,194 @@
+---
+title: Kotlin Multiplatform
+description: Play Pulsar haptics in sync with a Lottie animation in Compose Multiplatform, with any Compose Lottie renderer.
+head:
+  - tag: title
+    content: "Compose Multiplatform Lottie Haptics | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK for Kotlin Multiplatform - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "A Compose Multiplatform composable that plays Pulsar haptics in sync with any Lottie renderer's progress."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK for Kotlin Multiplatform - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "A Compose Multiplatform composable that plays Pulsar haptics in sync with any Lottie renderer's progress."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`pulsar-kmp-lottie` plays a Pulsar haptic pattern locked to a Lottie animation from common Compose Multiplatform code, on Android and iOS targets.
+
+It is the one package in this section that does not depend on a Lottie library. It follows the **progress value** you feed it, so it works with whichever Compose Lottie renderer you already use — [compottie](https://github.com/alexzhirkevich/compottie), for example. The only Compose dependency is `compose-runtime`.
+
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+
+## Requirements
+
+- Kotlin 2.0+
+- Android API 24+ (Android 7.0) for Android targets, iOS 13+ for iOS targets
+- The [Pulsar KMP SDK](/pulsar/sdk/kmp/) (`com.swmansion:pulsar-kmp`)
+- A Compose Lottie renderer of your choosing
+
+## Installation
+
+{/* GENERATED:KMP_LOTTIE_VERSION_START */}
+Latest available version: `0.1.0`
+{/* GENERATED:KMP_LOTTIE_VERSION_END */}
+
+Add the dependency to your shared module:
+
+{/* GENERATED:KMP_LOTTIE_INSTALL_SNIPPET_START */}
+```kotlin
+commonMain.dependencies {
+  implementation("com.swmansion:pulsar-kmp-lottie:0.1.0")
+}
+```
+{/* GENERATED:KMP_LOTTIE_INSTALL_SNIPPET_END */}
+
+The library publishes a Kotlin Multiplatform module, so Gradle resolves the right variant per target. Add your Lottie renderer separately — this package has no opinion about which one.
+
+The Android target needs the vibration permission in your app's `AndroidManifest.xml`:
+
+```xml
+<manifest ...>
+  <uses-permission android:name="android.permission.VIBRATE" />
+
+  <application ...>
+    ...
+  </application>
+</manifest>
+```
+
+---
+
+## HapticLottie
+
+Render the animation however you like, then place `HapticLottie` next to it and feed it the same `progress`, `durationMillis` and `isPlaying`:
+
+```kotlin
+import com.swmansion.pulsar.kmp.PatternData
+import com.swmansion.pulsar.lottie.HapticLottie
+import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
+import io.github.alexzhirkevich.compottie.rememberLottieComposition
+import io.github.alexzhirkevich.compottie.rememberLottiePainter
+
+@Composable
+fun Success(pattern: PatternData, playing: Boolean) {
+  val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+  val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
+
+  Image(
+    painter = rememberLottiePainter(composition, progress = { progress }),
+    contentDescription = null,
+  )
+
+  HapticLottie(
+    progress = progress,
+    durationMillis = composition?.duration?.inWholeMilliseconds ?: 0L,
+    isPlaying = playing,
+    haptics = pattern,
+  )
+}
+```
+
+`HapticLottie` emits no UI of its own — it exists purely to hold the haptic engine across recompositions and to react to the values you pass.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `progress` | `Float` | – | Current animation progress, `0..1`. |
+| `durationMillis` | `Long` | – | Total animation length in ms. |
+| `isPlaying` | `Boolean` | – | Whether the animation is running. A `false → true` transition starts the haptics. |
+| `haptics` | `PatternData?` | – | Pattern to sync. `null` disables haptics. |
+| `mode` | `HapticMode` | `Realtime` | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffsetMs` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
+| `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
+
+<Aside type="note" title="Pass your own Pulsar instance">
+  The default creates a fresh `Pulsar` for the composable. In an app that already holds one — most do, for presets and composers elsewhere — pass it in, so every haptic in the app shares one engine.
+</Aside>
+
+The engine is rebuilt whenever `pulsar`, `haptics`, `mode`, `hapticOffsetMs` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline in the composable body.
+
+---
+
+## HapticLottieEngine
+
+The composable is a thin wrapper around a plain, framework-agnostic engine. Use it directly when the progress comes from somewhere Compose is not involved in, or when you want to own the lifetime yourself:
+
+```kotlin
+import com.swmansion.pulsar.lottie.HapticLottieEngine
+import com.swmansion.pulsar.lottie.HapticMode
+
+val engine = HapticLottieEngine(
+  pulsar = pulsar,
+  haptics = pattern,
+  mode = HapticMode.Realtime,
+  offsetMs = 0,
+  enabled = true,
+)
+
+engine.setPlaying(true)
+engine.onProgress(progress, durationMs)  // every frame
+engine.stop()
+```
+
+| Member | Description |
+| --- | --- |
+| `setPlaying(isPlaying: Boolean)` | Notify a play/pause transition. In `Pattern` mode a `true` transition fires the buffered pattern; `false` stops the haptics. |
+| `onProgress(progress: Float, durationMs: Long)` | Feed the current position. Ignored unless `Realtime` mode is active and playing. |
+| `stop()` | Stop the haptics and reset the discrete-event window. |
+
+`onProgress` handles a wrapped playhead: when the new time is behind the previous one — a loop or a backwards seek — the discrete window restarts from zero, so looping re-fires the events rather than swallowing them.
+
+In `Pattern` mode the pattern is parsed in the constructor, so the engine is warm and the first play fires without the usual first-play latency.
+
+---
+
+## Engine modes
+
+```kotlin
+enum class HapticMode { Realtime, Pattern }
+```
+
+- **`Realtime`** (default) — the animation progress is the master clock and the pattern is sampled into `RealtimeComposer.set` and `playDiscrete` on every progress update. Honours pause, seek and loop. On Android the vibrator is re-driven per update, so continuous fidelity is coarser there than on iOS.
+- **`Pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the start, which gives the best native fidelity at the cost of seeking.
+
+Because the sampling rate is the rate at which you call `onProgress`, realtime fidelity in this package tracks your renderer's frame rate. A progress value updated on every Compose frame gives the same result as the native SDKs; a throttled one gives coarser haptics.
+
+Passing `Realtime` without a pattern leaves the animation without haptics, because there is nothing to sample.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Testing on simulators
+
+Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).

--- a/docs/src/content/docs/lottie/overview.mdx
+++ b/docs/src/content/docs/lottie/overview.mdx
@@ -1,0 +1,148 @@
+---
+title: Overview
+description: Play Pulsar haptics in sync with a Lottie animation on iOS, Android, React Native, Kotlin Multiplatform and Flutter.
+head:
+  - tag: title
+    content: "Pulsar Lottie SDK: Haptics Synced to Lottie Animations | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "Play Pulsar haptics in sync with a Lottie animation on iOS, Android, React Native, Kotlin Multiplatform and Flutter."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "Play Pulsar haptics in sync with a Lottie animation on iOS, Android, React Native, Kotlin Multiplatform and Flutter."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+The Pulsar Lottie SDK plays a Pulsar haptic pattern **locked to a Lottie animation's timeline**, so the vibration lands exactly when the animation lands. It is a thin layer on top of two things you already have: the [Pulsar haptics SDK](/pulsar/sdk/overview/) for your platform, and that platform's own Lottie renderer. No haptics are reimplemented and no animation is re-rendered — the Lottie SDK only connects the two clocks.
+
+Read the [SDK overview](/pulsar/sdk/overview/) first: patterns, discrete and continuous haptics, presets, caching and preloading all work the same way here.
+
+This page covers the concepts shared by every platform. The platform guides carry the API: [iOS](/pulsar/lottie/ios/), [Android](/pulsar/lottie/android/), [React Native](/pulsar/lottie/react-native/), [Kotlin Multiplatform](/pulsar/lottie/kmp/), [Flutter](/pulsar/lottie/flutter/).
+
+{/* GENERATED:LOTTIE_OVERVIEW_VERSIONS_START */}
+## Latest available version
+
+| Platform | Package | Version |
+| --- | --- | --- |
+| iOS | Swift Package / `PulsarLottie` (CocoaPods) | `0.1.0` |
+| Android | `com.swmansion:pulsar-lottie` (Maven) | `0.1.0` |
+| React Native | `react-native-pulsar-lottie` (npm) | `0.1.0` |
+| Kotlin Multiplatform | `com.swmansion:pulsar-kmp-lottie` (Maven) | `0.1.0` |
+| Flutter | `pulsar_haptics_lottie` (pub.dev) | `0.1.0` |
+{/* GENERATED:LOTTIE_OVERVIEW_VERSIONS_END */}
+
+There is no Web package — the [Web SDK](/pulsar/sdk/web/) has no Lottie integration.
+
+## What each package renders with
+
+Every package builds on the Lottie renderer that is idiomatic for its platform, and depends on the matching Pulsar core:
+
+| Platform | Lottie renderer | Pulsar core |
+| --- | --- | --- |
+| iOS | [`lottie-ios`](https://github.com/airbnb/lottie-ios) | `PulsarHaptics` |
+| Android | [`com.airbnb.android:lottie`](https://github.com/airbnb/lottie-android) | `com.swmansion:pulsar` |
+| React Native | [`lottie-react-native`](https://github.com/lottie-react-native/lottie-react-native) | `react-native-pulsar` |
+| Kotlin Multiplatform | any Compose renderer (e.g. [compottie](https://github.com/alexzhirkevich/compottie)) | `com.swmansion:pulsar-kmp` |
+| Flutter | [`lottie`](https://pub.dev/packages/lottie) | `pulsar_haptics` |
+
+The Kotlin Multiplatform package is the odd one out: it depends only on `compose-runtime` and follows the **progress value** you feed it, so it works with whichever Compose Lottie renderer you already use.
+
+## How the sync works
+
+A Pulsar pattern is a timeline of milliseconds — discrete events at fixed times, plus amplitude and frequency envelopes. A Lottie animation is a timeline too. The Lottie SDK makes the **animation the master clock** and reads the pattern against it:
+
+1. Every frame, the current animation position is converted to milliseconds.
+2. The amplitude and frequency envelopes are linearly interpolated at that time and pushed to the `RealtimeComposer`.
+3. Any discrete event whose time falls in the window since the previous frame is fired as a one-shot.
+
+Because the animation drives the pattern rather than the two running side by side, pausing, seeking, replaying or looping the animation keeps the haptics aligned for free.
+
+## Engine modes
+
+Every platform exposes the same two modes.
+
+### Realtime (default)
+
+The animation timeline is the master clock and the pattern is sampled per frame into `RealtimeComposer` events.
+
+- Honours pause, seek and loop coherently.
+- Requires an actual pattern — a bare preset trigger has no timeline to sample.
+- Continuous fidelity is realtime-grade, and coarser on Android than on iOS, because Android's vibrator is re-driven per frame rather than following a pre-compiled curve.
+
+### Pattern
+
+The whole pattern is pre-parsed and played once through `PatternComposer`, aligned to the animation start.
+
+- Best native fidelity — the platform haptic engine plays a compiled pattern, exactly as it would outside a Lottie context.
+- Pausing stops the haptic instead of suspending it, and there is no mid-pattern seek.
+- Accepts a preset trigger as well as a pattern, since nothing needs to be sampled.
+
+### Choosing between them
+
+|  | Realtime | Pattern |
+| --- | --- | --- |
+| **Master clock** | Animation timeline | Haptic engine |
+| **Pause / resume** | Follows the animation | Stops the haptic |
+| **Seek** | Animation and haptics move together | Not supported |
+| **Loop** | Re-fires per iteration | Fires once at the start |
+| **Continuous fidelity** | Realtime-grade (coarser on Android) | Native |
+| **Accepts a preset trigger** | No | Yes |
+
+Reach for **realtime** for anything longer than about a second, anything the user can scrub, and anything that loops. Reach for **pattern** for short, start-aligned accents where the sharpest possible feel matters more than seeking.
+
+## Timing and duration
+
+The clock length is resolved in this order, and the first value that is available wins:
+
+1. An explicit duration you pass.
+2. The Lottie composition's own duration, once the animation has loaded.
+3. The pattern's own length — the largest timestamp across its discrete events and both envelopes.
+
+A pattern shorter than the animation simply ends early (its envelopes hold their last value); a longer one is cut off when the animation ends. Authoring both to the same length is the least surprising option.
+
+### Tuning the offset
+
+Perceived haptics lag the visual by a device-dependent few milliseconds. Every platform takes a haptic offset in milliseconds that shifts the haptic timeline relative to the animation — negative fires earlier, positive later. It is a per-device tuning knob, not a design parameter; leave it at `0` until a device tells you otherwise.
+
+### No playback-speed control
+
+None of the packages expose a playback-speed setting. A haptic timeline cannot be rate-shifted coherently — resampling an envelope changes how the vibration feels, not just how fast it goes — so the animation always runs at its authored speed. If you need a faster or slower version, author it that way.
+
+## Where the pattern comes from
+
+Three routes, all producing the same `Pattern` / `PatternData`:
+
+- **Generate it from the animation.** [Pulsar Studio](https://docs.swmansion.com/pulsar/studio/) samples an attached Lottie and derives a pattern from how much the animation is moving, which is the fastest way to a pattern that already matches the motion. See the [Studio guide](https://docs.swmansion.com/pulsar/studio/).
+- **Ship it in a `.pulsar` bundle.** A bundle preset pairs a pattern with the animation it was authored against, so the two can never drift apart. On React Native the bundle preset [drops straight into the view](/pulsar/lottie/react-native/#from-a-bundle-preset); on the other platforms the preset carries the Lottie bytes for your own renderer.
+- **Write it by hand.** A literal pattern is often enough for a short accent — see the platform guides for the shape.
+
+## Testing without a device
+
+Simulators and emulators have no haptic hardware. Pulsar's debug builds play an audio rendering of the pattern instead, so a Lottie animation running in a simulator still tells you whether the haptics land on the right frames. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators) for how to turn that off.
+
+Amplitude and sharpness still need a real device before you ship — the audio preview tells you about timing, not about feel.

--- a/docs/src/content/docs/lottie/react-native.mdx
+++ b/docs/src/content/docs/lottie/react-native.mdx
@@ -1,0 +1,307 @@
+---
+title: React Native
+description: Play Pulsar haptics in sync with a Lottie animation in React Native — a drop-in superset of LottieView from lottie-react-native.
+head:
+  - tag: title
+    content: "React Native Lottie Haptics: Sync Vibration to Animations | Pulsar"
+  - tag: meta
+    attrs:
+      property: og:type
+      content: website
+  - tag: meta
+    attrs:
+      property: og:title
+      content: "Pulsar Lottie SDK for React Native - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      property: og:description
+      content: "A drop-in superset of lottie-react-native's LottieView that plays Pulsar haptics in sync with the animation."
+  - tag: meta
+    attrs:
+      property: og:image
+      content: https://docs.swmansion.com/pulsar/og.png
+  - tag: meta
+    attrs:
+      name: twitter:card
+      content: summary_large_image
+  - tag: meta
+    attrs:
+      name: twitter:title
+      content: "Pulsar Lottie SDK for React Native - haptics locked to your Lottie timeline"
+  - tag: meta
+    attrs:
+      name: twitter:description
+      content: "A drop-in superset of lottie-react-native's LottieView that plays Pulsar haptics in sync with the animation."
+  - tag: meta
+    attrs:
+      name: twitter:image
+      content: https://docs.swmansion.com/pulsar/og.png
+---
+
+import { Tabs, TabItem, Code, Aside } from '@astrojs/starlight/components';
+
+`react-native-pulsar-lottie` plays a Pulsar haptic pattern locked to a Lottie animation. Its `HapticLottieView` is a **non-breaking superset** of [`lottie-react-native`](https://github.com/lottie-react-native/lottie-react-native)'s `LottieView`: it accepts every prop and ref method you already use and adds haptic-only ones. With `haptics` omitted it behaves exactly like `LottieView`.
+
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+
+## Requirements
+
+- React Native 0.71+ with the New Architecture enabled
+- The [Pulsar React Native SDK](/pulsar/sdk/react-native/) (`react-native-pulsar` 1.6+)
+- `lottie-react-native` 7.0+
+- `react-native-reanimated` 4.0+ and `react-native-worklets`
+
+## Installation
+
+{/* GENERATED:REACT_NATIVE_LOTTIE_VERSION_START */}
+Latest available version: `0.1.0`
+{/* GENERATED:REACT_NATIVE_LOTTIE_VERSION_END */}
+
+<Tabs>
+  <TabItem label="Expo">
+    <Code
+      code="npx expo install react-native-pulsar-lottie react-native-pulsar lottie-react-native react-native-reanimated"
+      lang="bash"
+      frame="terminal"
+    />
+    Then run prebuild to generate the native project files:
+    <Code
+      code="npx expo prebuild"
+      lang="bash"
+      frame="terminal"
+    />
+  </TabItem>
+  <TabItem label="npm" icon="npm">
+    <Code
+      code="npm install react-native-pulsar-lottie react-native-pulsar lottie-react-native react-native-reanimated react-native-worklets"
+      lang="bash"
+      frame="terminal"
+    />
+  </TabItem>
+</Tabs>
+
+Everything here is a peer dependency, so each package is installed and configured exactly as its own docs describe — this library adds no native code of its own.
+
+---
+
+## HapticLottieView
+
+```tsx
+import { HapticLottieView } from 'react-native-pulsar-lottie';
+import type { Pattern } from 'react-native-pulsar';
+
+const pattern: Pattern = {
+  discretePattern: [{ time: 0, amplitude: 1, frequency: 0.5 }],
+  continuousPattern: {
+    amplitude: [
+      { time: 0, value: 0 },
+      { time: 400, value: 1 },
+      { time: 800, value: 0 },
+    ],
+    frequency: [
+      { time: 0, value: 0.3 },
+      { time: 800, value: 0.8 },
+    ],
+  },
+};
+
+function Success() {
+  return (
+    <HapticLottieView
+      source={require('./success.json')}
+      haptics={pattern}
+      autoPlay
+      style={{ width: 200, height: 200 }}
+    />
+  );
+}
+```
+
+Everything `LottieView` does still works — `source`, `loop`, `autoPlay`, `style`, `resizeMode`, `onAnimationFinish` and the rest. You only **add** haptics.
+
+### Haptic props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `preset` | `PresetHandle` | – | A bundle preset supplying `source`, `haptics` and `durationMs` at once. |
+| `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger function (`pattern` mode only). |
+| `hapticMode` | `'realtime' \| 'pattern'` | `'realtime'` | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `number` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `boolean` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `number` | derived | Clock length in `realtime` mode. See [Duration](#duration). |
+
+`source` is required as usual, unless a `preset` supplies it.
+
+### Duration
+
+In `realtime` mode the view needs to know how long the animation is. It resolves that in order:
+
+1. An explicit `durationMs` prop.
+2. The preset's authored duration, when a `preset` is passed.
+3. The Lottie JSON's own `fr` / `ip` / `op` fields — only readable when `source` is an inline object, such as a `require('./success.json')`.
+4. The pattern's own length.
+
+A remote animation loaded by URL exposes none of that to JS, so pass `durationMs` explicitly when the source is a URI.
+
+---
+
+## From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `source`, no `haptics`:
+
+```tsx
+import { createBundle } from 'react-native-pulsar';
+import { HapticLottieView } from 'react-native-pulsar-lottie';
+import pack from '@/assets/my-pack.bundle.json';
+
+const Pack = createBundle(pack);
+
+function Celebration() {
+  return (
+    <HapticLottieView
+      preset={Pack.celebration}
+      autoPlay
+      style={{ width: 200, height: 200 }}
+    />
+  );
+}
+```
+
+The preset fills in three things, each still overridable on its own: `source` from its Lottie, `haptics` from its pattern, and `durationMs` from its authored length.
+
+The animation only travels in JS on the **inline** path (`createBundle`) and only for JSON Lotties. A preset from `loadBundle`, or one authored as a dotLottie, reports `hasAnimation: true` but carries no `animation` — pass `source` yourself there. When neither is available the view renders nothing and warns once, rather than crashing.
+
+See [preset bundles](/pulsar/sdk/react-native/#preset-bundles) on the React Native SDK page for how bundles are generated and loaded.
+
+---
+
+## Imperative control
+
+The ref mirrors `LottieView`'s transport and adds `stop()` and `setTimestamp(ms)`. In `realtime` mode these steer the shared master clock, so the animation and the haptics move together.
+
+```tsx
+import { useRef } from 'react';
+import { HapticLottieView, type HapticLottieRef } from 'react-native-pulsar-lottie';
+
+function Success() {
+  const ref = useRef<HapticLottieRef>(null);
+
+  return (
+    <>
+      <HapticLottieView
+        ref={ref}
+        source={require('./success.json')}
+        haptics={pattern}
+        style={{ width: 200, height: 200 }}
+      />
+      <Button title="Replay" onPress={() => ref.current?.play()} />
+    </>
+  );
+}
+```
+
+| Method | Description |
+| --- | --- |
+| `play(startFrame?, endFrame?)` | Play from the start, or a frame segment. Starts the haptics too. |
+| `pause()` | Pause both animation and haptics. |
+| `resume()` | Resume from the current position. |
+| `stop()` | Stop and rewind to the start. |
+| `reset()` | Rewind to the start and stop the haptics. |
+| `setTimestamp(ms)` | Seek both animation and haptics to `ms` from the start. |
+
+<Aside type="note" title="Transport in pattern mode">
+  `setTimestamp(ms)` is a no-op in `pattern` mode — `lottie-react-native` exposes no imperative seek, and a buffered haptic cannot be repositioned mid-flight. The frame segment arguments to `play()` are likewise a `pattern`-mode feature.
+</Aside>
+
+---
+
+## Engine modes
+
+```ts
+type HapticMode = 'realtime' | 'pattern';
+```
+
+### realtime (default)
+
+A Reanimated frame callback drives the Lottie `progress` on the UI thread — no React re-renders — and samples the pattern into `RealtimeComposer` events. It honours `pause`, `setTimestamp`, `loop` and segments coherently. Requires a `Pattern`; a preset trigger function has no timeline to sample.
+
+Because the view owns the clock in this mode, `autoPlay` is an initial-state flag read once on mount, not a live toggle: flipping it later does not start or stop playback — call `play()` or `pause()` on the ref instead.
+
+### pattern
+
+The pattern (or a preset trigger) plays whole through `PatternComposer`, aligned to the animation start, and the animation plays itself. Best native fidelity. `pause` stops the haptic instead of suspending it, and there is no mid-pattern seek — best for short, mostly start-aligned animations.
+
+Passing `hapticMode="realtime"` with a preset trigger function rather than a `Pattern` falls back to the pattern-mode path.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## useHapticLottie
+
+Attach haptics to a `LottieView` you already own, without swapping the component. This is the `pattern`-mode (aligned-start) path: the hook pre-parses the pattern so the engine is warm, and hands back `play` and `stop` to call next to your own transport.
+
+```tsx
+import LottieView from 'lottie-react-native';
+import { useHapticLottie } from 'react-native-pulsar-lottie';
+
+function Success() {
+  const lottieRef = useRef<LottieView>(null);
+  const haptics = useHapticLottie({ haptics: pattern });
+
+  const start = () => {
+    lottieRef.current?.play();
+    haptics.play();
+  };
+
+  const pause = () => {
+    lottieRef.current?.pause();
+    haptics.stop();
+  };
+
+  return <LottieView ref={lottieRef} source={require('./success.json')} />;
+}
+```
+
+### Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `haptics` | `Pattern \| () => void` | – | Pattern or preset trigger to fire with the animation. |
+| `hapticsEnabled` | `boolean` | `true` | Disable firing without unwiring the hook. |
+
+### Returns
+
+| Member | Description |
+| --- | --- |
+| `play()` | Fire the haptic — call alongside your own `play()`. |
+| `stop()` | Stop the haptic — call alongside pause or stop. |
+| `isReady` | `true` once the pattern is parsed. Always `true` for a preset trigger. |
+
+A bundle preset works here today with no extra option: `useHapticLottie({ haptics: preset.pattern })`.
+
+For progress-driven `realtime` sync with seek and loop, use [`HapticLottieView`](#hapticlottieview) instead.
+
+---
+
+## Types
+
+```ts
+import type {
+  HapticConfig,
+  HapticLottieProps,
+  HapticLottieRef,
+  HapticMode,
+  HapticSource,
+  HapticLottieHandle,
+  UseHapticLottieOptions,
+} from 'react-native-pulsar-lottie';
+```
+
+`HapticSource` is `Pattern | (() => void)` — a pattern works in both modes, a preset trigger function in `pattern` mode only. `HapticLottieProps` is `LottieViewProps` plus `HapticConfig`, with `source` required unless a `preset` supplies it.
+
+---
+
+## Testing on the simulator
+
+Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators) and the [Jest mock](/pulsar/sdk/react-native/#testing-with-jest) for unit tests.

--- a/tools/scripts/sync-sdk-versions.mjs
+++ b/tools/scripts/sync-sdk-versions.mjs
@@ -19,6 +19,12 @@ const files = [
   'docs/src/content/docs/sdk/kmp.mdx',
   'docs/src/content/docs/sdk/flutter.mdx',
   'docs/src/content/docs/sdk/web.mdx',
+  'docs/src/content/docs/lottie/overview.mdx',
+  'docs/src/content/docs/lottie/ios.mdx',
+  'docs/src/content/docs/lottie/android.mdx',
+  'docs/src/content/docs/lottie/react-native.mdx',
+  'docs/src/content/docs/lottie/kmp.mdx',
+  'docs/src/content/docs/lottie/flutter.mdx',
   'iOS/Pulsar/README.md',
   'Android/Pulsar/README.md',
   'react-native/react-native-pulsar/README.md',
@@ -157,6 +163,59 @@ dependencies:
 \`\`\``;
 }
 
+function getLottieOverviewBlock() {
+  return `## Latest available version
+
+| Platform | Package | Version |
+| --- | --- | --- |
+| iOS | Swift Package / \`PulsarLottie\` (CocoaPods) | \`${versions.iosLottie.version}\` |
+| Android | \`${versions.androidLottie.mavenCoordinate}\` (Maven) | \`${versions.androidLottie.version}\` |
+| React Native | \`${versions.reactNativeLottie.packageName}\` (npm) | \`${versions.reactNativeLottie.version}\` |
+| Kotlin Multiplatform | \`${versions.kmpLottie.mavenCoordinate}\` (Maven) | \`${versions.kmpLottie.version}\` |
+| Flutter | \`${versions.flutterLottie.packageName}\` (pub.dev) | \`${versions.flutterLottie.version}\` |`;
+}
+
+function getVersionLine(version) {
+  return `Latest available version: \`${version}\``;
+}
+
+function getIosLottieSnippet() {
+  return `\`\`\`swift
+dependencies: [
+  .package(url: "${versions.iosLottie.swiftPackageUrl}", from: "${versions.iosLottie.version}")
+]
+\`\`\``;
+}
+
+function getIosLottieCocoaPodsSnippet() {
+  return `\`\`\`ruby
+pod 'PulsarLottie', '~> ${versions.iosLottie.version}'
+\`\`\``;
+}
+
+function getAndroidLottieSnippet() {
+  return `\`\`\`kotlin
+dependencies {
+  implementation("${versions.androidLottie.mavenCoordinate}:${versions.androidLottie.version}")
+}
+\`\`\``;
+}
+
+function getKmpLottieSnippet() {
+  return `\`\`\`kotlin
+commonMain.dependencies {
+  implementation("${versions.kmpLottie.mavenCoordinate}:${versions.kmpLottie.version}")
+}
+\`\`\``;
+}
+
+function getFlutterLottieSnippet() {
+  return `\`\`\`yaml
+dependencies:
+  ${versions.flutterLottie.packageName}: ^${versions.flutterLottie.version}
+\`\`\``;
+}
+
 function syncMarkedVersion(content, key, version, label) {
   const marker = `pulsar-sync:${key}`;
   const semver = /\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/;
@@ -245,6 +304,35 @@ for (const relativeFile of files) {
     relativeFile === 'README.md'
   ) {
     content = replaceGeneratedSection(content, 'WEB_VERSION', getWebVersionLine());
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/overview.mdx') {
+    content = replaceGeneratedSection(content, 'LOTTIE_OVERVIEW_VERSIONS', getLottieOverviewBlock());
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/ios.mdx') {
+    content = replaceGeneratedSection(content, 'IOS_LOTTIE_VERSION', getVersionLine(versions.iosLottie.version));
+    content = replaceGeneratedSection(content, 'IOS_LOTTIE_INSTALL_SNIPPET', getIosLottieSnippet());
+    content = replaceGeneratedSection(content, 'IOS_LOTTIE_COCOAPODS_INSTALL_SNIPPET', getIosLottieCocoaPodsSnippet());
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/android.mdx') {
+    content = replaceGeneratedSection(content, 'ANDROID_LOTTIE_VERSION', getVersionLine(versions.androidLottie.version));
+    content = replaceGeneratedSection(content, 'ANDROID_LOTTIE_INSTALL_SNIPPET', getAndroidLottieSnippet());
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/react-native.mdx') {
+    content = replaceGeneratedSection(content, 'REACT_NATIVE_LOTTIE_VERSION', getVersionLine(versions.reactNativeLottie.version));
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/kmp.mdx') {
+    content = replaceGeneratedSection(content, 'KMP_LOTTIE_VERSION', getVersionLine(versions.kmpLottie.version));
+    content = replaceGeneratedSection(content, 'KMP_LOTTIE_INSTALL_SNIPPET', getKmpLottieSnippet());
+  }
+
+  if (relativeFile === 'docs/src/content/docs/lottie/flutter.mdx') {
+    content = replaceGeneratedSection(content, 'FLUTTER_LOTTIE_VERSION', getVersionLine(versions.flutterLottie.version));
+    content = replaceGeneratedSection(content, 'FLUTTER_LOTTIE_INSTALL_SNIPPET', getFlutterLottieSnippet());
   }
 
   await fs.writeFile(absoluteFile, content);


### PR DESCRIPTION
## What

A new **Pulsar Lottie SDK** docs section — one page per platform plus a shared overview — covering the five Lottie packages: `react-native-pulsar-lottie`, `PulsarLottie` (iOS and Android), `pulsar-kmp-lottie` and `pulsar_haptics_lottie`. Until now these were documented only in their package READMEs.

It is structured like the main SDK section: same frontmatter and OG meta shape, same `GENERATED:` version markers, same section rhythm, and it sits between **SDK** and **Web** in the sidebar.

## Pages

- **Overview** — package matrix, how the sync works (the animation as master clock), the realtime/pattern trade-off as a comparison table, how the clock length is resolved, the offset knob, why there is no playback-speed control, where the pattern comes from (Studio / `.pulsar` bundle / hand-written), and simulator testing.
- **iOS** — SPM + CocoaPods, `HapticLottieView` (SwiftUI) and `HapticLottieController` (UIKit / `PulsarLottie.bind`), parameter and transport tables, display-link lifetime, bundle-preset animation bytes.
- **Android** — Maven install (noting Lottie is *not* transitive while the Pulsar core is), the `HapticLottieView` subclass, the `bindHaptics` extension, a Compose `AndroidView` recipe, the `release()` requirement, the composition-duration timing caveat.
- **React Native** — Expo/npm install tabs, haptic props, duration resolution order, bundle presets via the `preset` prop, the imperative ref, both engine modes, `useHapticLottie`, exported types.
- **Kotlin Multiplatform** — the renderer-agnostic `HapticLottie` composable, the standalone `HapticLottieEngine`, and why sampling fidelity tracks the `onProgress` cadence.
- **Flutter** — `HapticLottie.asset` / `.network`, `HapticLottieController` over your own `AnimationController`, transport table, and the "dispose the controller, not the `AnimationController`" rule.

Several sharp edges that the source makes real but the READMEs do not call out are documented: SwiftUI having no handle on its controller (replay via `.id()`), `loopMode` being inert in iOS realtime mode, `autoPlay` being a mount-time flag in React Native realtime mode, and bundle presets wiring into the view on React Native only — the native `PresetHandle` exposes animation bytes but not its `PatternData`.

## Supporting changes

- `docs/astro.config.mjs` — the new sidebar group.
- `tools/scripts/sync-sdk-versions.mjs` — the six pages registered with generators for every new marker, so Lottie versions and install snippets come from `sdk-versions.json` like the rest.

## Verification

- `node tools/scripts/sync-sdk-versions.mjs` runs clean and is idempotent against the new pages.
- `astro build` succeeds; all six pages are emitted.
- Every internal link and cross-page anchor on the new pages resolves against the built site (checked programmatically).
- Pages rendered in a browser to confirm the sidebar group and asides.

## Not included

`sdk-versions.json` already carries `iosLottie` / `androidLottie` / etc., and the Lottie package manifests already have `pulsar-sync:*-lottie-version` markers, but the sync script never wired those up — so bumping a Lottie version updates the docs but not the podspec/gradle/pubspec. That is a packaging fix rather than a docs one, so it is left alone here.
