### PR TITLE
chore(docs): serve the Studio demo video from the Pulsar assets CDN

### DIFF
--- a/docs/src/components/landing/StudioSection/StudioSection.tsx
+++ b/docs/src/components/landing/StudioSection/StudioSection.tsx
@@ -27,7 +27,7 @@ function StudioPreview() {
       <div className={styles.previewBody}>
         <video
           className={styles.video}
-          src="https://xhxogbcwlfdzhbojhtwe.supabase.co/storage/v1/object/public/pulsar_docs/Pulsar%20Studio.mp4"
+          src="https://assets.puslar.swmansion.com/media/Pulsar_Studio.mp4"
           poster={`${BASE_PATH}/assets/pulsar-demo-poster.jpg`}
           controls
           autoPlay

--- a/docs/src/components/studio/StudioDemo/StudioDemo.tsx
+++ b/docs/src/components/studio/StudioDemo/StudioDemo.tsx
@@ -69,7 +69,7 @@ export function StudioDemo() {
               <video
                 ref={videoRef}
                 className={styles.video}
-                src="https://xhxogbcwlfdzhbojhtwe.supabase.co/storage/v1/object/public/pulsar_docs/Pulsar%20Studio.mp4"
+                src="https://assets.puslar.swmansion.com/media/Pulsar_Studio.mp4"
                 poster={`${BASE_PATH}/assets/pulsar-demo-poster.jpg`}
                 controls
                 loop


### PR DESCRIPTION
The Studio showcase clip moved off the public Supabase storage bucket to the Pulsar assets CDN.

- `https://assets.puslar.swmansion.com/media/Pulsar_Studio.mp4` replaces the old `xhxogbcwlfdzhbojhtwe.supabase.co/.../pulsar_docs/Pulsar%20Studio.mp4` in both places it was used: the landing page's `StudioSection` and the Studio docs' `StudioDemo`.

Verified the new URL serves `video/mp4` and answers range requests (206).