### PR TITLE
feat(lottie): unify the haptics API and accept a bundle preset on every SDK

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/bundle/BundleLoader.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/bundle/BundleLoader.kt
@@ -50,10 +50,11 @@ internal object BundleLoaderImpl {
 
             handles[preset.id] = PresetHandle(
                 id = preset.id,
+                name = preset.name,
                 duration = (preset.duration ?: 0.0).toLong(),
                 animation = animation,
-                haptics = haptics,
                 pattern = pattern,
+                haptics = haptics,
                 sound = sound,
             )
         }

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/bundle/PulsarBundle.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/bundle/PulsarBundle.kt
@@ -15,12 +15,24 @@ class BundleAnimation internal constructor(
 /** A single playable preset from a loaded bundle. Parses its pattern lazily on first play. */
 class PresetHandle internal constructor(
     val id: String,
+    /** Human label the preset was authored under. */
+    val name: String,
     val duration: Long,
     val animation: BundleAnimation?,
+    /**
+     * The authored pattern. Read it to drive a timeline yourself — the Lottie SDK samples it per
+     * frame in realtime mode. [play] stays the pre-parsed, engine-native route.
+     */
+    val pattern: PatternData,
     private val haptics: Pulsar,
-    private val pattern: PatternData,
     private val sound: SoundData?,
 ) {
+    /** Whether the preset carries a synced audio track, which [play] plays alongside the haptics. */
+    val hasAudio: Boolean get() = sound != null
+
+    /** Whether the preset carries a Lottie animation, exposed as [animation]. */
+    val hasAnimation: Boolean get() = animation != null
+
     private var composer: PatternComposer? = null
 
     private fun ensureParsed() {

--- a/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/BundlesScreen.kt
+++ b/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/BundlesScreen.kt
@@ -3,18 +3,23 @@ package com.swmansion.pulsarapp.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.swmansion.pulsar.Pulsar
 import com.swmansion.pulsar.bundle.PresetHandle
+import com.swmansion.pulsar.lottie.HapticLottieController
+import com.swmansion.pulsar.lottie.HapticLottieView
 import com.swmansion.pulsarapp.bundles.HapticsBundle
 
 /**
@@ -54,16 +59,34 @@ fun BundlesScreen(pulsar: Pulsar?) {
         // Carries Lottie bytes: Pulsar times them, the app renders them.
         PresetButton("Lottie", bundle.lottie)
 
-        val animation = bundle.lottie.animation
+        Text("Animation from a preset", fontSize = 18.sp)
         Text(
-            if (animation != null) {
-                "The Lottie preset also carries ${animation.data.size} bytes of animation at " +
-                    "${animation.frameRate} fps — hand them to your own Lottie view."
-            } else {
-                "This build carries no animation bytes for the Lottie preset."
-            },
-            fontSize = 12.sp,
+            "The Lottie preset carries its animation as well as its pattern, so HapticLottieView " +
+                "needs neither an animation nor a haptics argument.",
+            fontSize = 14.sp,
         )
+
+        val controllerRef = remember { arrayOfNulls<HapticLottieController>(1) }
+        AndroidView(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp),
+            factory = { ctx ->
+                HapticLottieView(ctx).apply {
+                    repeatCount = 0
+                    if (pulsar != null) {
+                        controllerRef[0] = bindHaptics(pulsar, preset = bundle.lottie)
+                            .also { it.play() }
+                    }
+                }
+            },
+        )
+        OutlinedButton(
+            onClick = { controllerRef[0]?.play() },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("▶ Replay animation")
+        }
 
         Text(
             "Ids are also reachable at runtime: ${HapticsBundle.descriptor.presetIds.joinToString()}",

--- a/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/LottieHapticsScreen.kt
+++ b/Android/PulsarApp/app/src/main/java/com/swmansion/pulsarapp/screens/LottieHapticsScreen.kt
@@ -58,7 +58,7 @@ fun LottieHapticsScreen(pulsar: Pulsar?) {
                     setAnimation(R.raw.verified)
                     repeatCount = 0
                     if (pulsar != null) {
-                        val controller = setHaptics(pulsar, pattern)
+                        val controller = bindHaptics(pulsar, haptics = pattern)
                         controllerRef[0] = controller
                         controller.play()
                     } else {

--- a/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieController.kt
+++ b/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieController.kt
@@ -34,10 +34,9 @@ enum class HapticMode {
  * animator (the per-frame clock) and samples the pattern; in [HapticMode.PATTERN]
  * it fires a pre-parsed pattern aligned to the start.
  *
- * Pass a bundle [preset] to take its pattern and authored duration, or [haptics] for
- * a pattern of your own — an explicit [haptics] wins. A preset that carries audio plays
- * through its own handle, which needs [HapticMode.PATTERN], so [hapticMode] defaults to
- * `PATTERN` for one; pass it yourself to override.
+ * A bundle [preset] supplies the pattern and authored duration; an explicit [haptics]
+ * overrides it. [hapticMode] defaults to [HapticMode.REALTIME], or to [HapticMode.PATTERN]
+ * for a preset carrying audio, which only sounds there.
  *
  * Call [release] when done to detach the animator listener and stop haptics.
  */
@@ -52,8 +51,8 @@ class HapticLottieController @JvmOverloads constructor(
     durationMs: Long? = null,
 ) {
     private val pattern: PatternData? = haptics ?: preset?.pattern
-    private val playsItself = haptics == null && preset?.hasAudio == true
-    private val mode = hapticMode ?: if (playsItself) HapticMode.PATTERN else HapticMode.REALTIME
+    private val playsOwnAudio = haptics == null && preset?.hasAudio == true
+    private val mode = hapticMode ?: if (playsOwnAudio) HapticMode.PATTERN else HapticMode.REALTIME
 
     private val useRealtime = mode == HapticMode.REALTIME && pattern != null
     private val hasContinuous = pattern != null &&
@@ -63,11 +62,10 @@ class HapticLottieController @JvmOverloads constructor(
     private val realtime: RealtimeComposer? =
         if (useRealtime) pulsar.getRealtimeComposer() else null
 
-    /** Set when the preset plays itself, so the audio it was authored with plays too. */
-    private val presetPlayback: PresetHandle? = if (!useRealtime && playsItself) preset else null
+    private val audioPreset: PresetHandle? = if (!useRealtime && playsOwnAudio) preset else null
 
     private val composer: PatternComposer? =
-        if (!useRealtime && !playsItself && pattern != null) {
+        if (!useRealtime && !playsOwnAudio && pattern != null) {
             // Pre-parse so the engine is warm and play() fires without delay.
             pulsar.getPatternComposer().apply { parsePattern(pattern) }
         } else {
@@ -124,7 +122,7 @@ class HapticLottieController @JvmOverloads constructor(
         if (!hapticsEnabled) return
         when {
             useRealtime -> lastT = 0L
-            presetPlayback != null -> presetPlayback.play()
+            audioPreset != null -> audioPreset.play()
             else -> composer?.play()
         }
     }
@@ -135,7 +133,7 @@ class HapticLottieController @JvmOverloads constructor(
                 lastT = 0L
                 if (hasContinuous) realtime?.stop()
             }
-            presetPlayback != null -> presetPlayback.stop()
+            audioPreset != null -> audioPreset.stop()
             else -> composer?.stop()
         }
     }

--- a/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieController.kt
+++ b/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieController.kt
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieDrawable
 import com.swmansion.pulsar.Pulsar
+import com.swmansion.pulsar.bundle.PresetHandle
 import com.swmansion.pulsar.composers.PatternComposer
 import com.swmansion.pulsar.composers.RealtimeComposer
 import com.swmansion.pulsar.types.PatternData
@@ -33,32 +34,55 @@ enum class HapticMode {
  * animator (the per-frame clock) and samples the pattern; in [HapticMode.PATTERN]
  * it fires a pre-parsed pattern aligned to the start.
  *
+ * Pass a bundle [preset] to take its pattern and authored duration, or [haptics] for
+ * a pattern of your own — an explicit [haptics] wins. A preset that carries audio plays
+ * through its own handle, which needs [HapticMode.PATTERN], so [hapticMode] defaults to
+ * `PATTERN` for one; pass it yourself to override.
+ *
  * Call [release] when done to detach the animator listener and stop haptics.
  */
 class HapticLottieController @JvmOverloads constructor(
     private val lottieView: LottieAnimationView,
     pulsar: Pulsar,
-    private val haptics: PatternData? = null,
-    private val mode: HapticMode = HapticMode.REALTIME,
-    private val offsetMs: Long = 0L,
-    private val enabled: Boolean = true,
+    preset: PresetHandle? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    private val hapticOffset: Long = 0L,
+    private val hapticsEnabled: Boolean = true,
+    durationMs: Long? = null,
 ) {
-    private val useRealtime = mode == HapticMode.REALTIME && haptics != null
-    private val hasContinuous = haptics != null &&
-        haptics.continuousPattern.amplitude.isNotEmpty() &&
-        haptics.continuousPattern.frequency.isNotEmpty()
+    private val pattern: PatternData? = haptics ?: preset?.pattern
+    private val playsItself = haptics == null && preset?.hasAudio == true
+    private val mode = hapticMode ?: if (playsItself) HapticMode.PATTERN else HapticMode.REALTIME
+
+    private val useRealtime = mode == HapticMode.REALTIME && pattern != null
+    private val hasContinuous = pattern != null &&
+        pattern.continuousPattern.amplitude.isNotEmpty() &&
+        pattern.continuousPattern.frequency.isNotEmpty()
 
     private val realtime: RealtimeComposer? =
         if (useRealtime) pulsar.getRealtimeComposer() else null
-    private val pattern: PatternComposer? =
-        if (!useRealtime && haptics != null) {
+
+    /** Set when the preset plays itself, so the audio it was authored with plays too. */
+    private val presetPlayback: PresetHandle? = if (!useRealtime && playsItself) preset else null
+
+    private val composer: PatternComposer? =
+        if (!useRealtime && !playsItself && pattern != null) {
             // Pre-parse so the engine is warm and play() fires without delay.
-            pulsar.getPatternComposer().apply { parsePattern(haptics) }
+            pulsar.getPatternComposer().apply { parsePattern(pattern) }
         } else {
             null
         }
 
-    private var durationMs: Long = haptics?.let { patternDurationMs(it) } ?: 0L
+    /**
+     * Clock length in ms: an explicit duration, else the preset's authored one, else the
+     * Lottie composition once loaded, else the pattern's own length.
+     */
+    private val fixedDurationMs: Long? =
+        durationMs?.takeIf { it > 0L } ?: preset?.duration?.takeIf { it > 0L }
+    private var resolvedDurationMs: Long = fixedDurationMs
+        ?: pattern?.let { patternDurationMs(it) }
+        ?: 0L
     private var lastT: Long = 0L
 
     private val updateListener = ValueAnimator.AnimatorUpdateListener { anim ->
@@ -66,27 +90,29 @@ class HapticLottieController @JvmOverloads constructor(
     }
 
     init {
-        if (haptics != null && enabled) {
-            lottieView.addLottieOnCompositionLoadedListener { composition ->
-                durationMs = composition.duration.toLong()
+        if (pattern != null && hapticsEnabled) {
+            if (fixedDurationMs == null) {
+                lottieView.addLottieOnCompositionLoadedListener { composition ->
+                    resolvedDurationMs = composition.duration.toLong()
+                }
             }
             if (useRealtime) lottieView.addAnimatorUpdateListener(updateListener)
         }
     }
 
     private fun onTick(fraction: Float) {
-        if (!enabled || !useRealtime || haptics == null) return
-        val t = (fraction * durationMs).toLong()
-        val ht = t + offsetMs
+        if (!hapticsEnabled || !useRealtime || pattern == null) return
+        val t = (fraction * resolvedDurationMs).toLong()
+        val ht = t + hapticOffset
         if (hasContinuous) {
             realtime?.set(
-                clamp01(sampleEnvelope(haptics.continuousPattern.amplitude, ht)),
-                clamp01(sampleEnvelope(haptics.continuousPattern.frequency, ht)),
+                clamp01(sampleEnvelope(pattern.continuousPattern.amplitude, ht)),
+                clamp01(sampleEnvelope(pattern.continuousPattern.frequency, ht)),
             )
         }
         var prev = lastT
         if (t < prev) prev = 0L // wrapped on loop
-        for (e in haptics.discretePattern) {
+        for (e in pattern.discretePattern) {
             if (e.time > prev && e.time <= t) {
                 realtime?.playDiscrete(clamp01(e.amplitude), clamp01(e.frequency))
             }
@@ -95,16 +121,22 @@ class HapticLottieController @JvmOverloads constructor(
     }
 
     private fun fireHaptics() {
-        if (!enabled || haptics == null) return
-        if (useRealtime) lastT = 0L else pattern?.play()
+        if (!hapticsEnabled) return
+        when {
+            useRealtime -> lastT = 0L
+            presetPlayback != null -> presetPlayback.play()
+            else -> composer?.play()
+        }
     }
 
     private fun stopHaptics() {
-        if (useRealtime) {
-            lastT = 0L
-            if (hasContinuous) realtime?.stop()
-        } else {
-            pattern?.stop()
+        when {
+            useRealtime -> {
+                lastT = 0L
+                if (hasContinuous) realtime?.stop()
+            }
+            presetPlayback != null -> presetPlayback.stop()
+            else -> composer?.stop()
         }
     }
 
@@ -140,7 +172,9 @@ class HapticLottieController @JvmOverloads constructor(
 
     /** Seek both animation and haptics to [ms] from the start. */
     fun setTimestamp(ms: Long) {
-        if (durationMs > 0L) lottieView.progress = clamp01(ms.toFloat() / durationMs)
+        if (resolvedDurationMs > 0L) {
+            lottieView.progress = clamp01(ms.toFloat() / resolvedDurationMs)
+        }
         lastT = ms
     }
 
@@ -165,12 +199,26 @@ class HapticLottieController @JvmOverloads constructor(
  * Attach Pulsar haptics to this [LottieAnimationView] without swapping the view.
  * Returns a [HapticLottieController] you drive; call [HapticLottieController.release]
  * when done.
+ *
+ * This binds haptics only — the view keeps whatever animation you gave it. Use
+ * [HapticLottieView.bindHaptics] to have a bundle [preset]'s Lottie rendered for you.
  */
 @JvmOverloads
 fun LottieAnimationView.bindHaptics(
     pulsar: Pulsar,
-    haptics: PatternData,
-    mode: HapticMode = HapticMode.REALTIME,
-    offsetMs: Long = 0L,
-    enabled: Boolean = true,
-): HapticLottieController = HapticLottieController(this, pulsar, haptics, mode, offsetMs, enabled)
+    preset: PresetHandle? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    hapticOffset: Long = 0L,
+    hapticsEnabled: Boolean = true,
+    durationMs: Long? = null,
+): HapticLottieController = HapticLottieController(
+    this,
+    pulsar,
+    preset,
+    haptics,
+    hapticMode,
+    hapticOffset,
+    hapticsEnabled,
+    durationMs,
+)

--- a/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieView.kt
+++ b/Android/PulsarLottie/src/main/java/com/swmansion/pulsar/lottie/HapticLottieView.kt
@@ -4,13 +4,15 @@ import android.content.Context
 import android.util.AttributeSet
 import com.airbnb.lottie.LottieAnimationView
 import com.swmansion.pulsar.Pulsar
+import com.swmansion.pulsar.bundle.PresetHandle
 import com.swmansion.pulsar.types.PatternData
 
 /**
  * A [LottieAnimationView] subclass that plays Pulsar haptics in sync.
  *
- * A drop-in replacement for `LottieAnimationView`: with no haptics set it
- * behaves identically. Call [setHaptics] to attach a pattern and drive transport
+ * A drop-in replacement for `LottieAnimationView`: with no haptics bound it
+ * behaves identically. Call [bindHaptics] to attach a pattern — or a whole bundle
+ * preset, whose Lottie animation this view renders for you — and drive transport
  * through the returned [HapticLottieController].
  */
 class HapticLottieView @JvmOverloads constructor(
@@ -21,20 +23,40 @@ class HapticLottieView @JvmOverloads constructor(
 
     private var controller: HapticLottieController? = null
 
-    /** Attach [haptics] and return the controller that steers animation + haptics. */
+    /**
+     * Bind haptics and return the controller that steers animation + haptics.
+     *
+     * A bundle [preset] supplies all three of the animation, the pattern and the
+     * authored duration; each is still overridable on its own. An explicit [haptics]
+     * wins over the preset's pattern, and an animation already set on this view is
+     * kept rather than replaced.
+     */
     @JvmOverloads
-    fun setHaptics(
+    fun bindHaptics(
         pulsar: Pulsar,
-        haptics: PatternData,
-        mode: HapticMode = HapticMode.REALTIME,
-        offsetMs: Long = 0L,
-        enabled: Boolean = true,
+        preset: PresetHandle? = null,
+        haptics: PatternData? = null,
+        hapticMode: HapticMode? = null,
+        hapticOffset: Long = 0L,
+        hapticsEnabled: Boolean = true,
+        durationMs: Long? = null,
     ): HapticLottieController {
         controller?.release()
-        return HapticLottieController(this, pulsar, haptics, mode, offsetMs, enabled)
-            .also { controller = it }
+        preset?.animation?.let { animation ->
+            if (composition == null) setAnimation(animation.data.inputStream(), preset.id)
+        }
+        return HapticLottieController(
+            this,
+            pulsar,
+            preset,
+            haptics,
+            hapticMode,
+            hapticOffset,
+            hapticsEnabled,
+            durationMs,
+        ).also { controller = it }
     }
 
-    /** The current controller, or `null` if [setHaptics] hasn't been called. */
+    /** The current controller, or `null` if [bindHaptics] hasn't been called. */
     fun hapticController(): HapticLottieController? = controller
 }

--- a/docs/src/content/docs/lottie/android.mdx
+++ b/docs/src/content/docs/lottie/android.mdx
@@ -124,7 +124,7 @@ val view = HapticLottieView(context).apply {
   setAnimation(R.raw.success)
   repeatCount = 0
 }
-val controller = view.setHaptics(pulsar, pattern)
+val controller = view.bindHaptics(pulsar, haptics = pattern)
 controller.play()
 ```
 
@@ -142,8 +142,8 @@ In XML it is used exactly like `LottieAnimationView`:
 
 | Method | Description |
 | --- | --- |
-| `setHaptics(pulsar, haptics, mode, offsetMs, enabled)` | Attach a pattern and return the [`HapticLottieController`](#hapticlottiecontroller) that steers animation and haptics. Releases any previously attached controller. |
-| `hapticController()` | The current controller, or `null` before `setHaptics` is called. |
+| `bindHaptics(pulsar, preset, haptics, hapticMode, hapticOffset, hapticsEnabled, durationMs)` | Bind haptics and return the [`HapticLottieController`](#hapticlottiecontroller) that steers animation and haptics. Renders a `preset`'s own animation when the view has none. Releases any previously bound controller. |
+| `hapticController()` | The current controller, or `null` before `bindHaptics` is called. |
 
 Every `LottieAnimationView` member — `setAnimation`, `progress`, `repeatCount`, `playAnimation` and the rest — is still available. Drive playback through the returned controller so the haptics stay in step.
 
@@ -162,7 +162,7 @@ fun SuccessBadge(pulsar: Pulsar, pattern: PatternData) {
       HapticLottieView(ctx).apply {
         setAnimation(R.raw.success)
         repeatCount = 0
-        controller[0] = setHaptics(pulsar, pattern).also { it.play() }
+        controller[0] = bindHaptics(pulsar, haptics = pattern).also { it.play() }
       }
     },
   )
@@ -182,7 +182,7 @@ Attaches haptics to a `LottieAnimationView` without swapping the view, and becom
 ```kotlin
 import com.swmansion.pulsar.lottie.bindHaptics
 
-val controller = animationView.bindHaptics(pulsar, pattern)
+val controller = animationView.bindHaptics(pulsar, haptics = pattern)
 
 controller.play()
 controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
@@ -190,18 +190,22 @@ controller.pause()
 controller.release()          // when the view goes away
 ```
 
-`bindHaptics` is an extension on `LottieAnimationView` and a convenience over the constructor. Construct the controller directly when the pattern is optional:
+`bindHaptics` is an extension on `LottieAnimationView` and a convenience over the constructor. Construct the controller directly to spell every argument out:
 
 ```kotlin
 val controller = HapticLottieController(
   lottieView = animationView,
   pulsar = pulsar,
-  haptics = pattern,          // optional — null plays the animation alone
-  mode = HapticMode.REALTIME,
-  offsetMs = 0L,
-  enabled = true,
+  preset = pack.celebration,  // optional — supplies the pattern and duration
+  haptics = pattern,          // optional — overrides the preset's pattern
+  hapticMode = HapticMode.REALTIME,
+  hapticOffset = 0L,
+  hapticsEnabled = true,
+  durationMs = null,
 )
 ```
+
+The extension binds haptics only: the view keeps whatever animation you gave it. Use [`HapticLottieView.bindHaptics`](#hapticlottieview) to have a preset's Lottie rendered for you.
 
 ### Parameters
 
@@ -209,10 +213,12 @@ val controller = HapticLottieController(
 | --- | --- | --- | --- |
 | `lottieView` | `LottieAnimationView` | – | The view to drive. |
 | `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. `null` leaves the animation without haptics. |
-| `mode` | `HapticMode` | `REALTIME` | Engine mode — see [Engine modes](#engine-modes). |
-| `offsetMs` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `enabled` | `Boolean` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; `null` with no preset leaves the animation without haptics. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `Boolean` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `durationMs` | `Long?` | derived | Clock length in ms. Overrides every derived duration. |
 
 In `PATTERN` mode the pattern is parsed in the constructor, so the engine is warm and the first `play()` fires without the usual first-play latency.
 
@@ -250,6 +256,8 @@ enum class HapticMode { REALTIME, PATTERN }
 
 Passing `REALTIME` without a pattern falls back to the pattern-mode path, because there is nothing to sample.
 
+`hapticMode` is nullable: leave it out and the mode is `REALTIME`, except for a `preset` that carries audio, which starts in `PATTERN` so that audio plays. Passing a mode always wins.
+
 Unlike iOS, the animation always plays through the view's own animator in both modes — realtime only *observes* it. Anything that moves the view's `progress`, including your own `playAnimation()` calls, keeps the haptics aligned.
 
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
@@ -258,17 +266,39 @@ See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for 
 
 ## Bundle presets
 
-A preset from a `.pulsar` bundle carries the Lottie bytes it was authored against, on `PresetHandle.animation`:
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset to `HapticLottieView` and it takes both — no `setAnimation`, no `haptics`:
+
+```kotlin
+val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
+
+val view = HapticLottieView(context)
+val controller = view.bindHaptics(pulsar, preset = bundle.celebration)
+controller.play()
+```
+
+The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `PATTERN` mode.
+
+`PresetHandle` exposes all of it, so you can also render into a view of your own — the `bindHaptics` extension never touches the animation:
 
 ```kotlin
 val animation = preset.animation
 if (animation != null) {
-  view.setAnimation(animation.data.inputStream(), preset.id)
+  animationView.setAnimation(animation.data.inputStream(), preset.id)
   // animation.frameRate and animation.totalFrames describe the authored timing
 }
+val controller = animationView.bindHaptics(pulsar, preset = preset)
 ```
 
-`PresetHandle` plays its own haptics through `play()` and `stop()`, which is the aligned-start `PATTERN` behaviour. It does not expose its `PatternData`, so a bundle preset cannot currently drive `HapticLottieController` in `REALTIME` mode — pass the pattern yourself when you need per-frame sync.
+| Member | Type | Description |
+| --- | --- | --- |
+| `id` / `name` | `String` | Code-safe id, and the human label it was authored under. |
+| `duration` | `Long` | Authored length in ms, or `0` when the bundle carries no hint. |
+| `pattern` | `PatternData` | The authored pattern — what `REALTIME` samples. |
+| `animation` | `BundleAnimation?` | Lottie `data`, `frameRate` and `totalFrames`. |
+| `hasAudio` / `hasAnimation` | `Boolean` | What the preset was authored with. |
+| `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
+
+`HapticLottieView.bindHaptics` only sets the preset's animation when the view has none, so an animation you set yourself is never replaced.
 
 ---
 

--- a/docs/src/content/docs/lottie/android.mdx
+++ b/docs/src/content/docs/lottie/android.mdx
@@ -38,11 +38,9 @@ head:
       content: https://docs.swmansion.com/pulsar/og.png
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 `pulsar-lottie` plays a Pulsar haptic pattern locked to a Lottie animation on Android. It exposes two entry points: `HapticLottieView`, a drop-in `LottieAnimationView` subclass, and `HapticLottieController`, which attaches to a `LottieAnimationView` you already have.
 
-Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes, timing rules and emulator notes this page assumes.
 
 ## Requirements
 
@@ -93,39 +91,19 @@ Without `android.permission.VIBRATE`, Android blocks vibration playback. Pulsar 
 
 ## HapticLottieView
 
-A `LottieAnimationView` subclass that plays haptics in sync. With no haptics set it behaves exactly like `LottieAnimationView`, so it is safe to swap in.
+A `LottieAnimationView` subclass that plays Pulsar haptics in sync. With no haptics bound it behaves identically, so it is a drop-in replacement.
 
 ```kotlin
-import com.swmansion.pulsar.Pulsar
-import com.swmansion.pulsar.lottie.HapticLottieView
-import com.swmansion.pulsar.types.ContinuousPattern
-import com.swmansion.pulsar.types.ConfigPoint
-import com.swmansion.pulsar.types.PatternData
-import com.swmansion.pulsar.types.ValuePoint
-
 val pattern = PatternData(
   continuousPattern = ContinuousPattern(
-    amplitude = listOf(
-      ValuePoint(time = 0, value = 0f),
-      ValuePoint(time = 400, value = 1f),
-      ValuePoint(time = 800, value = 0f),
-    ),
-    frequency = listOf(
-      ValuePoint(time = 0, value = 0.3f),
-      ValuePoint(time = 800, value = 0.8f),
-    ),
+    amplitude = listOf(ValuePoint(time = 0, value = 0f), ValuePoint(time = 800, value = 1f)),
+    frequency = listOf(ValuePoint(time = 0, value = 0.3f)),
   ),
-  discretePattern = listOf(
-    ConfigPoint(time = 0, amplitude = 1f, frequency = 0.5f),
-  ),
+  discretePattern = listOf(ConfigPoint(time = 0, amplitude = 1f, frequency = 0.5f)),
 )
 
-val view = HapticLottieView(context).apply {
-  setAnimation(R.raw.success)
-  repeatCount = 0
-}
-val controller = view.bindHaptics(pulsar, haptics = pattern)
-controller.play()
+val view = HapticLottieView(context).apply { setAnimation(R.raw.success) }
+view.bindHaptics(pulsar, haptics = pattern).play()
 ```
 
 In XML it is used exactly like `LottieAnimationView`:
@@ -138,14 +116,29 @@ In XML it is used exactly like `LottieAnimationView`:
     app:lottie_rawRes="@raw/success" />
 ```
 
+### From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `setAnimation`, no `haptics`:
+
+```kotlin
+val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
+
+val view = HapticLottieView(context)
+view.bindHaptics(pulsar, preset = bundle.celebration).play()
+```
+
+The preset supplies the animation, `haptics` from its `pattern`, and `durationMs` from its authored length — each still overridable on its own. One that carries audio plays that audio too, which is why it starts in `PATTERN` mode. See [bundle presets](/pulsar/lottie/overview/#bundle-presets).
+
+`bindHaptics` only sets the preset's animation when the view has none, so an animation you set yourself is never replaced.
+
 ### Methods
 
 | Method | Description |
 | --- | --- |
-| `bindHaptics(pulsar, preset, haptics, hapticMode, hapticOffset, hapticsEnabled, durationMs)` | Bind haptics and return the [`HapticLottieController`](#hapticlottiecontroller) that steers animation and haptics. Renders a `preset`'s own animation when the view has none. Releases any previously bound controller. |
+| `bindHaptics(pulsar, preset, haptics, hapticMode, hapticOffset, hapticsEnabled, durationMs)` | Bind haptics and return the [`HapticLottieController`](#hapticlottiecontroller). Releases any previously bound controller. |
 | `hapticController()` | The current controller, or `null` before `bindHaptics` is called. |
 
-Every `LottieAnimationView` member — `setAnimation`, `progress`, `repeatCount`, `playAnimation` and the rest — is still available. Drive playback through the returned controller so the haptics stay in step.
+Every `LottieAnimationView` member — `setAnimation`, `progress`, `repeatCount`, `playAnimation` — is still available. Drive playback through the returned controller so the haptics stay in step.
 
 ### From Compose
 
@@ -153,23 +146,19 @@ Wrap the view with `AndroidView` and keep the controller across recompositions:
 
 ```kotlin
 @Composable
-fun SuccessBadge(pulsar: Pulsar, pattern: PatternData) {
+fun Celebration(pulsar: Pulsar, preset: PresetHandle) {
   val controller = remember { arrayOfNulls<HapticLottieController>(1) }
 
   AndroidView(
     modifier = Modifier.size(220.dp),
     factory = { ctx ->
       HapticLottieView(ctx).apply {
-        setAnimation(R.raw.success)
-        repeatCount = 0
-        controller[0] = bindHaptics(pulsar, haptics = pattern).also { it.play() }
+        controller[0] = bindHaptics(pulsar, preset = preset).also { it.play() }
       }
     },
   )
 
-  DisposableEffect(Unit) {
-    onDispose { controller[0]?.release() }
-  }
+  DisposableEffect(Unit) { onDispose { controller[0]?.release() } }
 }
 ```
 
@@ -177,12 +166,12 @@ fun SuccessBadge(pulsar: Pulsar, pattern: PatternData) {
 
 ## HapticLottieController
 
-Attaches haptics to a `LottieAnimationView` without swapping the view, and becomes the transport for both.
+Attaches haptics to a `LottieAnimationView` without swapping the view, and becomes the transport for both. The extension binds haptics only — the view keeps whatever animation you gave it.
 
 ```kotlin
 import com.swmansion.pulsar.lottie.bindHaptics
 
-val controller = animationView.bindHaptics(pulsar, haptics = pattern)
+val controller = animationView.bindHaptics(pulsar, preset = bundle.celebration)
 
 controller.play()
 controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
@@ -190,102 +179,28 @@ controller.pause()
 controller.release()          // when the view goes away
 ```
 
-`bindHaptics` is an extension on `LottieAnimationView` and a convenience over the constructor. Construct the controller directly to spell every argument out:
-
-```kotlin
-val controller = HapticLottieController(
-  lottieView = animationView,
-  pulsar = pulsar,
-  preset = pack.celebration,  // optional — supplies the pattern and duration
-  haptics = pattern,          // optional — overrides the preset's pattern
-  hapticMode = HapticMode.REALTIME,
-  hapticOffset = 0L,
-  hapticsEnabled = true,
-  durationMs = null,
-)
-```
-
-The extension binds haptics only: the view keeps whatever animation you gave it. Use [`HapticLottieView.bindHaptics`](#hapticlottieview) to have a preset's Lottie rendered for you.
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `lottieView` | `LottieAnimationView` | – | The view to drive. |
-| `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; `null` with no preset leaves the animation without haptics. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
-| `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `hapticsEnabled` | `Boolean` | `true` | When `false`, the animation plays and no haptics are emitted. |
-| `durationMs` | `Long?` | derived | Clock length in ms. Overrides every derived duration. |
-
-In `PATTERN` mode the pattern is parsed in the constructor, so the engine is warm and the first `play()` fires without the usual first-play latency.
-
-### Transport
+`bindHaptics` is a convenience over the constructor, which takes the same arguments — `preset`, `haptics`, `hapticMode`, `hapticOffset`, `hapticsEnabled`, `durationMs` — plus `lottieView` and `pulsar`.
 
 | Method | Description |
 | --- | --- |
 | `play()` | Rewind to the start and play animation and haptics together. |
 | `pause()` | Pause both. In `PATTERN` mode the haptic stops rather than suspending. |
 | `resume()` | Resume from the current position. |
-| `stop()` | Cancel the animation, rewind to the start, stop the haptics. |
-| `reset()` | Alias of `stop()`. |
-| `setTimestamp(ms: Long)` | Seek both animation and haptics to `ms` from the start. |
+| `stop()` / `reset()` | Stop and rewind to the start. |
+| `setTimestamp(ms: Long)` | Seek both to `ms` from the start. |
 | `setLoop(loop: Boolean, count: Int, reverse: Boolean)` | Loop the animation. `count` defaults to `LottieDrawable.INFINITE`; `reverse` plays a boomerang. |
 | `release()` | Detach the animator listener and stop the haptics. |
 
-<Aside type="caution" title="Always release">
-  `release()` removes the animator update listener the controller installed on the view and stops any running haptics. Call it from `onDestroyView`, `onDispose`, or wherever the view's lifetime ends — a controller left attached keeps sampling while the view animates.
-</Aside>
-
-### Duration
-
-The controller reads the composition duration from `addLottieOnCompositionLoadedListener`, so it is exact as soon as the animation has loaded. Until then it falls back to the pattern's own length. `setTimestamp(ms)` before the composition loads therefore maps against the pattern length rather than the animation's — seek after the animation is ready.
+Unlike iOS, the animation always plays through the view's own animator in both modes — realtime only *observes* it, so anything that moves the view's `progress`, including your own `playAnimation()` calls, keeps the haptics aligned.
 
 ---
 
-## Engine modes
+## Reading a preset yourself
+
+`PresetHandle` carries everything the view reads, so you can render into a view of your own:
 
 ```kotlin
-enum class HapticMode { REALTIME, PATTERN }
-```
-
-- **`REALTIME`** (default) — the controller listens to the view's own animator, converts each update to milliseconds and samples the pattern into `RealtimeComposer.set` and `playDiscrete`. Honours pause, seek and loop. Because Android re-drives the vibrator every frame, continuous fidelity is coarser here than on iOS.
-- **`PATTERN`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
-
-Passing `REALTIME` without a pattern falls back to the pattern-mode path, because there is nothing to sample.
-
-`hapticMode` is nullable: leave it out and the mode is `REALTIME`, except for a `preset` that carries audio, which starts in `PATTERN` so that audio plays. Passing a mode always wins.
-
-Unlike iOS, the animation always plays through the view's own animator in both modes — realtime only *observes* it. Anything that moves the view's `progress`, including your own `playAnimation()` calls, keeps the haptics aligned.
-
-See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
-
----
-
-## Bundle presets
-
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset to `HapticLottieView` and it takes both — no `setAnimation`, no `haptics`:
-
-```kotlin
-val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
-
-val view = HapticLottieView(context)
-val controller = view.bindHaptics(pulsar, preset = bundle.celebration)
-controller.play()
-```
-
-The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `PATTERN` mode.
-
-`PresetHandle` exposes all of it, so you can also render into a view of your own — the `bindHaptics` extension never touches the animation:
-
-```kotlin
-val animation = preset.animation
-if (animation != null) {
-  animationView.setAnimation(animation.data.inputStream(), preset.id)
-  // animation.frameRate and animation.totalFrames describe the authored timing
-}
+preset.animation?.let { animationView.setAnimation(it.data.inputStream(), preset.id) }
 val controller = animationView.bindHaptics(pulsar, preset = preset)
 ```
 
@@ -298,10 +213,4 @@ val controller = animationView.bindHaptics(pulsar, preset = preset)
 | `hasAudio` / `hasAnimation` | `Boolean` | What the preset was authored with. |
 | `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
 
-`HapticLottieView.bindHaptics` only sets the preset's animation when the view has none, so an animation you set yourself is never replaced.
-
----
-
-## Testing on the emulator
-
-Android emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).
+See the [Android SDK page](/pulsar/sdk/android/) for how bundles are loaded.

--- a/docs/src/content/docs/lottie/flutter.mdx
+++ b/docs/src/content/docs/lottie/flutter.mdx
@@ -44,7 +44,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 It is a pure-Dart package — no native halves of its own. Both the haptics and the rendering come from packages you already have: [`pulsar_haptics`](https://pub.dev/packages/pulsar_haptics) and [`lottie`](https://pub.dev/packages/lottie).
 
-Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes, timing rules and simulator notes this page assumes.
 
 ## Requirements
 
@@ -109,31 +109,40 @@ HapticLottie.asset(
   autoPlay: true,
   width: 200,
   height: 200,
-  onControllerCreated: (controller) => _haptic = controller,
 );
 ```
 
-`HapticLottie.network(url, ...)` takes the same arguments and loads the animation from a URL instead, and `HapticLottie.preset(preset, ...)` drops the `src` and renders a bundle preset's own animation — see [Bundle presets](#bundle-presets).
+`HapticLottie.network(url, ...)` takes the same arguments and loads from a URL instead.
+
+### From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the widget takes both — no `src`, no `haptics`:
+
+```dart
+final pack = await pulsar.loadBundleAsync(acmePack); // acmePack is generated
+
+HapticLottie.preset(pack.celebration, autoPlay: true, width: 200, height: 200);
+```
+
+The preset supplies the animation, `haptics` from its `pattern`, and `durationMs` from its authored length — each still overridable on its own. One that carries audio plays that audio too, which is why it starts in `pattern` mode. See [bundle presets](/pulsar/lottie/overview/#bundle-presets).
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `src` | `String` | – | Asset name or URL, passed positionally. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
+| `src` | `String` | – | Asset name or URL, passed positionally. Replaced by the preset in `HapticLottie.preset`. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the animation, pattern and duration. |
 | `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both for a plain animation. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticMode` | `HapticMode?` | derived | `realtime`, or `pattern` for a preset carrying audio. |
 | `hapticOffset` | `double` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `bool` | `true` | Turn haptics off without touching the animation. |
 | `durationMs` | `double?` | derived | Clock length in ms. Overrides every derived duration. |
 | `autoPlay` | `bool` | `false` | Start as soon as the animation loads. |
-| `repeat` | `bool` | `false` | Loop the animation, with `autoPlay`. |
-| `repeatCount` | `int?` | `null` | Limit the number of loops. `null` loops forever. |
-| `repeatReverse` | `bool` | `false` | Boomerang loop — forward, then reverse. |
+| `repeat` / `repeatCount` / `repeatReverse` | | | Looping, with `autoPlay`. |
 | `onControllerCreated` | `void Function(HapticLottieController)?` | `null` | Called once with the controller, so you can drive transport. |
 | `width` / `height` / `fit` / `alignment` | | | Forwarded to the underlying `Lottie` widget. |
 
-The widget sets the animation controller's duration from the loaded composition, disposes both the controller and the haptics on unmount, and — with `autoPlay` — starts either a single play or a loop depending on `repeat`.
+The widget sets the controller's duration from the loaded composition and disposes both it and the haptics on unmount.
 
 <Aside type="note" title="Grab the controller">
   The widget has no imperative handle of its own. Capture the `HapticLottieController` from `onControllerCreated` when you need to replay, pause or seek later.
@@ -150,95 +159,41 @@ final anim = AnimationController(vsync: this);
 
 final haptic = HapticLottieController(
   animationController: anim,
-  haptics: pattern,
+  preset: pack.celebration,
 );
 
-Lottie.asset(
-  'assets/success.json',
-  controller: anim,
-  onLoaded: (composition) => anim.duration = composition.duration,
-);
+Lottie.asset('assets/success.json', controller: anim,
+  onLoaded: (composition) => anim.duration = composition.duration);
 
-// transport steers both the animation and the haptics
 haptic.play();
 haptic.setTimestamp(1200);
 haptic.pause();
 ```
 
-### Parameters
-
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `animationController` | `AnimationController` | – | The clock this controller follows and steers. Owned by you. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; `null` with no preset leaves the animation without haptics. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode. `realtime`, or `pattern` for a preset that carries audio. |
-| `hapticOffset` | `double` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `hapticsEnabled` | `bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
-| `durationMs` | `double?` | `null` | Clock length in ms. Overrides every derived duration. |
-| `pulsar` | `Pulsar?` | `null` | Provide your own instance; one is created internally otherwise. |
-
-In `pattern` mode the pattern is pre-parsed at construction, so the engine is warm and the first `play()` fires without the usual first-play latency.
-
-### Transport
+It takes the same arguments as the widget — `preset`, `haptics`, `hapticMode`, `hapticOffset`, `hapticsEnabled`, `durationMs` — plus `animationController` and an optional `pulsar`.
 
 | Method | Description |
 | --- | --- |
 | `play()` | Rewind to the start and play animation and haptics together. |
 | `pause()` | Pause both. In `pattern` mode the haptic stops rather than suspending. |
 | `resume()` | Resume from the current position. |
-| `stop()` | Reset the animation to the start and stop the haptics. |
-| `reset()` | Same as `stop()`. |
-| `setTimestamp(double ms)` | Seek both animation and haptics to `ms` from the start. |
-| `setLoop(bool loop, {int? count, bool reverse})` | Loop the animation. `count` limits iterations (`null` loops forever); `reverse` plays a boomerang. |
-| `durationMsResolved` | Effective clock length: an explicit `durationMs`, else the preset's authored duration, else the composition duration once loaded, else the pattern's own length. |
-| `dispose()` | Detach from the animation and release the haptic resources. |
+| `stop()` / `reset()` | Reset the animation to the start and stop the haptics. |
+| `setTimestamp(double ms)` | Seek both to `ms` from the start. |
+| `setLoop(bool loop, {int? count, bool reverse})` | Loop the animation. In `pattern` mode the pattern fires once at the start, not per iteration. |
+| `durationMsResolved` | The clock length actually in use. |
+| `dispose()` | Detach and release the haptic resources. |
 
-The transport methods return `Future<void>` — `await` them when the ordering matters, ignore them otherwise.
+The transport methods return `Future<void>` — `await` them when ordering matters.
 
 <Aside type="caution" title="Dispose, but not the AnimationController">
-  `dispose()` removes the listener the controller installed and releases its composers. It deliberately does **not** dispose `animationController` — that one is yours, so dispose it yourself in `State.dispose`, after the haptic controller.
+  `dispose()` removes the listener and releases the composers. It deliberately does **not** dispose `animationController` — that one is yours, so dispose it in `State.dispose`, after the haptic controller.
 </Aside>
 
-In `pattern` mode `setLoop(true)` fires the pattern once at the start of the loop; it is not re-fired per iteration.
-
 ---
 
-## Engine modes
+## Reading a preset yourself
 
-```dart
-enum HapticMode { realtime, pattern }
-```
-
-- **`realtime`** (default) — the `AnimationController` is the master clock and the pattern is sampled every frame into `RealtimeComposer.set` and `playDiscrete`. Honours pause, `setTimestamp` and loop. Continuous fidelity is realtime-grade, and coarser on Android than on iOS.
-- **`pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
-
-Passing `realtime` without a pattern leaves the animation without haptics, because there is nothing to sample.
-
-`hapticMode` is nullable: leave it out and the mode is `realtime`, except for a `preset` that carries audio, which starts in `pattern` so that audio plays. Passing a mode always wins.
-
-See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
-
----
-
-## Bundle presets
-
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the widget takes both — no `src`, no `haptics`:
-
-```dart
-final bundle = await pulsar.loadBundleAsync(acmePack); // acmePack is generated
-
-HapticLottie.preset(
-  bundle.celebration,
-  autoPlay: true,
-  width: 200,
-  height: 200,
-);
-```
-
-The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `pattern` mode.
-
-`PresetHandle` exposes all of it, so you can also render it yourself and pass the preset to a `HapticLottieController`:
+`PresetHandle` carries everything the widget reads:
 
 | Member | Type | Description |
 | --- | --- | --- |
@@ -249,12 +204,6 @@ The preset fills in three things, each still overridable on its own: the animati
 | `hasAudio` / `hasAnimation` | `bool` | What the preset was authored with. |
 | `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
 
-The animation bytes cross the platform channel once, when the bundle loads. Pass `includeAnimations: false` to `loadBundleAsync` to skip that when nothing will render them.
+The animation bytes cross the platform channel once, when the bundle loads; pass `includeAnimations: false` to `loadBundleAsync` to skip that when nothing will render them. A preset with no animation renders an empty box.
 
-A preset with no animation renders an empty box — check `hasAnimation`, or use `HapticLottie.asset` and pass the preset alongside it.
-
----
-
-## Testing on simulators
-
-Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).
+See the [Flutter SDK page](/pulsar/sdk/flutter/) for how bundles are loaded.

--- a/docs/src/content/docs/lottie/flutter.mdx
+++ b/docs/src/content/docs/lottie/flutter.mdx
@@ -113,17 +113,19 @@ HapticLottie.asset(
 );
 ```
 
-`HapticLottie.network(url, ...)` takes the same arguments and loads the animation from a URL instead.
+`HapticLottie.network(url, ...)` takes the same arguments and loads the animation from a URL instead, and `HapticLottie.preset(preset, ...)` drops the `src` and renders a bundle preset's own animation — see [Bundle presets](#bundle-presets).
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | `src` | `String` | – | Asset name or URL, passed positionally. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. Omit for a plain animation. |
-| `mode` | `HapticMode` | `realtime` | Engine mode — see [Engine modes](#engine-modes). |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both for a plain animation. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
 | `hapticOffset` | `double` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `bool` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `double?` | derived | Clock length in ms. Overrides every derived duration. |
 | `autoPlay` | `bool` | `false` | Start as soon as the animation loads. |
 | `repeat` | `bool` | `false` | Loop the animation, with `autoPlay`. |
 | `repeatCount` | `int?` | `null` | Limit the number of loops. `null` loops forever. |
@@ -168,10 +170,12 @@ haptic.pause();
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | `animationController` | `AnimationController` | – | The clock this controller follows and steers. Owned by you. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. `null` leaves the animation without haptics. |
-| `mode` | `HapticMode` | `realtime` | Engine mode. |
-| `offsetMs` | `double` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `enabled` | `bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; `null` with no preset leaves the animation without haptics. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode. `realtime`, or `pattern` for a preset that carries audio. |
+| `hapticOffset` | `double` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `durationMs` | `double?` | `null` | Clock length in ms. Overrides every derived duration. |
 | `pulsar` | `Pulsar?` | `null` | Provide your own instance; one is created internally otherwise. |
 
 In `pattern` mode the pattern is pre-parsed at construction, so the engine is warm and the first `play()` fires without the usual first-play latency.
@@ -187,7 +191,7 @@ In `pattern` mode the pattern is pre-parsed at construction, so the engine is wa
 | `reset()` | Same as `stop()`. |
 | `setTimestamp(double ms)` | Seek both animation and haptics to `ms` from the start. |
 | `setLoop(bool loop, {int? count, bool reverse})` | Loop the animation. `count` limits iterations (`null` loops forever); `reverse` plays a boomerang. |
-| `durationMs` | Effective clock length: the composition duration once loaded, else the pattern's own length. |
+| `durationMsResolved` | Effective clock length: an explicit `durationMs`, else the preset's authored duration, else the composition duration once loaded, else the pattern's own length. |
 | `dispose()` | Detach from the animation and release the haptic resources. |
 
 The transport methods return `Future<void>` — `await` them when the ordering matters, ignore them otherwise.
@@ -211,7 +215,43 @@ enum HapticMode { realtime, pattern }
 
 Passing `realtime` without a pattern leaves the animation without haptics, because there is nothing to sample.
 
+`hapticMode` is nullable: leave it out and the mode is `realtime`, except for a `preset` that carries audio, which starts in `pattern` so that audio plays. Passing a mode always wins.
+
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Bundle presets
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the widget takes both — no `src`, no `haptics`:
+
+```dart
+final bundle = await pulsar.loadBundleAsync(acmePack); // acmePack is generated
+
+HapticLottie.preset(
+  bundle.celebration,
+  autoPlay: true,
+  width: 200,
+  height: 200,
+);
+```
+
+The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `pattern` mode.
+
+`PresetHandle` exposes all of it, so you can also render it yourself and pass the preset to a `HapticLottieController`:
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `id` / `name` | `String` | Code-safe id, and the human label it was authored under. |
+| `duration` | `double` | Authored length in ms, or `0` when the bundle carries no hint. |
+| `pattern` | `PatternData` | The authored pattern — what `realtime` samples. |
+| `animation` | `BundleAnimation?` | Lottie `data` (ready for `Lottie.memory`), `frameRate` and `totalFrames`. |
+| `hasAudio` / `hasAnimation` | `bool` | What the preset was authored with. |
+| `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
+
+The animation bytes cross the platform channel once, when the bundle loads. Pass `includeAnimations: false` to `loadBundleAsync` to skip that when nothing will render them.
+
+A preset with no animation renders an empty box — check `hasAnimation`, or use `HapticLottie.asset` and pass the preset alongside it.
 
 ---
 

--- a/docs/src/content/docs/lottie/ios.mdx
+++ b/docs/src/content/docs/lottie/ios.mdx
@@ -118,12 +118,16 @@ struct SuccessBadge: View {
 | --- | --- | --- | --- |
 | `name` | `String` | – | Name of the Lottie animation to load, passed positionally. |
 | `bundle` | `Bundle` | `.main` | Bundle the animation is loaded from. |
+| `preset` | `PresetHandle?` | `nil` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
 | `haptics` | `PatternData?` | `nil` | Pattern to sync. `nil` renders a plain animation. |
-| `mode` | `HapticMode` | `.realtime` | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
 | `hapticOffset` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `Bool` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `Double?` | derived | Clock length in ms. See [Timing and duration](/pulsar/lottie/overview/#timing-and-duration). |
 | `autoPlay` | `Bool` | `true` | Play as soon as the view is created. |
 | `loopMode` | `LottieLoopMode` | `.playOnce` | Loop behaviour of the underlying `LottieAnimationView`. |
+
+There is a second initializer, `HapticLottieView(preset:)`, which drops the `name` and `bundle` arguments and renders the preset's own animation.
 
 The view creates and owns a `Pulsar` instance and a `HapticLottieController` for its lifetime, and sets `contentMode` to `.scaleAspectFit`.
 
@@ -163,18 +167,22 @@ controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
 controller.pause()
 ```
 
-`PulsarLottie.bind(_:pulsar:haptics:mode:offsetMs:enabled:)` is a convenience over the initializer. Call the initializer directly when the pattern is optional:
+`PulsarLottie.bind(_:pulsar:preset:haptics:hapticMode:hapticOffset:hapticsEnabled:durationMs:)` is a convenience over the initializer. Call the initializer directly to spell every argument out:
 
 ```swift
 let controller = HapticLottieController(
   animationView: animationView,
   pulsar: pulsar,
-  haptics: pattern,   // optional — nil plays the animation alone
-  mode: .realtime,
-  offsetMs: 0,
-  enabled: true
+  preset: pack.celebration, // optional — supplies the pattern and duration
+  haptics: pattern,         // optional — overrides the preset's pattern
+  hapticMode: .realtime,
+  hapticOffset: 0,
+  hapticsEnabled: true,
+  durationMs: nil
 )
 ```
+
+`bind` attaches haptics only: the animation view keeps whatever animation you gave it. Use `HapticLottieView(preset:)` to have a preset's Lottie rendered for you.
 
 ### Parameters
 
@@ -182,10 +190,12 @@ let controller = HapticLottieController(
 | --- | --- | --- | --- |
 | `animationView` | `LottieAnimationView` | – | The view to drive. Held for the controller's lifetime. |
 | `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
-| `haptics` | `PatternData?` | `nil` | Pattern to sync. `nil` leaves the animation without haptics. |
-| `mode` | `HapticMode` | `.realtime` | Engine mode. |
-| `offsetMs` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `enabled` | `Bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `preset` | `PresetHandle?` | `nil` | Bundle preset supplying the pattern and duration. |
+| `haptics` | `PatternData?` | `nil` | Pattern to sync. Overrides the preset's pattern; `nil` with no preset leaves the animation without haptics. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode. `.realtime`, or `.pattern` for a preset that carries audio. |
+| `hapticOffset` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `Bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
+| `durationMs` | `Double?` | derived | Clock length in ms. Overrides every derived duration. |
 
 In `.pattern` mode the pattern is parsed in the initializer, so the engine is warm and the first `play()` fires without the usual first-play latency.
 
@@ -223,23 +233,52 @@ public enum HapticMode {
 
 Passing `.realtime` without a pattern falls back to `.pattern` behaviour, because there is nothing to sample.
 
+`hapticMode` is optional: leave it out and the mode is `.realtime`, except for a `preset` that carries audio, which starts in `.pattern` so that audio plays. Passing a mode always wins.
+
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
 
 ---
 
 ## Bundle presets
 
-A preset from a `.pulsar` bundle carries the Lottie bytes it was authored against, on `PresetHandle.animation`:
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `name`, no `haptics`:
+
+```swift
+let bundle = try pulsar.loadBundleSync(AcmePack.descriptor)
+
+struct Celebration: View {
+  let pack: PulsarBundle<AcmePack.Presets>
+
+  var body: some View {
+    HapticLottieView(preset: pack.celebration)
+      .frame(width: 200, height: 200)
+  }
+}
+```
+
+The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `.pattern` mode.
+
+`PresetHandle` exposes all of it, so you can also drive your own view:
 
 ```swift
 if let animation = preset.animation {
   let lottieAnimation = try? LottieAnimation.from(data: animation.data)
   let animationView = LottieAnimationView(animation: lottieAnimation)
   // animation.frameRate and animation.totalFrames describe the authored timing
+  let controller = PulsarLottie.bind(animationView, pulsar: pulsar, preset: preset)
 }
 ```
 
-`PresetHandle` plays its own haptics through `play()` and `stop()`, which is the aligned-start `.pattern` behaviour. It does not expose its `PatternData`, so a bundle preset cannot currently drive `HapticLottieController` in `.realtime` mode — pass the pattern yourself when you need per-frame sync. See the [bundle format](/pulsar/sdk/ios/) notes on the iOS SDK page for how bundles are loaded.
+| Member | Type | Description |
+| --- | --- | --- |
+| `id` / `name` | `String` | Code-safe id, and the human label it was authored under. |
+| `duration` | `Double` | Authored length in ms, or `0` when the bundle carries no hint. |
+| `pattern` | `PatternData` | The authored pattern — what `.realtime` samples. |
+| `animation` | `BundleAnimation?` | Lottie `data`, `frameRate` and `totalFrames`. |
+| `hasAudio` / `hasAnimation` | `Bool` | What the preset was authored with. |
+| `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
+
+A preset with no animation renders nothing — check `hasAnimation`, or use the `name:` initializer and pass the preset alongside it. See the [bundle format](/pulsar/sdk/ios/) notes on the iOS SDK page for how bundles are loaded.
 
 ---
 

--- a/docs/src/content/docs/lottie/ios.mdx
+++ b/docs/src/content/docs/lottie/ios.mdx
@@ -40,9 +40,9 @@ head:
 
 import { Aside } from '@astrojs/starlight/components';
 
-`PulsarLottie` plays a Pulsar haptic pattern locked to a Lottie animation on iOS. It exposes two entry points: `HapticLottieView` for SwiftUI, and `HapticLottieController` for a `LottieAnimationView` you already own.
+`PulsarLottie` plays a Pulsar haptic pattern locked to a Lottie animation on iOS: `HapticLottieView` for SwiftUI, and `HapticLottieController` for a `LottieAnimationView` you already own.
 
-Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes, timing rules and simulator notes this page assumes.
 
 ## Requirements
 
@@ -81,7 +81,7 @@ Both `PulsarHaptics` and `lottie-ios` come along as dependencies — you do not 
 
 ## HapticLottieView
 
-A SwiftUI view that renders a bundled Lottie animation and plays a pattern locked to its timeline.
+A SwiftUI view that renders a Lottie animation and plays a pattern locked to its timeline.
 
 ```swift
 import Pulsar
@@ -89,182 +89,90 @@ import PulsarLottie
 
 let pattern = PatternData(
   continuousPattern: ContinuousPattern(
-    amplitude: [
-      ValuePoint(time: 0, value: 0),
-      ValuePoint(time: 400, value: 1),
-      ValuePoint(time: 800, value: 0),
-    ],
-    frequency: [
-      ValuePoint(time: 0, value: 0.3),
-      ValuePoint(time: 800, value: 0.8),
-    ]
+    amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 800, value: 1)],
+    frequency: [ValuePoint(time: 0, value: 0.3)]
   ),
-  discretePattern: [
-    DiscretePoint(time: 0, amplitude: 1, frequency: 0.5)
-  ]
+  discretePattern: [DiscretePoint(time: 0, amplitude: 1, frequency: 0.5)]
 )
 
-struct SuccessBadge: View {
-  var body: some View {
-    HapticLottieView("success", haptics: pattern, autoPlay: true)
-      .frame(width: 200, height: 200)
-  }
-}
+HapticLottieView("success", haptics: pattern)
+  .frame(width: 200, height: 200)
 ```
+
+### From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `name`, no `haptics`:
+
+```swift
+let pack = try pulsar.loadBundleSync(AcmePack.descriptor)
+
+HapticLottieView(preset: pack.celebration)
+  .frame(width: 200, height: 200)
+```
+
+The preset supplies the animation, `haptics` from its `pattern`, and `durationMs` from its authored length — each still overridable on its own. One that carries audio plays that audio too, which is why it starts in `.pattern` mode. See [bundle presets](/pulsar/lottie/overview/#bundle-presets).
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `name` | `String` | – | Name of the Lottie animation to load, passed positionally. |
+| `name` | `String` | – | Lottie animation to load, passed positionally. Replaced by `preset:` in the second initializer. |
 | `bundle` | `Bundle` | `.main` | Bundle the animation is loaded from. |
-| `preset` | `PresetHandle?` | `nil` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
-| `haptics` | `PatternData?` | `nil` | Pattern to sync. `nil` renders a plain animation. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `preset` | `PresetHandle?` | `nil` | Bundle preset supplying the animation, pattern and duration. |
+| `haptics` | `PatternData?` | `nil` | Pattern to sync. Overrides the preset's pattern; `nil` with no preset renders a plain animation. |
+| `hapticMode` | `HapticMode?` | derived | `.realtime`, or `.pattern` for a preset carrying audio. |
 | `hapticOffset` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `Bool` | `true` | Turn haptics off without touching the animation. |
-| `durationMs` | `Double?` | derived | Clock length in ms. See [Timing and duration](/pulsar/lottie/overview/#timing-and-duration). |
+| `durationMs` | `Double?` | derived | Clock length in ms. Overrides every derived duration. |
 | `autoPlay` | `Bool` | `true` | Play as soon as the view is created. |
 | `loopMode` | `LottieLoopMode` | `.playOnce` | Loop behaviour of the underlying `LottieAnimationView`. |
 
-There is a second initializer, `HapticLottieView(preset:)`, which drops the `name` and `bundle` arguments and renders the preset's own animation.
-
-The view creates and owns a `Pulsar` instance and a `HapticLottieController` for its lifetime, and sets `contentMode` to `.scaleAspectFit`.
+The view owns a `Pulsar` instance and a `HapticLottieController` for its lifetime, and sets `contentMode` to `.scaleAspectFit`.
 
 <Aside type="caution" title="Transport from SwiftUI">
-  The view does not expose its controller, so there is no way to call `play()` or `setTimestamp(_:)` on it from SwiftUI. To replay, force a remount by changing the view's identity:
+  The view does not expose its controller. To replay, force a remount by changing the view's identity — `HapticLottieView(preset: pack.celebration).id(runId)`. For real transport control, use [`HapticLottieController`](#hapticlottiecontroller).
 
-  ```swift
-  HapticLottieView("success", haptics: pattern, autoPlay: true)
-    .id(runId)
-  ```
-
-  When you need real transport control, use [`HapticLottieController`](#hapticlottiecontroller) with your own `LottieAnimationView` instead.
-</Aside>
-
-<Aside type="note" title="loopMode and realtime">
-  `loopMode` configures the underlying `LottieAnimationView`, which only drives its own playback in `.pattern` mode. In the default `.realtime` mode the controller advances the animation itself, so looping comes from `setLoop(_:count:reverse:)` on the controller — another reason to reach for the controller when the animation loops.
+  `loopMode` only drives playback in `.pattern` mode; in `.realtime` the controller advances the animation itself, so looping comes from `setLoop(_:count:reverse:)` on the controller.
 </Aside>
 
 ---
 
 ## HapticLottieController
 
-Attaches haptics to a `LottieAnimationView` you already have, and becomes the transport for both.
+Attaches haptics to a `LottieAnimationView` you already have, and becomes the transport for both. It binds haptics only — the view keeps whatever animation you gave it.
 
 ```swift
-import Lottie
-import Pulsar
-import PulsarLottie
-
-let pulsar = Pulsar()
-let animationView = LottieAnimationView(name: "success")
-
-let controller = PulsarLottie.bind(animationView, pulsar: pulsar, haptics: pattern)
+let controller = PulsarLottie.bind(animationView, pulsar: pulsar, preset: pack.celebration)
 
 controller.play()
 controller.setTimestamp(1200) // seek both animation and haptics to 1.2s
 controller.pause()
 ```
 
-`PulsarLottie.bind(_:pulsar:preset:haptics:hapticMode:hapticOffset:hapticsEnabled:durationMs:)` is a convenience over the initializer. Call the initializer directly to spell every argument out:
-
-```swift
-let controller = HapticLottieController(
-  animationView: animationView,
-  pulsar: pulsar,
-  preset: pack.celebration, // optional — supplies the pattern and duration
-  haptics: pattern,         // optional — overrides the preset's pattern
-  hapticMode: .realtime,
-  hapticOffset: 0,
-  hapticsEnabled: true,
-  durationMs: nil
-)
-```
-
-`bind` attaches haptics only: the animation view keeps whatever animation you gave it. Use `HapticLottieView(preset:)` to have a preset's Lottie rendered for you.
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `animationView` | `LottieAnimationView` | – | The view to drive. Held for the controller's lifetime. |
-| `pulsar` | `Pulsar` | – | The Pulsar instance the composers come from. |
-| `preset` | `PresetHandle?` | `nil` | Bundle preset supplying the pattern and duration. |
-| `haptics` | `PatternData?` | `nil` | Pattern to sync. Overrides the preset's pattern; `nil` with no preset leaves the animation without haptics. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode. `.realtime`, or `.pattern` for a preset that carries audio. |
-| `hapticOffset` | `Double` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `hapticsEnabled` | `Bool` | `true` | When `false`, the animation plays and no haptics are emitted. |
-| `durationMs` | `Double?` | derived | Clock length in ms. Overrides every derived duration. |
-
-In `.pattern` mode the pattern is parsed in the initializer, so the engine is warm and the first `play()` fires without the usual first-play latency.
-
-### Transport
+`bind` is a convenience over the initializer, which takes the same arguments as the view — `preset`, `haptics`, `hapticMode`, `hapticOffset`, `hapticsEnabled`, `durationMs` — plus `animationView` and `pulsar`.
 
 | Method | Description |
 | --- | --- |
 | `play()` | Rewind to the start and play animation and haptics together. |
 | `pause()` | Pause both. In `.pattern` mode the haptic stops rather than suspending. |
 | `resume()` | Resume from the current position. |
-| `stop()` | Stop and rewind to the start. |
-| `reset()` | Alias of `stop()`. |
-| `setTimestamp(_ ms: Double)` | Seek both animation and haptics to `ms` from the start. |
+| `stop()` / `reset()` | Stop and rewind to the start. |
+| `setTimestamp(_ ms: Double)` | Seek both to `ms` from the start. |
 | `setLoop(_ loop: Bool, count: Int?, reverse: Bool)` | Loop the animation. `count` limits iterations (`nil` loops forever); `reverse` plays a boomerang. |
 
 `setTimestamp(_:)` clamps into `0 ... duration` and repositions the discrete-event window, so seeking backwards re-fires the events you seek past. In `.pattern` mode it moves the animation only — a buffered pattern cannot be repositioned mid-flight.
 
-### Lifetime
-
-The controller retains the animation view and installs a `CADisplayLink` on the main run loop while playing. The display link is invalidated when playback ends and on `deinit`, so the only thing you have to get right is **keeping a strong reference to the controller** for as long as the view is on screen. A controller that is deallocated stops driving the animation.
+The controller installs a `CADisplayLink` while playing and invalidates it on `deinit`, so **keep a strong reference to it** for as long as the view is on screen.
 
 ---
 
-## Engine modes
+## Reading a preset yourself
 
-```swift
-public enum HapticMode {
-  case realtime
-  case pattern
-}
-```
-
-- **`.realtime`** (default) — a `CADisplayLink` makes the animation timeline the master clock, driving `currentProgress` and sampling the pattern into `RealtimeComposer.set` and `playDiscrete`. Honours pause, `setTimestamp(_:)` and loop.
-- **`.pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the animation start, which gives the best native fidelity at the cost of seeking.
-
-Passing `.realtime` without a pattern falls back to `.pattern` behaviour, because there is nothing to sample.
-
-`hapticMode` is optional: leave it out and the mode is `.realtime`, except for a `preset` that carries audio, which starts in `.pattern` so that audio plays. Passing a mode always wins.
-
-See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
-
----
-
-## Bundle presets
-
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `name`, no `haptics`:
-
-```swift
-let bundle = try pulsar.loadBundleSync(AcmePack.descriptor)
-
-struct Celebration: View {
-  let pack: PulsarBundle<AcmePack.Presets>
-
-  var body: some View {
-    HapticLottieView(preset: pack.celebration)
-      .frame(width: 200, height: 200)
-  }
-}
-```
-
-The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length. A preset that carries audio also plays that audio, which is why it starts in `.pattern` mode.
-
-`PresetHandle` exposes all of it, so you can also drive your own view:
+`PresetHandle` carries everything the view reads, so you can drive your own `LottieAnimationView`:
 
 ```swift
 if let animation = preset.animation {
-  let lottieAnimation = try? LottieAnimation.from(data: animation.data)
-  let animationView = LottieAnimationView(animation: lottieAnimation)
-  // animation.frameRate and animation.totalFrames describe the authored timing
+  let animationView = LottieAnimationView(animation: try? LottieAnimation.from(data: animation.data))
   let controller = PulsarLottie.bind(animationView, pulsar: pulsar, preset: preset)
 }
 ```
@@ -278,10 +186,4 @@ if let animation = preset.animation {
 | `hasAudio` / `hasAnimation` | `Bool` | What the preset was authored with. |
 | `play()` / `stop()` | – | Play the preset natively: haptics, plus its synced audio. |
 
-A preset with no animation renders nothing — check `hasAnimation`, or use the `name:` initializer and pass the preset alongside it. See the [bundle format](/pulsar/sdk/ios/) notes on the iOS SDK page for how bundles are loaded.
-
----
-
-## Testing on the simulator
-
-Core Haptics is unavailable on the iOS Simulator. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).
+A preset with no animation renders nothing through `HapticLottieView(preset:)` — check `hasAnimation`, or use the `name:` initializer and pass the preset alongside it. See the [iOS SDK page](/pulsar/sdk/ios/) for how bundles are loaded.

--- a/docs/src/content/docs/lottie/kmp.mdx
+++ b/docs/src/content/docs/lottie/kmp.mdx
@@ -42,7 +42,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 `pulsar-kmp-lottie` plays a Pulsar haptic pattern locked to a Lottie animation from common Compose Multiplatform code, on Android and iOS targets.
 
-`HapticLottie` renders through [compottie](https://github.com/alexzhirkevich/compottie), so the API matches the other platforms: pass a bundle preset and you get the animation and the haptics together. If you render with something else, [`HapticLottieSync`](#hapticlottiesync) follows a **progress value** you feed it and draws nothing.
+`HapticLottie` renders through [compottie](https://github.com/alexzhirkevich/compottie) and takes the same `LottieComposition` you already hand to `rememberLottiePainter`, so it drops into an existing screen. If you render with something else, [`HapticLottieSync`](#hapticlottiesync) follows a **progress value** you feed it and draws nothing.
 
 Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
 
@@ -87,38 +87,45 @@ The Android target needs the vibration permission in your app's `AndroidManifest
 
 ## HapticLottie
 
-Renders the animation and plays the haptics locked to its timeline. A bundle preset supplies
-all three of the animation, the pattern and the authored duration:
+Renders a Lottie animation and plays a pattern locked to its timeline. It takes the same
+`LottieComposition` compottie's own `rememberLottiePainter` takes, so an existing screen only
+swaps its `Image`:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.HapticLottie
+import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+import io.github.alexzhirkevich.compottie.rememberLottieComposition
 
 @Composable
-fun Celebration(pack: AcmePack.Presets) {
-  HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
+fun Success(pattern: PatternData) {
+  val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+
+  HapticLottie(composition, haptics = pattern, modifier = Modifier.size(200.dp))
 }
 ```
 
-Bring your own of each with `animation` and `haptics`:
+### From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and it loads the composition for you — no `rememberLottieComposition`, no `haptics`:
 
 ```kotlin
-import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
 
-HapticLottie(
-  animation = LottieCompositionSpec.JsonString(json),
-  haptics = pattern,
-  modifier = Modifier.size(200.dp),
-)
+HapticLottie(preset = bundle.celebration, modifier = Modifier.size(200.dp))
 ```
+
+The preset supplies the animation, `haptics` from its `pattern`, and `durationMs` from its authored length — each still overridable on its own. See [bundle presets](/pulsar/lottie/overview/#bundle-presets).
 
 ### Parameters
 
+Both overloads take the same arguments; the first is `composition: LottieComposition?`, the second `preset: PresetHandle`.
+
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
+| `composition` | `LottieComposition?` | – | The animation to render, from `rememberLottieComposition`. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and authored duration — and, in the preset overload, the animation. |
 | `modifier` | `Modifier` | `Modifier` | Applied to the rendered animation. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the animation, pattern and duration — see [Bundle presets](#bundle-presets). |
-| `animation` | `LottieCompositionSpec?` | `null` | The animation to render. Overrides the preset's own. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to disable haptics. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to render without haptics. |
 | `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
 | `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
@@ -126,69 +133,46 @@ HapticLottie(
 | `isPlaying` | `Boolean` | `true` | Whether the animation runs. A `false → true` transition starts the haptics. |
 | `iterations` | `Int` | `1` | Loop count. Pass `Compottie.IterateForever` to loop. |
 | `contentDescription` | `String?` | `null` | Accessibility label for the rendered animation. |
-| `contentScale` | `ContentScale` | `Fit` | How the animation fills `modifier`'s bounds. |
+| `alignment` / `contentScale` | | `Center` / `Fit` | Forwarded to the underlying `Image`. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
 
 <Aside type="note" title="Pass your own Pulsar instance">
   The default creates a fresh `Pulsar` for the composable. In an app that already holds one — most do, for presets and composers elsewhere — pass it in, so every haptic in the app shares one engine.
 </Aside>
 
-Rendering goes through [compottie](https://github.com/alexzhirkevich/compottie), which this package depends on. A preset with no animation, and no `animation` of its own, renders an empty `Box`.
+The preset overload renders an empty `Box` when the preset carries no animation.
 
 ---
 
 ## HapticLottieSync
 
-Renders nothing and follows a `progress` value you supply — for a renderer other than compottie, or for a progress source Compose is not involved in:
+Renders nothing and follows a `progress` value you supply — for a renderer other than compottie, or to add haptics to an existing screen without touching how it draws:
 
 ```kotlin
-import com.swmansion.pulsar.lottie.HapticLottieSync
+val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
 
-@Composable
-fun Success(pattern: PatternData, playing: Boolean) {
-  val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
-  val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
+Image(rememberLottiePainter(composition, progress = { progress }), contentDescription = null)
 
-  Image(
-    painter = rememberLottiePainter(composition, progress = { progress }),
-    contentDescription = null,
-  )
-
-  HapticLottieSync(
-    progress = progress,
-    isPlaying = playing,
-    haptics = pattern,
-    durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
-  )
-}
+HapticLottieSync(
+  progress = progress,
+  isPlaying = playing,
+  haptics = pattern,
+  durationMs = composition?.duration?.inWholeMilliseconds ?: 0,
+)
 ```
 
-### Parameters
+It takes `progress` and `isPlaying` in place of `composition`, plus the same haptic arguments as `HapticLottie`. `durationMs` here is the animation's own length; a `preset`'s authored duration takes precedence, and `0` falls back to that, then to the pattern's length.
 
-| Parameter | Type | Default | Description |
-| --- | --- | --- | --- |
-| `progress` | `Float` | – | Current animation progress, `0..1`. |
-| `isPlaying` | `Boolean` | – | Whether the animation is running. A `false → true` transition starts the haptics. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and authored duration. |
-| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to disable haptics. |
-| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
-| `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
-| `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
-| `durationMs` | `Long` | `0` | The animation's own length in ms. A `preset`'s authored duration takes precedence over it; `0` falls back to that, else to the pattern's own length. |
-| `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
-
-The engine is rebuilt whenever `pulsar`, `preset`, `haptics`, `hapticMode`, `hapticOffset` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline in the composable body.
+The engine is rebuilt whenever `pulsar`, `preset`, `haptics`, `hapticMode`, `hapticOffset` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline.
 
 ---
 
 ## HapticLottieEngine
 
-The composable is a thin wrapper around a plain, framework-agnostic engine. Use it directly when the progress comes from somewhere Compose is not involved in, or when you want to own the lifetime yourself:
+The pure, framework-agnostic engine behind both composables. Use it directly when the progress comes from somewhere Compose is not involved in:
 
 ```kotlin
-import com.swmansion.pulsar.lottie.HapticLottieEngine
-import com.swmansion.pulsar.lottie.HapticMode
-
 val engine = HapticLottieEngine(
   pulsar = pulsar,
   preset = pack.celebration, // optional — supplies the pattern and duration
@@ -206,14 +190,12 @@ engine.stop()
 
 | Member | Description |
 | --- | --- |
-| `setPlaying(isPlaying: Boolean)` | Notify a play/pause transition. In `PATTERN` mode a `true` transition fires the buffered pattern; `false` stops the haptics. |
-| `onProgress(progress: Float, durationMs: Long = 0)` | Feed the current position. Pass `0` to use the duration the engine resolved. Ignored unless `REALTIME` mode is active and playing. |
+| `setPlaying(isPlaying: Boolean)` | Notify a play/pause transition. In `PATTERN` mode a `true` transition fires the buffered pattern. |
+| `onProgress(progress: Float, durationMs: Long = 0)` | Feed the current position. `0` uses the duration the engine resolved. |
 | `stop()` | Stop the haptics and reset the discrete-event window. |
-| `resolvedDurationMs` | The clock length the engine resolved, for a caller with no duration of its own. |
+| `resolvedDurationMs` | The clock length the engine resolved. |
 
 `onProgress` handles a wrapped playhead: when the new time is behind the previous one — a loop or a backwards seek — the discrete window restarts from zero, so looping re-fires the events rather than swallowing them.
-
-In `PATTERN` mode the pattern is parsed in the constructor, so the engine is warm and the first play fires without the usual first-play latency.
 
 ---
 
@@ -226,29 +208,15 @@ enum class HapticMode { REALTIME, PATTERN }
 - **`REALTIME`** (default) — the animation progress is the master clock and the pattern is sampled into `RealtimeComposer.set` and `playDiscrete` on every progress update. Honours pause, seek and loop. On Android the vibrator is re-driven per update, so continuous fidelity is coarser there than on iOS.
 - **`PATTERN`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the start, which gives the best native fidelity at the cost of seeking.
 
-Because the sampling rate is the rate at which you call `onProgress`, realtime fidelity in this package tracks your renderer's frame rate. A progress value updated on every Compose frame gives the same result as the native SDKs; a throttled one gives coarser haptics.
-
-Passing `REALTIME` without a pattern leaves the animation without haptics, because there is nothing to sample.
-
-`hapticMode` is nullable: leave it out and the mode is `REALTIME`. KMP has no bundle audio yet, so the audio-preset exception described in the [overview](/pulsar/lottie/overview/#engine-modes) never fires here.
+Realtime fidelity tracks how often progress changes, so it follows your renderer's frame rate. KMP has no bundle audio yet, so the audio-preset exception described in the [overview](/pulsar/lottie/overview/#engine-modes) never fires here.
 
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
 
 ---
 
-## Bundle presets
+## Reading a preset yourself
 
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and `HapticLottie` takes both — no `animation`, no `haptics`:
-
-```kotlin
-val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
-
-HapticLottie(preset = bundle.celebration, modifier = Modifier.size(200.dp))
-```
-
-The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length.
-
-Rendering yourself with [`HapticLottieSync`](#hapticlottiesync)? `animationJson()` hands the preset's Lottie to your renderer as a JSON string, and returns `null` when it carries no animation:
+`animationJson()` hands a preset's Lottie to any renderer as a JSON string, and returns `null` when it carries no animation:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.animationJson
@@ -257,8 +225,6 @@ val composition by rememberLottieComposition {
   LottieCompositionSpec.JsonString(preset.animationJson()!!)
 }
 ```
-
-The preset's members are the same as on the native SDKs:
 
 | Member | Type | Description |
 | --- | --- | --- |
@@ -269,8 +235,4 @@ The preset's members are the same as on the native SDKs:
 | `hasAudio` / `hasAnimation` | `Boolean` | What the preset was authored with. `hasAudio` is always `false` on KMP. |
 | `play()` / `stop()` | – | Play the preset natively. |
 
----
-
-## Testing on simulators
-
-Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators).
+See the [KMP SDK page](/pulsar/sdk/kmp/) for how bundles are loaded.

--- a/docs/src/content/docs/lottie/kmp.mdx
+++ b/docs/src/content/docs/lottie/kmp.mdx
@@ -87,7 +87,7 @@ The Android target needs the vibration permission in your app's `AndroidManifest
 
 ## HapticLottie
 
-Render the animation however you like, then place `HapticLottie` next to it and feed it the same `progress`, `durationMillis` and `isPlaying`:
+Render the animation however you like, then place `HapticLottie` next to it and feed it the same `progress`, `durationMs` and `isPlaying`:
 
 ```kotlin
 import com.swmansion.pulsar.kmp.PatternData
@@ -109,7 +109,7 @@ fun Success(pattern: PatternData, playing: Boolean) {
 
   HapticLottie(
     progress = progress,
-    durationMillis = composition?.duration?.inWholeMilliseconds ?: 0L,
+    durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
     isPlaying = playing,
     haptics = pattern,
   )
@@ -123,19 +123,20 @@ fun Success(pattern: PatternData, playing: Boolean) {
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | `progress` | `Float` | – | Current animation progress, `0..1`. |
-| `durationMillis` | `Long` | – | Total animation length in ms. |
 | `isPlaying` | `Boolean` | – | Whether the animation is running. A `false → true` transition starts the haptics. |
-| `haptics` | `PatternData?` | – | Pattern to sync. `null` disables haptics. |
-| `mode` | `HapticMode` | `Realtime` | Engine mode — see [Engine modes](#engine-modes). |
-| `hapticOffsetMs` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to disable haptics. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `Long` | `0` | The animation's own length in ms — the composition-duration slot. A `preset`'s authored duration takes precedence over it; `0` falls back to that, else to the pattern's own length. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
 
 <Aside type="note" title="Pass your own Pulsar instance">
   The default creates a fresh `Pulsar` for the composable. In an app that already holds one — most do, for presets and composers elsewhere — pass it in, so every haptic in the app shares one engine.
 </Aside>
 
-The engine is rebuilt whenever `pulsar`, `haptics`, `mode`, `hapticOffsetMs` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline in the composable body.
+The engine is rebuilt whenever `pulsar`, `preset`, `haptics`, `hapticMode`, `hapticOffset` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline in the composable body.
 
 ---
 
@@ -149,10 +150,12 @@ import com.swmansion.pulsar.lottie.HapticMode
 
 val engine = HapticLottieEngine(
   pulsar = pulsar,
-  haptics = pattern,
-  mode = HapticMode.Realtime,
-  offsetMs = 0,
-  enabled = true,
+  preset = pack.celebration, // optional — supplies the pattern and duration
+  haptics = pattern,         // optional — overrides the preset's pattern
+  hapticMode = HapticMode.REALTIME,
+  hapticOffset = 0,
+  hapticsEnabled = true,
+  durationMs = null,
 )
 
 engine.setPlaying(true)
@@ -162,30 +165,70 @@ engine.stop()
 
 | Member | Description |
 | --- | --- |
-| `setPlaying(isPlaying: Boolean)` | Notify a play/pause transition. In `Pattern` mode a `true` transition fires the buffered pattern; `false` stops the haptics. |
-| `onProgress(progress: Float, durationMs: Long)` | Feed the current position. Ignored unless `Realtime` mode is active and playing. |
+| `setPlaying(isPlaying: Boolean)` | Notify a play/pause transition. In `PATTERN` mode a `true` transition fires the buffered pattern; `false` stops the haptics. |
+| `onProgress(progress: Float, durationMs: Long = 0)` | Feed the current position. Pass `0` to use the duration the engine resolved. Ignored unless `REALTIME` mode is active and playing. |
 | `stop()` | Stop the haptics and reset the discrete-event window. |
+| `resolvedDurationMs` | The clock length the engine resolved, for a caller with no duration of its own. |
 
 `onProgress` handles a wrapped playhead: when the new time is behind the previous one — a loop or a backwards seek — the discrete window restarts from zero, so looping re-fires the events rather than swallowing them.
 
-In `Pattern` mode the pattern is parsed in the constructor, so the engine is warm and the first play fires without the usual first-play latency.
+In `PATTERN` mode the pattern is parsed in the constructor, so the engine is warm and the first play fires without the usual first-play latency.
 
 ---
 
 ## Engine modes
 
 ```kotlin
-enum class HapticMode { Realtime, Pattern }
+enum class HapticMode { REALTIME, PATTERN }
 ```
 
-- **`Realtime`** (default) — the animation progress is the master clock and the pattern is sampled into `RealtimeComposer.set` and `playDiscrete` on every progress update. Honours pause, seek and loop. On Android the vibrator is re-driven per update, so continuous fidelity is coarser there than on iOS.
-- **`Pattern`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the start, which gives the best native fidelity at the cost of seeking.
+- **`REALTIME`** (default) — the animation progress is the master clock and the pattern is sampled into `RealtimeComposer.set` and `playDiscrete` on every progress update. Honours pause, seek and loop. On Android the vibrator is re-driven per update, so continuous fidelity is coarser there than on iOS.
+- **`PATTERN`** — the pre-parsed pattern plays whole through `PatternComposer`, aligned to the start, which gives the best native fidelity at the cost of seeking.
 
 Because the sampling rate is the rate at which you call `onProgress`, realtime fidelity in this package tracks your renderer's frame rate. A progress value updated on every Compose frame gives the same result as the native SDKs; a throttled one gives coarser haptics.
 
-Passing `Realtime` without a pattern leaves the animation without haptics, because there is nothing to sample.
+Passing `REALTIME` without a pattern leaves the animation without haptics, because there is nothing to sample.
+
+`hapticMode` is nullable: leave it out and the mode is `REALTIME`. KMP has no bundle audio yet, so the audio-preset exception described in the [overview](/pulsar/lottie/overview/#engine-modes) never fires here.
 
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
+
+---
+
+## Bundle presets
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. This package renders nothing itself, so a preset supplies the pattern and the duration to `HapticLottie`, and `animationJson()` hands the animation to your own renderer:
+
+```kotlin
+import com.swmansion.pulsar.lottie.animationJson
+
+@Composable
+fun Celebration(pack: AcmePack.Presets, playing: Boolean) {
+  val preset = pack.celebration
+  val composition by rememberLottieComposition {
+    LottieCompositionSpec.JsonString(preset.animationJson()!!)
+  }
+  val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
+
+  Image(
+    painter = rememberLottiePainter(composition, progress = { progress }),
+    contentDescription = preset.name,
+  )
+
+  HapticLottie(progress = progress, isPlaying = playing, preset = preset)
+}
+```
+
+`animationJson()` returns `null` when the preset carries no animation. The preset's other members are the same as on the native SDKs:
+
+| Member | Type | Description |
+| --- | --- | --- |
+| `id` / `name` | `String` | Code-safe id, and the human label it was authored under. |
+| `duration` | `Long` | Authored length in ms, or `0` when the bundle carries no hint. |
+| `pattern` | `PatternData` | The authored pattern — what `REALTIME` samples. |
+| `animation` | `BundleAnimation?` | Lottie `data`, `frameRate` and `totalFrames`. |
+| `hasAudio` / `hasAnimation` | `Boolean` | What the preset was authored with. `hasAudio` is always `false` on KMP. |
+| `play()` / `stop()` | – | Play the preset natively. |
 
 ---
 

--- a/docs/src/content/docs/lottie/kmp.mdx
+++ b/docs/src/content/docs/lottie/kmp.mdx
@@ -42,7 +42,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 `pulsar-kmp-lottie` plays a Pulsar haptic pattern locked to a Lottie animation from common Compose Multiplatform code, on Android and iOS targets.
 
-It is the one package in this section that does not depend on a Lottie library. It follows the **progress value** you feed it, so it works with whichever Compose Lottie renderer you already use — [compottie](https://github.com/alexzhirkevich/compottie), for example. The only Compose dependency is `compose-runtime`.
+`HapticLottie` renders through [compottie](https://github.com/alexzhirkevich/compottie), so the API matches the other platforms: pass a bundle preset and you get the animation and the haptics together. If you render with something else, [`HapticLottieSync`](#hapticlottiesync) follows a **progress value** you feed it and draws nothing.
 
 Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
 
@@ -50,8 +50,8 @@ Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes an
 
 - Kotlin 2.0+
 - Android API 24+ (Android 7.0) for Android targets, iOS 13+ for iOS targets
-- The [Pulsar KMP SDK](/pulsar/sdk/kmp/) (`com.swmansion:pulsar-kmp`)
-- A Compose Lottie renderer of your choosing
+- The [Pulsar KMP SDK](/pulsar/sdk/kmp/) (`com.swmansion:pulsar-kmp`), pulled in automatically
+- [compottie](https://github.com/alexzhirkevich/compottie), pulled in automatically — only `HapticLottieSync` works without it
 
 ## Installation
 
@@ -87,15 +87,62 @@ The Android target needs the vibration permission in your app's `AndroidManifest
 
 ## HapticLottie
 
-Render the animation however you like, then place `HapticLottie` next to it and feed it the same `progress`, `durationMs` and `isPlaying`:
+Renders the animation and plays the haptics locked to its timeline. A bundle preset supplies
+all three of the animation, the pattern and the authored duration:
 
 ```kotlin
-import com.swmansion.pulsar.kmp.PatternData
 import com.swmansion.pulsar.lottie.HapticLottie
+
+@Composable
+fun Celebration(pack: AcmePack.Presets) {
+  HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
+}
+```
+
+Bring your own of each with `animation` and `haptics`:
+
+```kotlin
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
-import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
-import io.github.alexzhirkevich.compottie.rememberLottieComposition
-import io.github.alexzhirkevich.compottie.rememberLottiePainter
+
+HapticLottie(
+  animation = LottieCompositionSpec.JsonString(json),
+  haptics = pattern,
+  modifier = Modifier.size(200.dp),
+)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `modifier` | `Modifier` | `Modifier` | Applied to the rendered animation. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the animation, pattern and duration — see [Bundle presets](#bundle-presets). |
+| `animation` | `LottieCompositionSpec?` | `null` | The animation to render. Overrides the preset's own. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to disable haptics. |
+| `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `Long` | `0` | Clock length in ms. `0` derives it from the preset, the composition, then the pattern. |
+| `isPlaying` | `Boolean` | `true` | Whether the animation runs. A `false → true` transition starts the haptics. |
+| `iterations` | `Int` | `1` | Loop count. Pass `Compottie.IterateForever` to loop. |
+| `contentDescription` | `String?` | `null` | Accessibility label for the rendered animation. |
+| `contentScale` | `ContentScale` | `Fit` | How the animation fills `modifier`'s bounds. |
+| `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
+
+<Aside type="note" title="Pass your own Pulsar instance">
+  The default creates a fresh `Pulsar` for the composable. In an app that already holds one — most do, for presets and composers elsewhere — pass it in, so every haptic in the app shares one engine.
+</Aside>
+
+Rendering goes through [compottie](https://github.com/alexzhirkevich/compottie), which this package depends on. A preset with no animation, and no `animation` of its own, renders an empty `Box`.
+
+---
+
+## HapticLottieSync
+
+Renders nothing and follows a `progress` value you supply — for a renderer other than compottie, or for a progress source Compose is not involved in:
+
+```kotlin
+import com.swmansion.pulsar.lottie.HapticLottieSync
 
 @Composable
 fun Success(pattern: PatternData, playing: Boolean) {
@@ -107,16 +154,14 @@ fun Success(pattern: PatternData, playing: Boolean) {
     contentDescription = null,
   )
 
-  HapticLottie(
+  HapticLottieSync(
     progress = progress,
-    durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
     isPlaying = playing,
     haptics = pattern,
+    durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
   )
 }
 ```
-
-`HapticLottie` emits no UI of its own — it exists purely to hold the haptic engine across recompositions and to react to the values you pass.
 
 ### Parameters
 
@@ -124,17 +169,13 @@ fun Success(pattern: PatternData, playing: Boolean) {
 | --- | --- | --- | --- |
 | `progress` | `Float` | – | Current animation progress, `0..1`. |
 | `isPlaying` | `Boolean` | – | Whether the animation is running. A `false → true` transition starts the haptics. |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and duration — see [Bundle presets](#bundle-presets). |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and authored duration. |
 | `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both to disable haptics. |
 | `hapticMode` | `HapticMode?` | derived | Engine mode — see [Engine modes](#engine-modes). |
 | `hapticOffset` | `Long` | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
-| `durationMs` | `Long` | `0` | The animation's own length in ms — the composition-duration slot. A `preset`'s authored duration takes precedence over it; `0` falls back to that, else to the pattern's own length. |
+| `durationMs` | `Long` | `0` | The animation's own length in ms. A `preset`'s authored duration takes precedence over it; `0` falls back to that, else to the pattern's own length. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your own platform-initialized instance. |
-
-<Aside type="note" title="Pass your own Pulsar instance">
-  The default creates a fresh `Pulsar` for the composable. In an app that already holds one — most do, for presets and composers elsewhere — pass it in, so every haptic in the app shares one engine.
-</Aside>
 
 The engine is rebuilt whenever `pulsar`, `preset`, `haptics`, `hapticMode`, `hapticOffset` or `hapticsEnabled` changes, and stopped when the composable leaves the composition. Hoist those values (`remember` the pattern) rather than constructing them inline in the composable body.
 
@@ -197,29 +238,27 @@ See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for 
 
 ## Bundle presets
 
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. This package renders nothing itself, so a preset supplies the pattern and the duration to `HapticLottie`, and `animationJson()` hands the animation to your own renderer:
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and `HapticLottie` takes both — no `animation`, no `haptics`:
+
+```kotlin
+val bundle = pulsar.loadBundleSync(AcmePack.descriptor)
+
+HapticLottie(preset = bundle.celebration, modifier = Modifier.size(200.dp))
+```
+
+The preset fills in three things, each still overridable on its own: the animation from its Lottie, `haptics` from its `pattern`, and `durationMs` from its authored length.
+
+Rendering yourself with [`HapticLottieSync`](#hapticlottiesync)? `animationJson()` hands the preset's Lottie to your renderer as a JSON string, and returns `null` when it carries no animation:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.animationJson
 
-@Composable
-fun Celebration(pack: AcmePack.Presets, playing: Boolean) {
-  val preset = pack.celebration
-  val composition by rememberLottieComposition {
-    LottieCompositionSpec.JsonString(preset.animationJson()!!)
-  }
-  val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
-
-  Image(
-    painter = rememberLottiePainter(composition, progress = { progress }),
-    contentDescription = preset.name,
-  )
-
-  HapticLottie(progress = progress, isPlaying = playing, preset = preset)
+val composition by rememberLottieComposition {
+  LottieCompositionSpec.JsonString(preset.animationJson()!!)
 }
 ```
 
-`animationJson()` returns `null` when the preset carries no animation. The preset's other members are the same as on the native SDKs:
+The preset's members are the same as on the native SDKs:
 
 | Member | Type | Description |
 | --- | --- | --- |

--- a/docs/src/content/docs/lottie/overview.mdx
+++ b/docs/src/content/docs/lottie/overview.mdx
@@ -70,7 +70,7 @@ Every package builds on the Lottie renderer that is idiomatic for its platform, 
 | Kotlin Multiplatform | [compottie](https://github.com/alexzhirkevich/compottie) | `com.swmansion:pulsar-kmp` |
 | Flutter | [`lottie`](https://pub.dev/packages/lottie) | `pulsar_haptics` |
 
-The Kotlin Multiplatform package also ships `HapticLottieSync`, which draws nothing and follows a **progress value** you feed it, for apps that render with something other than compottie.
+`HapticLottie` on Kotlin Multiplatform takes the same `LottieComposition` compottie's own render call takes, so it drops into an existing screen. The package also ships `HapticLottieSync`, which draws nothing and follows a **progress value** you feed it, for apps that render with something else.
 
 ## How the sync works
 
@@ -105,7 +105,7 @@ The transport is the same too — `play`, `pause`, `resume`, `stop`, `reset` and
 | Kotlin Multiplatform | `HapticLottie` (composable) | `HapticLottieEngine` | `HapticLottieSync` (composable) |
 | Flutter | `HapticLottie` | `HapticLottieController` | `HapticLottieController(animationController: …)` |
 
-Kotlin Multiplatform is declarative rather than imperative: `isPlaying` and `iterations` stand in for `autoPlay` and `setLoop`, and the lower-level `HapticLottieEngine` transport is `setPlaying` / `onProgress`.
+Kotlin Multiplatform is declarative rather than imperative: `isPlaying` and `iterations` stand in for `autoPlay` and `setLoop`, and the lower-level `HapticLottieEngine` transport is `setPlaying` / `onProgress`. Its preset overload loads the animation for you; the composition overload takes one you already loaded.
 
 ## Bundle presets
 

--- a/docs/src/content/docs/lottie/overview.mdx
+++ b/docs/src/content/docs/lottie/overview.mdx
@@ -82,6 +82,48 @@ A Pulsar pattern is a timeline of milliseconds — discrete events at fixed time
 
 Because the animation drives the pattern rather than the two running side by side, pausing, seeking, replaying or looping the animation keeps the haptics aligned for free.
 
+## The shared API
+
+The five packages are idiomatic for their platform, but the vocabulary is the same everywhere. Every entry point takes the same six haptic arguments, under the same names:
+
+| Argument | Meaning |
+| --- | --- |
+| `preset` | A `.pulsar` bundle preset supplying the animation, the pattern and the duration at once. |
+| `haptics` | A pattern to sync with the animation. Overrides a `preset`'s own pattern. |
+| `hapticMode` | `realtime` or `pattern` — see [Engine modes](#engine-modes). |
+| `hapticOffset` | Shift the haptics by ±ms relative to the animation. |
+| `hapticsEnabled` | Turn haptics off without touching the animation. |
+| `durationMs` | Clock length in ms. Overrides every derived duration. |
+
+The transport is the same too — `play`, `pause`, `resume`, `stop`, `reset` and `setTimestamp(ms)`, plus `setLoop` where the package owns the animation.
+
+| Platform | Drop-in view | Controller | Attach to a view you own |
+| --- | --- | --- | --- |
+| iOS | `HapticLottieView` (SwiftUI) | `HapticLottieController` | `PulsarLottie.bind(_:pulsar:preset:…)` |
+| Android | `HapticLottieView` | `HapticLottieController` | `LottieAnimationView.bindHaptics(pulsar, preset:…)` |
+| React Native | `HapticLottieView` | the `HapticLottieRef` handle | `useHapticLottie({ preset, … })` |
+| Kotlin Multiplatform | `HapticLottie` (composable) | `HapticLottieEngine` | `HapticLottieEngine` |
+| Flutter | `HapticLottie` | `HapticLottieController` | `HapticLottieController(animationController: …)` |
+
+Kotlin Multiplatform is the one package that renders nothing: it follows the `progress` you feed it, so it has no `autoPlay` and no `setLoop`, and its transport is `setPlaying` / `onProgress`.
+
+## Bundle presets
+
+A preset in a [`.pulsar` bundle](/pulsar/sdk/overview/) already pairs a pattern with the animation its author aligned to it, and often a sound as well. Pass the preset and the view takes all of it — no animation source, no pattern, no duration:
+
+| Passing a `preset` supplies | Overridden by |
+| --- | --- |
+| The Lottie animation it was authored against | the platform's own animation argument |
+| Its pattern | `haptics` |
+| Its authored duration | `durationMs` |
+| Its synced audio, played by the engine itself | `hapticMode`, or passing `haptics` |
+
+Because the audio is played by the haptic engine rather than sampled, a preset that carries audio starts in `pattern` mode instead of `realtime`. A preset without audio keeps the `realtime` default. Either way, an explicit `hapticMode` wins.
+
+Kotlin Multiplatform renders nothing itself, so there a preset supplies the pattern and duration, and `preset.animationJson()` hands the animation to your own Compose renderer.
+
+A preset that carries no animation cannot supply one — pass the animation yourself, or use a preset that was authored with one.
+
 ## Engine modes
 
 Every platform exposes the same two modes.
@@ -101,6 +143,7 @@ The whole pattern is pre-parsed and played once through `PatternComposer`, align
 - Best native fidelity — the platform haptic engine plays a compiled pattern, exactly as it would outside a Lottie context.
 - Pausing stops the haptic instead of suspending it, and there is no mid-pattern seek.
 - Accepts a preset trigger as well as a pattern, since nothing needs to be sampled.
+- The only mode that plays a bundle preset's **audio**: the sound is a track the engine plays alongside a compiled pattern, and realtime sampling has nothing to play it against.
 
 ### Choosing between them
 
@@ -112,16 +155,20 @@ The whole pattern is pre-parsed and played once through `PatternComposer`, align
 | **Loop** | Re-fires per iteration | Fires once at the start |
 | **Continuous fidelity** | Realtime-grade (coarser on Android) | Native |
 | **Accepts a preset trigger** | No | Yes |
+| **Plays a preset's audio** | No | Yes |
 
 Reach for **realtime** for anything longer than about a second, anything the user can scrub, and anything that loops. Reach for **pattern** for short, start-aligned accents where the sharpest possible feel matters more than seeking.
+
+The default is realtime — except for a preset that was authored with audio, which defaults to pattern so that audio actually plays. Setting the mode yourself always wins.
 
 ## Timing and duration
 
 The clock length is resolved in this order, and the first value that is available wins:
 
 1. An explicit duration you pass.
-2. The Lottie composition's own duration, once the animation has loaded.
-3. The pattern's own length — the largest timestamp across its discrete events and both envelopes.
+2. The preset's authored duration, when the haptics came from a bundle preset.
+3. The Lottie composition's own duration, once the animation has loaded.
+4. The pattern's own length — the largest timestamp across its discrete events and both envelopes.
 
 A pattern shorter than the animation simply ends early (its envelopes hold their last value); a longer one is cut off when the animation ends. Authoring both to the same length is the least surprising option.
 
@@ -138,7 +185,7 @@ None of the packages expose a playback-speed setting. A haptic timeline cannot b
 Three routes, all producing the same `Pattern` / `PatternData`:
 
 - **Generate it from the animation.** [Pulsar Studio](https://docs.swmansion.com/pulsar/studio/) samples an attached Lottie and derives a pattern from how much the animation is moving, which is the fastest way to a pattern that already matches the motion. See the [Studio guide](https://docs.swmansion.com/pulsar/studio/).
-- **Ship it in a `.pulsar` bundle.** A bundle preset pairs a pattern with the animation it was authored against, so the two can never drift apart. On React Native the bundle preset [drops straight into the view](/pulsar/lottie/react-native/#from-a-bundle-preset); on the other platforms the preset carries the Lottie bytes for your own renderer.
+- **Ship it in a `.pulsar` bundle.** A bundle preset pairs a pattern with the animation it was authored against, so the two can never drift apart, and it drops straight into the view on every platform — see [bundle presets](#bundle-presets) below.
 - **Write it by hand.** A literal pattern is often enough for a short accent — see the platform guides for the shape.
 
 ## Testing without a device

--- a/docs/src/content/docs/lottie/overview.mdx
+++ b/docs/src/content/docs/lottie/overview.mdx
@@ -67,10 +67,10 @@ Every package builds on the Lottie renderer that is idiomatic for its platform, 
 | iOS | [`lottie-ios`](https://github.com/airbnb/lottie-ios) | `PulsarHaptics` |
 | Android | [`com.airbnb.android:lottie`](https://github.com/airbnb/lottie-android) | `com.swmansion:pulsar` |
 | React Native | [`lottie-react-native`](https://github.com/lottie-react-native/lottie-react-native) | `react-native-pulsar` |
-| Kotlin Multiplatform | any Compose renderer (e.g. [compottie](https://github.com/alexzhirkevich/compottie)) | `com.swmansion:pulsar-kmp` |
+| Kotlin Multiplatform | [compottie](https://github.com/alexzhirkevich/compottie) | `com.swmansion:pulsar-kmp` |
 | Flutter | [`lottie`](https://pub.dev/packages/lottie) | `pulsar_haptics` |
 
-The Kotlin Multiplatform package is the odd one out: it depends only on `compose-runtime` and follows the **progress value** you feed it, so it works with whichever Compose Lottie renderer you already use.
+The Kotlin Multiplatform package also ships `HapticLottieSync`, which draws nothing and follows a **progress value** you feed it, for apps that render with something other than compottie.
 
 ## How the sync works
 
@@ -102,10 +102,10 @@ The transport is the same too — `play`, `pause`, `resume`, `stop`, `reset` and
 | iOS | `HapticLottieView` (SwiftUI) | `HapticLottieController` | `PulsarLottie.bind(_:pulsar:preset:…)` |
 | Android | `HapticLottieView` | `HapticLottieController` | `LottieAnimationView.bindHaptics(pulsar, preset:…)` |
 | React Native | `HapticLottieView` | the `HapticLottieRef` handle | `useHapticLottie({ preset, … })` |
-| Kotlin Multiplatform | `HapticLottie` (composable) | `HapticLottieEngine` | `HapticLottieEngine` |
+| Kotlin Multiplatform | `HapticLottie` (composable) | `HapticLottieEngine` | `HapticLottieSync` (composable) |
 | Flutter | `HapticLottie` | `HapticLottieController` | `HapticLottieController(animationController: …)` |
 
-Kotlin Multiplatform is the one package that renders nothing: it follows the `progress` you feed it, so it has no `autoPlay` and no `setLoop`, and its transport is `setPlaying` / `onProgress`.
+Kotlin Multiplatform is declarative rather than imperative: `isPlaying` and `iterations` stand in for `autoPlay` and `setLoop`, and the lower-level `HapticLottieEngine` transport is `setPlaying` / `onProgress`.
 
 ## Bundle presets
 
@@ -120,7 +120,7 @@ A preset in a [`.pulsar` bundle](/pulsar/sdk/overview/) already pairs a pattern 
 
 Because the audio is played by the haptic engine rather than sampled, a preset that carries audio starts in `pattern` mode instead of `realtime`. A preset without audio keeps the `realtime` default. Either way, an explicit `hapticMode` wins.
 
-Kotlin Multiplatform renders nothing itself, so there a preset supplies the pattern and duration, and `preset.animationJson()` hands the animation to your own Compose renderer.
+On Kotlin Multiplatform, `preset.animationJson()` hands the animation to your own Compose renderer when you use `HapticLottieSync` instead of the drop-in.
 
 A preset that carries no animation cannot supply one — pass the animation yourself, or use a preset that was authored with one.
 

--- a/docs/src/content/docs/lottie/react-native.mdx
+++ b/docs/src/content/docs/lottie/react-native.mdx
@@ -42,7 +42,7 @@ import { Tabs, TabItem, Code, Aside } from '@astrojs/starlight/components';
 
 `react-native-pulsar-lottie` plays a Pulsar haptic pattern locked to a Lottie animation. Its `HapticLottieView` is a **non-breaking superset** of [`lottie-react-native`](https://github.com/lottie-react-native/lottie-react-native)'s `LottieView`: it accepts every prop and ref method you already use and adds haptic-only ones. With `haptics` omitted it behaves exactly like `LottieView`.
 
-Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes and timing rules this page assumes.
+Read the [Lottie SDK overview](/pulsar/lottie/overview/) for the engine modes, timing rules and simulator notes this page assumes.
 
 ## Requirements
 
@@ -93,88 +93,53 @@ import type { Pattern } from 'react-native-pulsar';
 const pattern: Pattern = {
   discretePattern: [{ time: 0, amplitude: 1, frequency: 0.5 }],
   continuousPattern: {
-    amplitude: [
-      { time: 0, value: 0 },
-      { time: 400, value: 1 },
-      { time: 800, value: 0 },
-    ],
-    frequency: [
-      { time: 0, value: 0.3 },
-      { time: 800, value: 0.8 },
-    ],
+    amplitude: [{ time: 0, value: 0 }, { time: 400, value: 1 }, { time: 800, value: 0 }],
+    frequency: [{ time: 0, value: 0.3 }, { time: 800, value: 0.8 }],
   },
 };
 
-function Success() {
-  return (
-    <HapticLottieView
-      source={require('./success.json')}
-      haptics={pattern}
-      autoPlay
-      style={{ width: 200, height: 200 }}
-    />
-  );
-}
+<HapticLottieView
+  source={require('./success.json')}
+  haptics={pattern}
+  autoPlay
+  style={{ width: 200, height: 200 }}
+/>
 ```
 
 Everything `LottieView` does still works — `source`, `loop`, `autoPlay`, `style`, `resizeMode`, `onAnimationFinish` and the rest. You only **add** haptics.
+
+### From a bundle preset
+
+A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `source`, no `haptics`:
+
+```tsx
+import { loadBundleSync } from '@/assets/my-pack.bundle';
+
+const Pack = loadBundleSync();
+
+<HapticLottieView preset={Pack.celebration} autoPlay style={{ width: 200, height: 200 }} />
+```
+
+The preset supplies `source` from its Lottie, `haptics` from its pattern, and `durationMs` from its authored length — each still overridable on its own. One that carries audio plays that audio too, which is why it starts in `pattern` mode. See [bundle presets](/pulsar/lottie/overview/#bundle-presets).
+
+The generated module embeds JSON Lotties only, and both loaders carry them. A preset authored as a dotLottie reports `hasAnimation: true` but carries no `animation` — pass `source` yourself there. With neither available the view renders nothing and warns once. Its **audio** only reaches the device on the asset-backed path: `loadBundleSync()` plays the embedded pattern, while `loadBundleSync(true)` and `loadBundleAsync()` hand the `.pulsar` to native code, sound included.
+
+See [preset bundles](/pulsar/sdk/react-native/#preset-bundles) for how bundles are generated and loaded.
 
 ### Haptic props
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `preset` | `PresetHandle` | – | A bundle preset supplying `source`, `haptics` and `durationMs` at once. |
+| `preset` | `PresetHandle` | – | Bundle preset supplying `source`, `haptics` and `durationMs` at once. |
 | `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger function (`pattern` mode only). Overrides the preset's pattern. |
-| `hapticMode` | `'realtime' \| 'pattern'` | derived | Engine mode — see [Engine modes](#engine-modes). |
+| `hapticMode` | `'realtime' \| 'pattern'` | derived | `'realtime'`, or `'pattern'` for a preset carrying audio. |
 | `hapticOffset` | `number` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `boolean` | `true` | Turn haptics off without touching the animation. |
-| `durationMs` | `number` | derived | Clock length in `realtime` mode. See [Duration](#duration). |
+| `durationMs` | `number` | derived | Clock length in `realtime` mode. |
 
 `source` is required as usual, unless a `preset` supplies it.
 
-### Duration
-
-In `realtime` mode the view needs to know how long the animation is. It resolves that in order:
-
-1. An explicit `durationMs` prop.
-2. The preset's authored duration, when a `preset` is passed.
-3. The Lottie JSON's own `fr` / `ip` / `op` fields — only readable when `source` is an inline object, such as a `require('./success.json')`.
-4. The pattern's own length.
-
-A remote animation loaded by URL exposes none of that to JS, so pass `durationMs` explicitly when the source is a URI.
-
----
-
-## From a bundle preset
-
-A preset in a `.pulsar` bundle already pairs an animation with the pattern its author aligned to it. Pass the preset and the view takes both — no `source`, no `haptics`:
-
-```tsx
-import { HapticLottieView } from 'react-native-pulsar-lottie';
-import { loadBundleSync } from '@/assets/my-pack.bundle';
-
-const Pack = loadBundleSync();
-
-function Celebration() {
-  return (
-    <HapticLottieView
-      preset={Pack.celebration}
-      autoPlay
-      style={{ width: 200, height: 200 }}
-    />
-  );
-}
-```
-
-The preset fills in three things, each still overridable on its own: `source` from its Lottie, `haptics` from its pattern, and `durationMs` from its authored length.
-
-A preset that was authored with **audio** plays that audio too, through its own native handle. That needs `pattern` mode — the sound is a track the engine plays alongside a compiled pattern, and realtime sampling has nothing to play it against — so such a preset defaults to `hapticMode="pattern"` instead of `realtime`. Passing `hapticMode` yourself always wins, and passing your own `haptics` takes the preset out of the picture entirely.
-
-The audio itself only reaches the device on the asset-backed load path: `loadBundleSync()` plays the pattern embedded in the generated module, while `loadBundleSync(true)` and `loadBundleAsync()` hand the `.pulsar` to native code, sound included.
-
-Only JSON Lotties are embedded in the generated module; both loaders carry them, so this works on the asset-backed path too. A preset authored as a dotLottie reports `hasAnimation: true` but carries no `animation` — pass `source` yourself there. When neither is available the view renders nothing and warns once, rather than crashing.
-
-See [preset bundles](/pulsar/sdk/react-native/#preset-bundles) on the React Native SDK page for how bundles are generated and loaded.
+In `realtime` mode the duration resolves as: an explicit `durationMs`, then the preset's authored duration, then the Lottie JSON's own `fr`/`ip`/`op` — readable only when `source` is an inline object such as `require('./success.json')` — then the pattern's length. A remote animation loaded by URL exposes none of that to JS, so pass `durationMs` explicitly there.
 
 ---
 
@@ -183,24 +148,10 @@ See [preset bundles](/pulsar/sdk/react-native/#preset-bundles) on the React Nati
 The ref mirrors `LottieView`'s transport and adds `stop()` and `setTimestamp(ms)`. In `realtime` mode these steer the shared master clock, so the animation and the haptics move together.
 
 ```tsx
-import { useRef } from 'react';
-import { HapticLottieView, type HapticLottieRef } from 'react-native-pulsar-lottie';
+const ref = useRef<HapticLottieRef>(null);
 
-function Success() {
-  const ref = useRef<HapticLottieRef>(null);
-
-  return (
-    <>
-      <HapticLottieView
-        ref={ref}
-        source={require('./success.json')}
-        haptics={pattern}
-        style={{ width: 200, height: 200 }}
-      />
-      <Button title="Replay" onPress={() => ref.current?.play()} />
-    </>
-  );
-}
+<HapticLottieView ref={ref} preset={Pack.celebration} style={{ width: 200, height: 200 }} />
+<Button title="Replay" onPress={() => ref.current?.play()} />
 ```
 
 | Method | Description |
@@ -208,40 +159,14 @@ function Success() {
 | `play(startFrame?, endFrame?)` | Play from the start, or a frame segment. Starts the haptics too. |
 | `pause()` | Pause both animation and haptics. |
 | `resume()` | Resume from the current position. |
-| `stop()` | Stop and rewind to the start. |
-| `reset()` | Rewind to the start and stop the haptics. |
-| `setTimestamp(ms)` | Seek both animation and haptics to `ms` from the start. |
+| `stop()` / `reset()` | Rewind to the start and stop the haptics. |
+| `setTimestamp(ms)` | Seek both to `ms` from the start. |
 
 <Aside type="note" title="Transport in pattern mode">
   `setTimestamp(ms)` is a no-op in `pattern` mode — `lottie-react-native` exposes no imperative seek, and a buffered haptic cannot be repositioned mid-flight. The frame segment arguments to `play()` are likewise a `pattern`-mode feature.
+
+  In `realtime` mode the view owns the clock, so `autoPlay` is an initial-state flag read once on mount, not a live toggle. Call `play()` or `pause()` on the ref instead.
 </Aside>
-
----
-
-## Engine modes
-
-```ts
-type HapticMode = 'realtime' | 'pattern';
-```
-
-### realtime
-
-The default, unless a `preset` carries audio.
-
-
-A Reanimated frame callback drives the Lottie `progress` on the UI thread — no React re-renders — and samples the pattern into `RealtimeComposer` events. It honours `pause`, `setTimestamp`, `loop` and segments coherently. Requires a `Pattern`; a preset trigger function has no timeline to sample.
-
-Because the view owns the clock in this mode, `autoPlay` is an initial-state flag read once on mount, not a live toggle: flipping it later does not start or stop playback — call `play()` or `pause()` on the ref instead.
-
-### pattern
-
-The pattern (or a preset trigger) plays whole through `PatternComposer`, aligned to the animation start, and the animation plays itself. Best native fidelity. `pause` stops the haptic instead of suspending it, and there is no mid-pattern seek — best for short, mostly start-aligned animations.
-
-Passing `hapticMode="realtime"` with a preset trigger function rather than a `Pattern` falls back to the pattern-mode path.
-
-The default, when you do not set `hapticMode`, is `realtime` — except for a `preset` that carries audio, which starts here so that audio plays.
-
-See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
 
 ---
 
@@ -253,43 +178,39 @@ Attach haptics to a `LottieView` you already own, without swapping the component
 import LottieView from 'lottie-react-native';
 import { useHapticLottie } from 'react-native-pulsar-lottie';
 
-function Success() {
-  const lottieRef = useRef<LottieView>(null);
-  const haptics = useHapticLottie({ haptics: pattern });
+const lottieRef = useRef<LottieView>(null);
+const haptics = useHapticLottie({ preset: Pack.celebration });
 
-  const start = () => {
-    lottieRef.current?.play();
-    haptics.play();
-  };
-
-  const pause = () => {
-    lottieRef.current?.pause();
-    haptics.stop();
-  };
-
-  return <LottieView ref={lottieRef} source={require('./success.json')} />;
-}
+const start = () => {
+  lottieRef.current?.play();
+  haptics.play();
+};
 ```
-
-### Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `preset` | `PresetHandle` | – | Bundle preset to fire, including its synced audio. |
-| `haptics` | `Pattern \| () => void` | – | Pattern or preset trigger to fire with the animation. Overrides `preset`. |
+| `haptics` | `Pattern \| () => void` | – | Pattern or preset trigger to fire. Overrides `preset`. |
 | `hapticsEnabled` | `boolean` | `true` | Disable firing without unwiring the hook. |
 
-### Returns
-
-| Member | Description |
-| --- | --- |
-| `play()` | Fire the haptic — call alongside your own `play()`. |
-| `stop()` | Stop the haptic — call alongside pause or stop. |
-| `isReady` | `true` once the pattern is parsed. Always `true` for a preset trigger. |
-
-A bundle preset drops in as its own option — `useHapticLottie({ preset })` — and, when it carries audio, plays that audio alongside the haptics rather than replaying the pattern from JS.
+It returns `play()`, `stop()` and `isReady` — `true` once the pattern is parsed, and always `true` for a preset trigger.
 
 For progress-driven `realtime` sync with seek and loop, use [`HapticLottieView`](#hapticlottieview) instead.
+
+---
+
+## Engine modes
+
+```ts
+type HapticMode = 'realtime' | 'pattern';
+```
+
+- **`realtime`** (default) — a Reanimated frame callback drives the Lottie `progress` on the UI thread, with no React re-renders, and samples the pattern into `RealtimeComposer` events. Honours `pause`, `setTimestamp`, `loop` and segments. Requires a `Pattern`.
+- **`pattern`** — the pattern, preset or trigger plays whole through `PatternComposer`, aligned to the animation start. Best native fidelity, and the only mode that plays a preset's audio.
+
+Passing `hapticMode="realtime"` with a preset trigger function rather than a `Pattern` falls back to the pattern-mode path, because there is nothing to sample.
+
+See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
 
 ---
 
@@ -307,10 +228,4 @@ import type {
 } from 'react-native-pulsar-lottie';
 ```
 
-`HapticSource` is `Pattern | (() => void)` — a pattern works in both modes, a preset trigger function in `pattern` mode only. `HapticLottieProps` is `LottieViewProps` plus `HapticConfig`, with `source` required unless a `preset` supplies it.
-
----
-
-## Testing on the simulator
-
-Simulators and emulators have no haptic hardware. Debug builds of Pulsar play an audio rendering of the pattern instead, so the timing against the animation is still verifiable there — but run on a device before shipping to judge how it feels. See [testing haptics on simulators](/pulsar/sdk/overview/#testing-haptics-on-simulators) and the [Jest mock](/pulsar/sdk/react-native/#testing-with-jest) for unit tests.
+`HapticSource` is `Pattern | (() => void)`. `HapticLottieProps` is `LottieViewProps` plus `HapticConfig`, with `source` required unless a `preset` supplies it. See the [Jest mock](/pulsar/sdk/react-native/#testing-with-jest) for unit tests.

--- a/docs/src/content/docs/lottie/react-native.mdx
+++ b/docs/src/content/docs/lottie/react-native.mdx
@@ -124,8 +124,8 @@ Everything `LottieView` does still works — `source`, `loop`, `autoPlay`, `styl
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `preset` | `PresetHandle` | – | A bundle preset supplying `source`, `haptics` and `durationMs` at once. |
-| `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger function (`pattern` mode only). |
-| `hapticMode` | `'realtime' \| 'pattern'` | `'realtime'` | Engine mode — see [Engine modes](#engine-modes). |
+| `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger function (`pattern` mode only). Overrides the preset's pattern. |
+| `hapticMode` | `'realtime' \| 'pattern'` | derived | Engine mode — see [Engine modes](#engine-modes). |
 | `hapticOffset` | `number` (ms) | `0` | Shift the haptics by ±ms relative to the animation. |
 | `hapticsEnabled` | `boolean` | `true` | Turn haptics off without touching the animation. |
 | `durationMs` | `number` | derived | Clock length in `realtime` mode. See [Duration](#duration). |
@@ -167,6 +167,10 @@ function Celebration() {
 ```
 
 The preset fills in three things, each still overridable on its own: `source` from its Lottie, `haptics` from its pattern, and `durationMs` from its authored length.
+
+A preset that was authored with **audio** plays that audio too, through its own native handle. That needs `pattern` mode — the sound is a track the engine plays alongside a compiled pattern, and realtime sampling has nothing to play it against — so such a preset defaults to `hapticMode="pattern"` instead of `realtime`. Passing `hapticMode` yourself always wins, and passing your own `haptics` takes the preset out of the picture entirely.
+
+The audio itself only reaches the device on the asset-backed load path: `loadBundleSync()` plays the pattern embedded in the generated module, while `loadBundleSync(true)` and `loadBundleAsync()` hand the `.pulsar` to native code, sound included.
 
 Only JSON Lotties are embedded in the generated module; both loaders carry them, so this works on the asset-backed path too. A preset authored as a dotLottie reports `hasAnimation: true` but carries no `animation` — pass `source` yourself there. When neither is available the view renders nothing and warns once, rather than crashing.
 
@@ -220,7 +224,10 @@ function Success() {
 type HapticMode = 'realtime' | 'pattern';
 ```
 
-### realtime (default)
+### realtime
+
+The default, unless a `preset` carries audio.
+
 
 A Reanimated frame callback drives the Lottie `progress` on the UI thread — no React re-renders — and samples the pattern into `RealtimeComposer` events. It honours `pause`, `setTimestamp`, `loop` and segments coherently. Requires a `Pattern`; a preset trigger function has no timeline to sample.
 
@@ -231,6 +238,8 @@ Because the view owns the clock in this mode, `autoPlay` is an initial-state fla
 The pattern (or a preset trigger) plays whole through `PatternComposer`, aligned to the animation start, and the animation plays itself. Best native fidelity. `pause` stops the haptic instead of suspending it, and there is no mid-pattern seek — best for short, mostly start-aligned animations.
 
 Passing `hapticMode="realtime"` with a preset trigger function rather than a `Pattern` falls back to the pattern-mode path.
+
+The default, when you do not set `hapticMode`, is `realtime` — except for a `preset` that carries audio, which starts here so that audio plays.
 
 See [Choosing between them](/pulsar/lottie/overview/#choosing-between-them) for the trade-offs.
 
@@ -266,7 +275,8 @@ function Success() {
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `haptics` | `Pattern \| () => void` | – | Pattern or preset trigger to fire with the animation. |
+| `preset` | `PresetHandle` | – | Bundle preset to fire, including its synced audio. |
+| `haptics` | `Pattern \| () => void` | – | Pattern or preset trigger to fire with the animation. Overrides `preset`. |
 | `hapticsEnabled` | `boolean` | `true` | Disable firing without unwiring the hook. |
 
 ### Returns
@@ -277,7 +287,7 @@ function Success() {
 | `stop()` | Stop the haptic — call alongside pause or stop. |
 | `isReady` | `true` once the pattern is parsed. Always `true` for a preset trigger. |
 
-A bundle preset works here today with no extra option: `useHapticLottie({ haptics: preset.pattern })`.
+A bundle preset drops in as its own option — `useHapticLottie({ preset })` — and, when it carries audio, plays that audio alongside the haptics rather than replaying the pattern from JS.
 
 For progress-driven `realtime` sync with seek and loop, use [`HapticLottieView`](#hapticlottieview) instead.
 

--- a/docs/src/content/docs/sdk/android.mdx
+++ b/docs/src/content/docs/sdk/android.mdx
@@ -784,9 +784,11 @@ val bundle = pulsar.loadBundleAsync(AcmePack.descriptor)
 Both check the packaged bundle's content hash against the generated types, so a stale APK asset
 fails loudly instead of quietly playing the wrong pattern. Pass `strict = false` to skip it.
 
-Each `PresetHandle` exposes `id`, `duration`, `play()`, `stop()`, and `animation` — the Lottie bytes
+Each `PresetHandle` exposes `id`, `name`, `duration`, `pattern`, `hasAudio`, `hasAnimation`, `play()`, `stop()`, and `animation` — the Lottie bytes
 and timing for your own animation view. Pulsar carries and time-aligns the animation; the app
 renders it:
+
+The [Lottie SDK](/pulsar/lottie/overview/) takes a `PresetHandle` directly and reads all of that for you — pattern, animation and duration — so you rarely have to unpack it by hand.
 
 ```kotlin
 bundle.heartbeatV2.animation?.let {

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -727,6 +727,15 @@ to skip it.
 Audio authored into a preset plays through the native iOS/Android path alongside the haptics, and
 animation bytes are carried for your own Lottie view.
 
+Each `PresetHandle` exposes `id`, `name`, `duration`, `pattern`, `hasAudio`, `hasAnimation`,
+`play()`, `stop()`, and `animation` — the Lottie `data`, `frameRate` and `totalFrames`, ready for
+`Lottie.memory`. That metadata is read back from the native bundle when it loads; pass
+`includeAnimations: false` to `loadBundleAsync` to skip the animation bytes when nothing will
+render them.
+
+The [Lottie SDK](/pulsar/lottie/overview/) takes a `PresetHandle` directly and reads all of that
+for you — pattern, animation and duration — so you rarely have to unpack it by hand.
+
 For an id only known at runtime, `bundle.get(id)` returns a handle or `null`. Call `bundle.dispose()`
 when you are done with a bundle.
 

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -679,9 +679,11 @@ let bundle = try await pulsar.loadBundleAsync(AcmePack.descriptor)
 The descriptor finds the `.pulsar` in the app's main bundle, and its content hash is checked
 against the generated types so a stale copy fails loudly. Pass `strict: false` to skip that.
 
-Each `PresetHandle` exposes `id`, `duration`, `play()`, `stop()`, and `animation` — the Lottie bytes
+Each `PresetHandle` exposes `id`, `name`, `duration`, `pattern`, `hasAudio`, `hasAnimation`, `play()`, `stop()`, and `animation` — the Lottie bytes
 and timing for your own animation view. Pulsar carries and time-aligns the animation; the app
 renders it:
+
+The [Lottie SDK](/pulsar/lottie/overview/) takes a `PresetHandle` directly and reads all of that for you — pattern, animation and duration — so you rarely have to unpack it by hand.
 
 ```swift
 if let animation = bundle.heartbeatV2.animation {

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -687,8 +687,10 @@ a bundle kept there uses the `bytes` overload above.
 The loaded bundle's content hash is checked against the generated types; pass `strict = false`
 to skip it.
 
-Each `PresetHandle` exposes `id`, `duration`, `play()`, `stop()`, and `animation` — the Lottie bytes
+Each `PresetHandle` exposes `id`, `name`, `duration`, `pattern`, `hasAudio`, `hasAnimation`, `play()`, `stop()`, and `animation` — the Lottie bytes
 and timing for your own animation view.
+
+The [Lottie SDK](/pulsar/lottie/overview/) takes a `PresetHandle` directly and reads all of that for you — pattern, animation and duration — so you rarely have to unpack it by hand.
 
 :::caution
 KMP v1 plays a preset's haptics and carries its animation bytes, but **synced bundle audio is not

--- a/flutter/PulsarApp/lib/main.dart
+++ b/flutter/PulsarApp/lib/main.dart
@@ -317,8 +317,6 @@ class _PulsarDemoScreenState extends State<PulsarDemoScreen> {
             ),
           const SizedBox(height: 12),
 
-          // The `lottie` preset carries its animation as well as its pattern, so the
-          // widget needs neither an asset nor a haptics argument.
           if (_bundle != null) ...[
             _SectionHeader('Animation from a preset'),
             Center(

--- a/flutter/PulsarApp/lib/main.dart
+++ b/flutter/PulsarApp/lib/main.dart
@@ -317,6 +317,24 @@ class _PulsarDemoScreenState extends State<PulsarDemoScreen> {
             ),
           const SizedBox(height: 12),
 
+          // The `lottie` preset carries its animation as well as its pattern, so the
+          // widget needs neither an asset nor a haptics argument.
+          if (_bundle != null) ...[
+            _SectionHeader('Animation from a preset'),
+            Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: HapticLottie.preset(
+                  _bundle!.lottie,
+                  autoPlay: true,
+                  repeat: true,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+
           // System impacts
           _SectionHeader('System Impacts'),
           Wrap(

--- a/flutter/PulsarLottie/README.md
+++ b/flutter/PulsarLottie/README.md
@@ -31,6 +31,16 @@ HapticLottie.asset(
 );
 ```
 
+## Usage — from a bundle preset
+
+A `.pulsar` bundle preset carries its animation, pattern, duration and any synced audio, so the widget needs nothing else:
+
+```dart
+final pack = await pulsar.loadBundleAsync(acmePack);
+
+HapticLottie.preset(pack.celebration, autoPlay: true);
+```
+
 ## Usage — attach to your own `AnimationController`
 
 If you already drive Lottie with an `AnimationController`, wrap it:
@@ -55,16 +65,20 @@ haptic.pause();
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `haptics` | `PatternData?` | – | Pattern to sync. Omit for a plain animation. |
-| `mode` | `HapticMode` | `realtime` | `realtime` (progress-driven) or `pattern` (aligned-start). |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the animation, pattern and authored duration. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern; omit both for a plain animation. |
+| `hapticMode` | `HapticMode?` | `realtime` | `realtime` (progress-driven) or `pattern` (aligned-start). |
 | `hapticOffset` | `double` (ms) | `0` | Shift haptics ± relative to the animation. |
 | `hapticsEnabled` | `bool` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `double?` | `null` | Clock length in ms. Overrides every derived duration. |
 | `autoPlay` / `repeat` / `repeatCount` / `repeatReverse` | | | Standard Lottie steering. |
 
 ## Engine modes
 
 - **`realtime`** (default) — the `AnimationController` is the master clock; the pattern is sampled every frame into `RealtimeComposer.set` / `playDiscrete`. Honours pause / `setTimestamp` / loop. Continuous fidelity is realtime-grade (coarser on Android).
-- **`pattern`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity). Seek/pause on the haptic side are best-effort.
+- **`pattern`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity), and the only mode that plays a preset's synced audio. Seek/pause on the haptic side are best-effort.
+
+`hapticMode` defaults to `realtime`, except for a preset that carries audio, which starts in `pattern` so that audio plays.
 
 There is **no playback-speed control** — the haptic timeline can't be rate-shifted coherently, so the animation runs at its authored speed.
 

--- a/flutter/PulsarLottie/lib/src/haptic_lottie.dart
+++ b/flutter/PulsarLottie/lib/src/haptic_lottie.dart
@@ -4,13 +4,20 @@ import 'package:pulsar_haptics/pulsar.dart';
 
 import 'haptic_lottie_controller.dart';
 
-enum _LottieSource { asset, network }
+enum _LottieSource { asset, network, memory }
 
 /// A drop-in Lottie widget that plays Pulsar haptics in sync.
 ///
 /// Wraps the `lottie` package's `Lottie` widget with an internal
 /// `AnimationController` and a [HapticLottieController]. Pass [haptics] (a
 /// [PatternData]) to enable synced haptics; omit it for a plain animation.
+///
+/// [HapticLottie.preset] takes a bundle preset instead and renders the Lottie
+/// animation it was authored against, with its pattern and duration:
+///
+/// ```dart
+/// HapticLottie.preset(bundle.celebration, autoPlay: true)
+/// ```
 ///
 /// Grab the [HapticLottieController] via [onControllerCreated] to drive
 /// transport (`play`/`pause`/`setTimestamp`/…). Prefer this widget when you
@@ -21,10 +28,12 @@ class HapticLottie extends StatefulWidget {
   const HapticLottie.asset(
     this.src, {
     super.key,
+    this.preset,
     this.haptics,
-    this.mode = HapticMode.realtime,
+    this.hapticMode,
     this.hapticOffset = 0,
     this.hapticsEnabled = true,
+    this.durationMs,
     this.autoPlay = false,
     this.repeat = false,
     this.repeatCount,
@@ -40,10 +49,12 @@ class HapticLottie extends StatefulWidget {
   const HapticLottie.network(
     this.src, {
     super.key,
+    this.preset,
     this.haptics,
-    this.mode = HapticMode.realtime,
+    this.hapticMode,
     this.hapticOffset = 0,
     this.hapticsEnabled = true,
+    this.durationMs,
     this.autoPlay = false,
     this.repeat = false,
     this.repeatCount,
@@ -55,20 +66,55 @@ class HapticLottie extends StatefulWidget {
     this.alignment,
   }) : _source = _LottieSource.network;
 
+  /// Render a bundle [preset]: its Lottie animation, its pattern and its
+  /// authored duration, with no separate `src`.
+  ///
+  /// A preset that carries audio plays that audio too, which needs
+  /// [HapticMode.pattern] — so [hapticMode] defaults to `pattern` for one. A
+  /// preset with no animation renders an empty box; check `hasAnimation`, or use
+  /// [HapticLottie.asset] and pass the preset alongside it.
+  const HapticLottie.preset(
+    PresetHandle this.preset, {
+    super.key,
+    this.haptics,
+    this.hapticMode,
+    this.hapticOffset = 0,
+    this.hapticsEnabled = true,
+    this.durationMs,
+    this.autoPlay = false,
+    this.repeat = false,
+    this.repeatCount,
+    this.repeatReverse = false,
+    this.onControllerCreated,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment,
+  }) : src = '',
+       _source = _LottieSource.memory;
+
   /// Asset name or URL depending on the constructor used.
   final String src;
 
-  /// Pattern to sync with the animation. `null` ⇒ plain animation.
+  /// Bundle preset supplying the pattern and the authored duration — and, for
+  /// [HapticLottie.preset], the animation. `null` ⇒ none.
+  final PresetHandle? preset;
+
+  /// Pattern to sync with the animation. Overrides [preset]'s own pattern.
   final PatternData? haptics;
 
-  /// Engine mode. Defaults to [HapticMode.realtime].
-  final HapticMode mode;
+  /// Engine mode. Defaults to [HapticMode.realtime], or to [HapticMode.pattern]
+  /// for a [preset] that carries audio.
+  final HapticMode? hapticMode;
 
   /// Device tuning: shift haptics by ±ms relative to the animation.
   final double hapticOffset;
 
   /// Turn haptics off without changing the animation.
   final bool hapticsEnabled;
+
+  /// Explicit haptic clock length in ms. Overrides every derived duration.
+  final double? durationMs;
 
   /// Start playing as soon as the animation loads.
   final bool autoPlay;
@@ -114,10 +160,12 @@ class _HapticLottieState extends State<HapticLottie>
     _animController = AnimationController(vsync: this);
     _haptic = HapticLottieController(
       animationController: _animController,
+      preset: widget.preset,
       haptics: widget.haptics,
-      mode: widget.mode,
-      offsetMs: widget.hapticOffset,
-      enabled: widget.hapticsEnabled,
+      hapticMode: widget.hapticMode,
+      hapticOffset: widget.hapticOffset,
+      hapticsEnabled: widget.hapticsEnabled,
+      durationMs: widget.durationMs,
     );
     widget.onControllerCreated?.call(_haptic);
   }
@@ -160,6 +208,20 @@ class _HapticLottieState extends State<HapticLottie>
       case _LottieSource.network:
         return Lottie.network(
           widget.src,
+          controller: _animController,
+          onLoaded: _onLoaded,
+          width: widget.width,
+          height: widget.height,
+          fit: widget.fit,
+          alignment: widget.alignment,
+        );
+      case _LottieSource.memory:
+        final animation = widget.preset?.animation;
+        if (animation == null) {
+          return SizedBox(width: widget.width, height: widget.height);
+        }
+        return Lottie.memory(
+          animation.data,
           controller: _animController,
           onLoaded: _onLoaded,
           width: widget.width,

--- a/flutter/PulsarLottie/lib/src/haptic_lottie.dart
+++ b/flutter/PulsarLottie/lib/src/haptic_lottie.dart
@@ -69,10 +69,8 @@ class HapticLottie extends StatefulWidget {
   /// Render a bundle [preset]: its Lottie animation, its pattern and its
   /// authored duration, with no separate `src`.
   ///
-  /// A preset that carries audio plays that audio too, which needs
-  /// [HapticMode.pattern] — so [hapticMode] defaults to `pattern` for one. A
-  /// preset with no animation renders an empty box; check `hasAnimation`, or use
-  /// [HapticLottie.asset] and pass the preset alongside it.
+  /// A preset with no animation renders an empty box; check `hasAnimation`, or
+  /// use [HapticLottie.asset] and pass the preset alongside it.
   const HapticLottie.preset(
     PresetHandle this.preset, {
     super.key,

--- a/flutter/PulsarLottie/lib/src/haptic_lottie_controller.dart
+++ b/flutter/PulsarLottie/lib/src/haptic_lottie_controller.dart
@@ -30,11 +30,10 @@ enum HapticMode {
 class HapticLottieController {
   /// Creates a controller bound to [animationController].
   ///
-  /// Pass a bundle [preset] to take its pattern and authored duration, or
-  /// [haptics] for a pattern of your own — an explicit [haptics] wins. Omit both
-  /// for a plain animation. A preset that carries audio plays through its own
-  /// handle, which needs [HapticMode.pattern], so [hapticMode] defaults to
-  /// `pattern` for one; pass it yourself to override. The [pulsar] instance is
+  /// A bundle [preset] supplies the pattern and authored duration; an explicit
+  /// [haptics] overrides it, and omitting both leaves a plain animation.
+  /// [hapticMode] defaults to [HapticMode.realtime], or to [HapticMode.pattern]
+  /// for a preset carrying audio, which only sounds there. A [pulsar] instance is
   /// created internally if not supplied.
   HapticLottieController({
     required this.animationController,
@@ -46,7 +45,7 @@ class HapticLottieController {
     this.durationMs,
     Pulsar? pulsar,
   }) : _pulsar = pulsar ?? Pulsar(),
-       _playsItself = haptics == null && (preset?.hasAudio ?? false),
+       _playsOwnAudio = haptics == null && (preset?.hasAudio ?? false),
        hapticMode =
            hapticMode ??
            (haptics == null && (preset?.hasAudio ?? false)
@@ -78,7 +77,7 @@ class HapticLottieController {
   final double? durationMs;
 
   final Pulsar _pulsar;
-  final bool _playsItself;
+  final bool _playsOwnAudio;
   PulsarRealtimeComposer? _realtime;
   PulsarPatternComposer? _pattern;
   double _lastT = 0;
@@ -124,7 +123,7 @@ class HapticLottieController {
     if (_useRealtime) {
       _realtime = _pulsar.getRealtimeComposer();
       animationController.addListener(_onTick);
-    } else if (!_playsItself) {
+    } else if (!_playsOwnAudio) {
       _pattern = _pulsar.getPatternComposer();
       // Pre-parse so the engine is warm and play() fires without delay.
       unawaited(_pattern!.parsePattern(_resolvedPattern!));
@@ -167,7 +166,7 @@ class HapticLottieController {
     }
     if (_useRealtime) {
       _lastT = 0;
-    } else if (_playsItself) {
+    } else if (_playsOwnAudio) {
       preset!.play();
     } else {
       await _pattern?.play();
@@ -180,7 +179,7 @@ class HapticLottieController {
       if (_hasContinuous) {
         await _realtime?.stop();
       }
-    } else if (_playsItself) {
+    } else if (_playsOwnAudio) {
       preset?.stop();
     } else {
       await _pattern?.stop();

--- a/flutter/PulsarLottie/lib/src/haptic_lottie_controller.dart
+++ b/flutter/PulsarLottie/lib/src/haptic_lottie_controller.dart
@@ -30,83 +30,120 @@ enum HapticMode {
 class HapticLottieController {
   /// Creates a controller bound to [animationController].
   ///
-  /// Pass [haptics] (a [PatternData]) to enable haptics; omit it for a plain
-  /// animation. The [pulsar] instance is created internally if not supplied.
+  /// Pass a bundle [preset] to take its pattern and authored duration, or
+  /// [haptics] for a pattern of your own — an explicit [haptics] wins. Omit both
+  /// for a plain animation. A preset that carries audio plays through its own
+  /// handle, which needs [HapticMode.pattern], so [hapticMode] defaults to
+  /// `pattern` for one; pass it yourself to override. The [pulsar] instance is
+  /// created internally if not supplied.
   HapticLottieController({
     required this.animationController,
+    this.preset,
     this.haptics,
-    this.mode = HapticMode.realtime,
-    this.offsetMs = 0,
-    this.enabled = true,
+    HapticMode? hapticMode,
+    this.hapticOffset = 0,
+    this.hapticsEnabled = true,
+    this.durationMs,
     Pulsar? pulsar,
-  }) : _pulsar = pulsar ?? Pulsar() {
+  }) : _pulsar = pulsar ?? Pulsar(),
+       _playsItself = haptics == null && (preset?.hasAudio ?? false),
+       hapticMode =
+           hapticMode ??
+           (haptics == null && (preset?.hasAudio ?? false)
+               ? HapticMode.pattern
+               : HapticMode.realtime) {
     _attach();
   }
 
   /// The Lottie animation clock this controller follows and steers.
   final AnimationController animationController;
 
-  /// Pattern to sync with the animation. `null` ⇒ animation only.
+  /// Bundle preset supplying the pattern and the authored duration. `null` ⇒ none.
+  final PresetHandle? preset;
+
+  /// Pattern to sync with the animation. Overrides [preset]'s own pattern.
   final PatternData? haptics;
 
-  /// Engine mode. Defaults to [HapticMode.realtime].
-  final HapticMode mode;
+  /// Engine mode. Defaults to [HapticMode.realtime], or to [HapticMode.pattern]
+  /// for a [preset] that carries audio.
+  final HapticMode hapticMode;
 
   /// Device tuning: shift haptics by ±ms relative to the animation.
-  final double offsetMs;
+  final double hapticOffset;
 
   /// When `false`, the animation still plays but no haptics are emitted.
-  final bool enabled;
+  final bool hapticsEnabled;
+
+  /// Explicit clock length in ms. Overrides every derived duration.
+  final double? durationMs;
 
   final Pulsar _pulsar;
+  final bool _playsItself;
   PulsarRealtimeComposer? _realtime;
   PulsarPatternComposer? _pattern;
   double _lastT = 0;
   bool _disposed = false;
 
-  bool get _useRealtime => mode == HapticMode.realtime && haptics != null;
+  /// The pattern actually driving the haptics: an explicit one, else the preset's.
+  PatternData? get _resolvedPattern => haptics ?? preset?.pattern;
 
-  bool get _hasContinuous =>
-      haptics != null &&
-      haptics!.continuousPattern.amplitude.isNotEmpty &&
-      haptics!.continuousPattern.frequency.isNotEmpty;
+  bool get _useRealtime =>
+      hapticMode == HapticMode.realtime && _resolvedPattern != null;
 
-  /// Effective clock length in ms: the Lottie composition duration once loaded,
-  /// else the pattern's length.
-  double get durationMs {
+  bool get _hasContinuous {
+    final pattern = _resolvedPattern;
+    return pattern != null &&
+        pattern.continuousPattern.amplitude.isNotEmpty &&
+        pattern.continuousPattern.frequency.isNotEmpty;
+  }
+
+  /// Effective clock length in ms: an explicit [durationMs], else the preset's
+  /// authored duration, else the Lottie composition once loaded, else the
+  /// pattern's own length.
+  double get durationMsResolved {
+    final explicit = durationMs;
+    if (explicit != null && explicit > 0) {
+      return explicit;
+    }
+    final authored = preset?.duration;
+    if (authored != null && authored > 0) {
+      return authored;
+    }
     final d = animationController.duration;
     if (d != null && d.inMicroseconds > 0) {
       return d.inMicroseconds / 1000.0;
     }
-    return haptics != null ? patternDurationMs(haptics!) : 0;
+    final pattern = _resolvedPattern;
+    return pattern != null ? patternDurationMs(pattern) : 0;
   }
 
   void _attach() {
-    if (haptics == null || !enabled) {
+    if (_resolvedPattern == null || !hapticsEnabled) {
       return;
     }
     if (_useRealtime) {
       _realtime = _pulsar.getRealtimeComposer();
       animationController.addListener(_onTick);
-    } else {
+    } else if (!_playsItself) {
       _pattern = _pulsar.getPatternComposer();
       // Pre-parse so the engine is warm and play() fires without delay.
-      unawaited(_pattern!.parsePattern(haptics!));
+      unawaited(_pattern!.parsePattern(_resolvedPattern!));
     }
   }
 
   void _onTick() {
-    if (_disposed || !enabled || !_useRealtime) {
+    final pattern = _resolvedPattern;
+    if (_disposed || !hapticsEnabled || !_useRealtime || pattern == null) {
       return;
     }
-    final dur = durationMs;
+    final dur = durationMsResolved;
     final t = animationController.value * dur;
-    final ht = t + offsetMs;
+    final ht = t + hapticOffset;
     if (_hasContinuous) {
       unawaited(
         _realtime!.set(
-          clamp01(sampleEnvelope(haptics!.continuousPattern.amplitude, ht)),
-          clamp01(sampleEnvelope(haptics!.continuousPattern.frequency, ht)),
+          clamp01(sampleEnvelope(pattern.continuousPattern.amplitude, ht)),
+          clamp01(sampleEnvelope(pattern.continuousPattern.frequency, ht)),
         ),
       );
     }
@@ -114,20 +151,24 @@ class HapticLottieController {
     if (t < prev) {
       prev = 0; // wrapped on loop
     }
-    for (final e in haptics!.discretePattern) {
+    for (final e in pattern.discretePattern) {
       if (e.time > prev && e.time <= t) {
-        unawaited(_realtime!.playDiscrete(clamp01(e.amplitude), clamp01(e.frequency)));
+        unawaited(
+          _realtime!.playDiscrete(clamp01(e.amplitude), clamp01(e.frequency)),
+        );
       }
     }
     _lastT = t;
   }
 
   Future<void> _fireHaptics() async {
-    if (!enabled || haptics == null) {
+    if (!hapticsEnabled || _resolvedPattern == null) {
       return;
     }
     if (_useRealtime) {
       _lastT = 0;
+    } else if (_playsItself) {
+      preset!.play();
     } else {
       await _pattern?.play();
     }
@@ -139,6 +180,8 @@ class HapticLottieController {
       if (_hasContinuous) {
         await _realtime?.stop();
       }
+    } else if (_playsItself) {
+      preset?.stop();
     } else {
       await _pattern?.stop();
     }
@@ -178,7 +221,7 @@ class HapticLottieController {
 
   /// Seek both animation and haptics to [ms] from the start.
   void setTimestamp(double ms) {
-    final dur = durationMs;
+    final dur = durationMsResolved;
     if (dur > 0) {
       animationController.value = clamp01(ms / dur);
     }

--- a/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
+++ b/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pulsar_haptics/pulsar.dart';
+import 'package:pulsar_haptics_lottie/pulsar_haptics_lottie.dart';
+
+const _pattern = PatternData(
+  continuousPattern: ContinuousPattern(
+    amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 800, value: 1)],
+    frequency: [ValuePoint(time: 0, value: 0.3)],
+  ),
+  discretePattern: [DiscretePoint(time: 250, amplitude: 1, frequency: 0.5)],
+);
+
+PresetHandle _preset({bool hasAudio = false, double duration = 1500}) =>
+    PresetHandle(
+      'token',
+      'celebration',
+      name: 'Celebration',
+      duration: duration,
+      pattern: _pattern,
+      hasAudio: hasAudio,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('pulsar'),
+          (call) async => null,
+        );
+  });
+
+  HapticLottieController controllerFor({
+    PresetHandle? preset,
+    PatternData? haptics,
+    HapticMode? hapticMode,
+    double? durationMs,
+    Duration? compositionDuration,
+  }) {
+    final animation = AnimationController(
+      vsync: const TestVSync(),
+      duration: compositionDuration,
+    );
+    addTearDown(animation.dispose);
+    final controller = HapticLottieController(
+      animationController: animation,
+      preset: preset,
+      haptics: haptics,
+      hapticMode: hapticMode,
+      durationMs: durationMs,
+    );
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  test('a silent preset stays in realtime mode', () {
+    expect(controllerFor(preset: _preset()).hapticMode, HapticMode.realtime);
+  });
+
+  test('a preset with audio defaults to pattern mode, so its audio plays', () {
+    expect(
+      controllerFor(preset: _preset(hasAudio: true)).hapticMode,
+      HapticMode.pattern,
+    );
+  });
+
+  test('an explicit hapticMode wins over an audio preset default', () {
+    expect(
+      controllerFor(
+        preset: _preset(hasAudio: true),
+        hapticMode: HapticMode.realtime,
+      ).hapticMode,
+      HapticMode.realtime,
+    );
+  });
+
+  test('explicit haptics keep an audio preset from taking over the mode', () {
+    expect(
+      controllerFor(preset: _preset(hasAudio: true), haptics: _pattern).hapticMode,
+      HapticMode.realtime,
+    );
+  });
+
+  group('duration resolution', () {
+    test('an explicit durationMs wins over everything', () {
+      expect(
+        controllerFor(
+          preset: _preset(),
+          durationMs: 99,
+          compositionDuration: const Duration(milliseconds: 2400),
+        ).durationMsResolved,
+        99,
+      );
+    });
+
+    test("the preset's authored duration comes next", () {
+      expect(
+        controllerFor(
+          preset: _preset(),
+          compositionDuration: const Duration(milliseconds: 2400),
+        ).durationMsResolved,
+        1500,
+      );
+    });
+
+    test('then the Lottie composition, then the pattern length', () {
+      expect(
+        controllerFor(
+          haptics: _pattern,
+          compositionDuration: const Duration(milliseconds: 2400),
+        ).durationMsResolved,
+        2400,
+      );
+      expect(controllerFor(haptics: _pattern).durationMsResolved, 800);
+    });
+  });
+}

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
@@ -87,6 +87,37 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
 
+            "Pulsar_bundlePresets" -> {
+                val token = call.argument<String>("token")
+                val bundle = token?.let { bundles[it] }
+                    ?: return result.error("INVALID_ARGS", "unknown bundle token", null)
+                val includeAnimations = call.argument<Boolean>("includeAnimations") ?: true
+                result.success(
+                    bundle.presetIds.mapNotNull { id ->
+                        val preset = bundle.handle(id) ?: return@mapNotNull null
+                        buildMap<String, Any?> {
+                            put("id", preset.id)
+                            put("name", preset.name)
+                            put("duration", preset.duration.toDouble())
+                            put("hasAudio", preset.hasAudio)
+                            put("hasAnimation", preset.hasAnimation)
+                            put("pattern", patternMap(preset.pattern))
+                            val animation = preset.animation
+                            if (includeAnimations && animation != null) {
+                                put(
+                                    "animation",
+                                    mapOf(
+                                        "data" to animation.data,
+                                        "frameRate" to animation.frameRate,
+                                        "totalFrames" to animation.totalFrames,
+                                    ),
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+
             "Pulsar_playBundlePreset" -> {
                 val token = call.argument<String>("token")
                 val presetId = call.argument<String>("presetId")
@@ -342,6 +373,25 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             else -> result.notImplemented()
         }
     }
+
+    /** Wire shape for a preset's authored pattern — mirrors Dart's `PatternData.toMap()`. */
+    private fun patternMap(pattern: PatternData): Map<String, Any> = mapOf(
+        "continuousPattern" to mapOf(
+            "amplitude" to pattern.continuousPattern.amplitude.map {
+                mapOf("time" to it.time.toDouble(), "value" to it.value.toDouble())
+            },
+            "frequency" to pattern.continuousPattern.frequency.map {
+                mapOf("time" to it.time.toDouble(), "value" to it.value.toDouble())
+            },
+        ),
+        "discretePattern" to pattern.discretePattern.map {
+            mapOf(
+                "time" to it.time.toDouble(),
+                "amplitude" to it.amplitude.toDouble(),
+                "frequency" to it.frequency.toDouble(),
+            )
+        },
+    )
 
     @Suppress("UNCHECKED_CAST")
     private fun parsePatternData(data: Map<String, Any>): PatternData? {

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -19,6 +19,19 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
+  /// Wire shape for a preset's authored pattern — mirrors Dart's `PatternData.toMap()`.
+  private static func patternMap(_ pattern: PatternData) -> [String: Any] {
+    [
+      "continuousPattern": [
+        "amplitude": pattern.continuousPattern.amplitude.map { ["time": $0.time, "value": $0.value] },
+        "frequency": pattern.continuousPattern.frequency.map { ["time": $0.time, "value": $0.value] },
+      ],
+      "discretePattern": pattern.discretePattern.map {
+        ["time": $0.time, "amplitude": $0.amplitude, "frequency": $0.frequency]
+      },
+    ]
+  }
+
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     let args = call.arguments as? [String: Any]
     switch call.method {
@@ -45,6 +58,32 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
       } catch {
         result(FlutterError(code: "LOAD_BUNDLE_FAILED", message: "\(error)", details: nil))
       }
+
+    case "Pulsar_bundlePresets":
+      guard let token = args?["token"] as? String, let bundle = bundles[token] else {
+        result(FlutterError(code: "INVALID_ARGS", message: "unknown bundle token", details: nil))
+        return
+      }
+      let includeAnimations = args?["includeAnimations"] as? Bool ?? true
+      result(bundle.presetIds.compactMap { id -> [String: Any]? in
+        guard let preset = bundle.handle(id) else { return nil }
+        var map: [String: Any] = [
+          "id": preset.id,
+          "name": preset.name,
+          "duration": preset.duration,
+          "hasAudio": preset.hasAudio,
+          "hasAnimation": preset.hasAnimation,
+          "pattern": Self.patternMap(preset.pattern),
+        ]
+        if includeAnimations, let animation = preset.animation {
+          map["animation"] = [
+            "data": FlutterStandardTypedData(bytes: animation.data),
+            "frameRate": animation.frameRate,
+            "totalFrames": animation.totalFrames,
+          ]
+        }
+        return map
+      })
 
     case "Pulsar_playBundlePreset":
       guard let token = args?["token"] as? String, let presetId = args?["presetId"] as? String else {

--- a/flutter/pulsar/lib/pulsar_method_channel.dart
+++ b/flutter/pulsar/lib/pulsar_method_channel.dart
@@ -32,6 +32,18 @@ class MethodChannelPulsar extends PulsarPlatform {
   }
 
   @override
+  Future<List<Map<dynamic, dynamic>>> bundlePresets(
+    String token, {
+    bool includeAnimations = true,
+  }) async {
+    final presets = await methodChannel.invokeListMethod<dynamic>(
+      'Pulsar_bundlePresets',
+      {'token': token, 'includeAnimations': includeAnimations},
+    );
+    return (presets ?? const []).cast<Map<dynamic, dynamic>>();
+  }
+
+  @override
   Future<void> playBundlePreset(String token, String presetId) =>
       methodChannel.invokeMethod('Pulsar_playBundlePreset', {
         'token': token,

--- a/flutter/pulsar/lib/pulsar_platform_interface.dart
+++ b/flutter/pulsar/lib/pulsar_platform_interface.dart
@@ -34,6 +34,14 @@ abstract class PulsarPlatform extends PlatformInterface {
   Future<String> loadBundle(Uint8List bytes) =>
       throw UnimplementedError('loadBundle() not implemented');
 
+  /// Metadata for every preset in a loaded bundle: `id`, `name`, `duration`,
+  /// `hasAudio`, the authored `pattern`, and (when [includeAnimations]) the
+  /// Lottie bytes each preset was authored against.
+  Future<List<Map<dynamic, dynamic>>> bundlePresets(
+    String token, {
+    bool includeAnimations = true,
+  }) => throw UnimplementedError('bundlePresets() not implemented');
+
   Future<void> playBundlePreset(String token, String presetId) =>
       throw UnimplementedError('playBundlePreset() not implemented');
 

--- a/flutter/pulsar/lib/pulsar_types.dart
+++ b/flutter/pulsar/lib/pulsar_types.dart
@@ -76,6 +76,12 @@ class ValuePoint {
   /// Creates a [ValuePoint] with the given [time] (ms) and [value] (0.0–1.0).
   const ValuePoint({required this.time, required this.value});
 
+  /// Rebuilds a [ValuePoint] from its [toMap] shape.
+  factory ValuePoint.fromMap(Map<dynamic, dynamic> map) => ValuePoint(
+    time: (map['time'] as num).toDouble(),
+    value: (map['value'] as num).toDouble(),
+  );
+
   /// Time offset in milliseconds from the start of the pattern.
   final double time;
 
@@ -94,6 +100,13 @@ class DiscretePoint {
     required this.amplitude,
     required this.frequency,
   });
+
+  /// Rebuilds a [DiscretePoint] from its [toMap] shape.
+  factory DiscretePoint.fromMap(Map<dynamic, dynamic> map) => DiscretePoint(
+    time: (map['time'] as num).toDouble(),
+    amplitude: (map['amplitude'] as num).toDouble(),
+    frequency: (map['frequency'] as num).toDouble(),
+  );
 
   /// Time offset in milliseconds from the start of the pattern.
   final double time;
@@ -116,6 +129,18 @@ class ContinuousPattern {
   /// Creates a [ContinuousPattern] with the given [amplitude] and [frequency] curves.
   const ContinuousPattern({required this.amplitude, required this.frequency});
 
+  /// Rebuilds a [ContinuousPattern] from its [toMap] shape.
+  factory ContinuousPattern.fromMap(Map<dynamic, dynamic> map) =>
+      ContinuousPattern(
+        amplitude: _pointsFromList(map['amplitude']),
+        frequency: _pointsFromList(map['frequency']),
+      );
+
+  static List<ValuePoint> _pointsFromList(Object? raw) =>
+      (raw as List<dynamic>? ?? const [])
+          .map((p) => ValuePoint.fromMap(p as Map<dynamic, dynamic>))
+          .toList();
+
   /// Amplitude curve: list of [ValuePoint] controlling intensity over time.
   final List<ValuePoint> amplitude;
 
@@ -135,6 +160,18 @@ class PatternData {
     required this.continuousPattern,
     required this.discretePattern,
   });
+
+  /// Rebuilds a [PatternData] from its [toMap] shape — the wire form the native
+  /// side sends back for a bundle preset's authored pattern.
+  factory PatternData.fromMap(Map<dynamic, dynamic> map) => PatternData(
+    continuousPattern: ContinuousPattern.fromMap(
+      (map['continuousPattern'] as Map<dynamic, dynamic>?) ?? const {},
+    ),
+    discretePattern:
+        (map['discretePattern'] as List<dynamic>? ?? const [])
+            .map((p) => DiscretePoint.fromMap(p as Map<dynamic, dynamic>))
+            .toList(),
+  );
 
   /// Raw array constructor matching the native iOS/Android shorthand:
   ///

--- a/flutter/pulsar/lib/src/pulsar_bundle.dart
+++ b/flutter/pulsar/lib/src/pulsar_bundle.dart
@@ -1,40 +1,139 @@
 part of 'package:pulsar_haptics/pulsar.dart';
 
+/// Lottie bytes + timing for a preset's animation; the host app's own Lottie
+/// widget renders it. The Lottie SDK's `HapticLottie.preset` does it for you.
+class BundleAnimation {
+  /// Creates a [BundleAnimation] from raw Lottie bytes and its authored timing.
+  const BundleAnimation({
+    required this.data,
+    required this.frameRate,
+    required this.totalFrames,
+  });
+
+  /// Rebuilds a [BundleAnimation] from the wire shape the native side sends.
+  factory BundleAnimation.fromMap(Map<dynamic, dynamic> map) => BundleAnimation(
+    data: map['data'] as Uint8List,
+    frameRate: (map['frameRate'] as num?)?.toDouble() ?? 0,
+    totalFrames: (map['totalFrames'] as num?)?.toInt() ?? 0,
+  );
+
+  /// The raw Lottie JSON bytes, ready for `Lottie.memory`.
+  final Uint8List data;
+
+  /// Frames per second the animation was authored at.
+  final double frameRate;
+
+  /// Total frame count of the animation.
+  final int totalFrames;
+}
+
 /// A single playable preset from a loaded bundle.
+///
+/// [play] and [stop] run the preset natively — haptics plus its synced audio, if
+/// it has any. [pattern], [animation] and [duration] expose what the preset was
+/// authored from, so a Lottie view can sample the pattern against the animation
+/// timeline itself.
 class PresetHandle {
-  PresetHandle(this._token, this.id);
+  /// Creates a handle over the preset [id] in the bundle held under [token].
+  PresetHandle(
+    this._token,
+    this.id, {
+    this.name = '',
+    this.duration = 0,
+    PatternData? pattern,
+    this.animation,
+    this.hasAudio = false,
+  }) : pattern = pattern ?? _emptyPattern;
+
+  /// Rebuilds a [PresetHandle] from the wire shape the native side sends.
+  factory PresetHandle.fromMap(String token, Map<dynamic, dynamic> map) {
+    final animation = map['animation'] as Map<dynamic, dynamic>?;
+    return PresetHandle(
+      token,
+      map['id'] as String,
+      name: (map['name'] as String?) ?? '',
+      duration: (map['duration'] as num?)?.toDouble() ?? 0,
+      pattern: PatternData.fromMap(
+        (map['pattern'] as Map<dynamic, dynamic>?) ?? const {},
+      ),
+      animation:
+          animation == null ? null : BundleAnimation.fromMap(animation),
+      hasAudio: (map['hasAudio'] as bool?) ?? false,
+    );
+  }
+
+  static const _emptyPattern = PatternData(
+    continuousPattern: ContinuousPattern(amplitude: [], frequency: []),
+    discretePattern: [],
+  );
 
   final String _token;
+
+  /// Code-safe id the preset is addressed by.
   final String id;
 
+  /// Human label the preset was authored under.
+  final String name;
+
+  /// Authored length in milliseconds, or 0 when the bundle carries no hint.
+  final double duration;
+
+  /// The authored pattern. Read it to drive a timeline yourself — the Lottie SDK
+  /// samples it per frame in realtime mode. [play] stays the engine-native route.
+  final PatternData pattern;
+
+  /// The Lottie animation the preset was authored against, when it has one.
+  final BundleAnimation? animation;
+
+  /// Whether the preset carries a synced audio track, which [play] plays
+  /// alongside the haptics.
+  final bool hasAudio;
+
+  /// Whether the preset carries a Lottie animation, exposed as [animation].
+  bool get hasAnimation => animation != null;
+
+  /// Play the preset natively — haptics, plus its synced audio when it has any.
   void play() => unawaited(PulsarPlatform.instance.playBundlePreset(_token, id));
+
+  /// Stop a preset started with [play].
   void stop() => unawaited(PulsarPlatform.instance.stopBundlePreset(_token, id));
 }
 
 /// Looks up preset handles by id when a generated descriptor builds its typed presets view.
 /// Backs a generated presets class.
 class BundleResolver {
+  /// Creates a resolver over the bundle held natively under [_token].
   BundleResolver(this._token, this.bundleId, this.contentHash);
 
   final String _token;
 
+  /// Reverse-DNS identity of the loaded bundle.
   final String bundleId;
+
+  /// Content hash the generated descriptor was built against.
   final String contentHash;
 
-  PresetHandle operator [](String id) => PresetHandle(_token, id);
+  Map<String, PresetHandle> _handles = const {};
 
-  PresetHandle? handle(String id) => _presetIds.contains(id) ? PresetHandle(_token, id) : null;
+  /// Resolve a preset the descriptor already guaranteed exists.
+  PresetHandle operator [](String id) =>
+      _handles[id] ?? PresetHandle(_token, id);
 
+  /// Look a preset up by an id only known at runtime.
+  PresetHandle? handle(String id) => _handles[id];
+
+  /// Release the native patterns this bundle parsed.
   void dispose() => unawaited(PulsarPlatform.instance.disposeBundle(_token));
 
-  Set<String> _presetIds = const {};
   // ignore: use_setters_to_change_properties
-  void bindPresetIds(Set<String> ids) => _presetIds = ids;
+  /// Called by the loader with the metadata read back from the native bundle.
+  void bindPresets(Map<String, PresetHandle> handles) => _handles = handles;
 }
 
 /// Emitted by pulsar-gen: binds a bundle asset + hash to a typed presets builder.
 /// See the generated `*.bundle.dart`.
 class BundleDescriptor<P> {
+  /// Creates a descriptor for the bundle asset at [assetName].
   const BundleDescriptor({
     required this.assetName,
     required this.bundleId,
@@ -45,9 +144,17 @@ class BundleDescriptor<P> {
 
   /// Flutter asset path, e.g. `assets/pulsar/acme-pack.pulsar`.
   final String assetName;
+
+  /// Reverse-DNS identity of the bundle.
   final String bundleId;
+
+  /// Content hash the generated types were built against.
   final String contentHash;
+
+  /// Every preset id the generated types expect to find.
   final List<String> presetIds;
+
+  /// Builds the generated presets class from a resolver.
   final P Function(BundleResolver resolver) build;
 }
 
@@ -63,9 +170,13 @@ extension PulsarBundleLoader on Pulsar {
   /// final bundle = await pulsar.loadBundleAsync(acmePack); // acmePack is generated
   /// bundle.heartbeatV2.play();
   /// ```
+  ///
+  /// Pass `includeAnimations: false` to skip reading each preset's Lottie bytes
+  /// back across the platform channel when nothing will render them.
   Future<P> loadBundleAsync<P>(
     BundleDescriptor<P> descriptor, {
     bool strict = true,
+    bool includeAnimations = true,
   }) async {
     final data = await rootBundle.load(descriptor.assetName);
     final bytes = Uint8List.view(
@@ -77,8 +188,27 @@ extension PulsarBundleLoader on Pulsar {
     if (token.isEmpty) {
       throw StateError('Pulsar: failed to load bundle "${descriptor.bundleId}"');
     }
-    final resolver = BundleResolver(token, descriptor.bundleId, descriptor.contentHash)
-      ..bindPresetIds(descriptor.presetIds.toSet());
+    final raw = await PulsarPlatform.instance.bundlePresets(
+      token,
+      includeAnimations: includeAnimations,
+    );
+    final handles = {
+      for (final entry in raw)
+        entry['id'] as String: PresetHandle.fromMap(token, entry),
+    };
+    if (strict) {
+      final missing =
+          descriptor.presetIds.where((id) => !handles.containsKey(id)).toList();
+      if (missing.isNotEmpty) {
+        throw StateError(
+          'Pulsar: bundle "${descriptor.bundleId}" is missing preset(s) '
+          '$missing — regenerate types with pulsar-gen.',
+        );
+      }
+    }
+    final resolver =
+        BundleResolver(token, descriptor.bundleId, descriptor.contentHash)
+          ..bindPresets(handles);
     return descriptor.build(resolver);
   }
 }

--- a/flutter/pulsar/test/pulsar_method_channel_test.dart
+++ b/flutter/pulsar/test/pulsar_method_channel_test.dart
@@ -52,7 +52,13 @@ void main() {
     final call = loggedCalls.single;
     expect(call.method, 'PatternComposer_parsePatternWithSound');
     final args = call.arguments as Map;
-    expect(args['sound'], {'uri': 'beep', 'volume': 0.5, 'offset': 20});
+    expect(args['sound'], {
+      'uri': 'beep',
+      'volume': 0.5,
+      'offset': 20,
+      'start': 0,
+      'duration': 0,
+    });
     expect(args['data'], isNotNull);
     expect(args.containsKey('composerId'), isFalse);
   });

--- a/flutter/pulsar/test/pulsar_test.dart
+++ b/flutter/pulsar/test/pulsar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pulsar_haptics/pulsar.dart';
@@ -111,6 +113,31 @@ class MockPulsarPlatform
 
   @override
   Future<void> stopHaptics() async {}
+
+  @override
+  Future<String> loadBundle(Uint8List bytes) async => 'bundle-token';
+
+  @override
+  Future<List<Map<dynamic, dynamic>>> bundlePresets(
+    String token, {
+    bool includeAnimations = true,
+  }) async => const [];
+
+  @override
+  Future<void> playBundlePreset(String token, String presetId) async {}
+
+  @override
+  Future<void> stopBundlePreset(String token, String presetId) async {}
+
+  @override
+  Future<void> disposeBundle(String token) async {}
+
+  @override
+  Future<int> patternParsePatternWithSound(
+    PatternData data,
+    Sound sound, {
+    int? composerId,
+  }) async => nextComposerId++;
 }
 
 void main() {

--- a/iOS/Pulsar/Sources/Pulsar/Bundle/BundleLoader.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Bundle/BundleLoader.swift
@@ -35,6 +35,7 @@ extension Pulsar {
 
       handles[preset.id] = PresetHandle(
         id: preset.id,
+        name: preset.name,
         duration: preset.duration ?? 0,
         pulsar: self,
         pattern: pattern,

--- a/iOS/Pulsar/Sources/Pulsar/Bundle/PulsarBundle.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Bundle/PulsarBundle.swift
@@ -57,16 +57,25 @@ struct ResolvedSound {
 /// A single playable preset from a loaded bundle. Parses its pattern lazily on first play.
 @objc public final class PresetHandle: NSObject {
   @objc public let id: String
+  /// Human label the preset was authored under.
+  @objc public let name: String
   @objc public let duration: Double
   @objc public let animation: BundleAnimation?
+  /// The authored pattern. Read it to drive a timeline yourself — the Lottie SDK samples it per
+  /// frame in realtime mode. ``play()`` stays the pre-parsed, engine-native route.
+  @objc public let pattern: PatternData
+  /// Whether the preset carries a synced audio track, which ``play()`` plays alongside the haptics.
+  @objc public var hasAudio: Bool { sound != nil }
+  /// Whether the preset carries a Lottie animation, exposed as ``animation``.
+  @objc public var hasAnimation: Bool { animation != nil }
 
   private weak var pulsar: Pulsar?
-  private let pattern: PatternData
   private let sound: ResolvedSound?
   private var composer: PatternComposer?
 
-  init(id: String, duration: Double, pulsar: Pulsar, pattern: PatternData, sound: ResolvedSound?, animation: BundleAnimation?) {
+  init(id: String, name: String, duration: Double, pulsar: Pulsar, pattern: PatternData, sound: ResolvedSound?, animation: BundleAnimation?) {
     self.id = id
+    self.name = name
     self.duration = duration
     self.pulsar = pulsar
     self.pattern = pattern

--- a/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
@@ -4,8 +4,8 @@ import Foundation
 /// - time: Time in milliseconds (ms)
 /// - value: Normalized value between 0.0 and 1.0
 @objc public class ValuePoint: NSObject, Codable {
-  let time: Double
-  let value: Float
+  @objc public let time: Double
+  @objc public let value: Float
   @objc public init(time: Double, value: Float) {
     self.time = time
     self.value = value
@@ -17,9 +17,9 @@ import Foundation
 /// - amplitude: Intensity of the haptic (0.0 - 1.0)
 /// - frequency: Sharpness of the haptic (0.0 - 1.0)
 @objc public class DiscretePoint: NSObject, Codable {
-  let time: Double
-  let amplitude: Float
-  let frequency: Float
+  @objc public let time: Double
+  @objc public let amplitude: Float
+  @objc public let frequency: Float
   @objc public init(time: Double, amplitude: Float, frequency: Float) {
     self.time = time
     self.amplitude = amplitude
@@ -28,8 +28,8 @@ import Foundation
 }
 
 @objc public class ContinuousPattern: NSObject, Codable {
-  let amplitude: [ValuePoint]
-  let frequency: [ValuePoint]
+  @objc public let amplitude: [ValuePoint]
+  @objc public let frequency: [ValuePoint]
   @objc public init(amplitude: [ValuePoint], frequency: [ValuePoint]) {
     self.amplitude = amplitude
     self.frequency = frequency
@@ -37,8 +37,8 @@ import Foundation
 }
 
 @objc public class PatternData: NSObject, Codable {
-  let continuousPattern: ContinuousPattern
-  let discretePattern: [DiscretePoint]
+  @objc public let continuousPattern: ContinuousPattern
+  @objc public let discretePattern: [DiscretePoint]
   @objc public init(continuousPattern: ContinuousPattern, discretePattern: [DiscretePoint]) {
     self.continuousPattern = continuousPattern
     self.discretePattern = discretePattern

--- a/iOS/PulsarApp/PulsarApp/BundlesView.swift
+++ b/iOS/PulsarApp/PulsarApp/BundlesView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Pulsar
+import PulsarLottie
 
 /// Plays presets from `hapticsBundle.pulsar`, which Xcode's synchronized group copies into the app
 /// bundle. `HapticsBundle.swift` alongside it is committed `pulsar-gen --target swift` output.
@@ -8,6 +9,7 @@ struct BundlesView: View {
 
     @State private var bundle: PulsarBundle<HapticsBundle.Presets>?
     @State private var loadError: String?
+    @State private var lottieRunId = 0
 
     var body: some View {
         NavigationStack {
@@ -21,13 +23,18 @@ struct BundlesView: View {
                         PresetRow(title: "Lottie", preset: bundle.lottie, note: "with animation")
                     }
 
-                    Section("Animation bytes") {
-                        // Pulsar carries and times the Lottie; the app renders it.
+                    Section("Animation from a preset") {
+                        // The preset carries its animation as well as its pattern, so
+                        // HapticLottieView needs neither a name nor a haptics argument.
+                        HapticLottieView(preset: bundle.lottie)
+                            .frame(height: 160)
+                            .frame(maxWidth: .infinity)
+                            .id(lottieRunId)
+                        Button("▶ Replay animation") { lottieRunId += 1 }
                         if let animation = bundle.lottie.animation {
                             Text("\(animation.data.count) bytes at \(Int(animation.frameRate)) fps, \(animation.totalFrames) frames")
                                 .font(.footnote)
-                        } else {
-                            Text("No animation carried for this preset.").font(.footnote)
+                                .foregroundStyle(.secondary)
                         }
                     }
 

--- a/iOS/PulsarApp/PulsarApp/BundlesView.swift
+++ b/iOS/PulsarApp/PulsarApp/BundlesView.swift
@@ -24,8 +24,6 @@ struct BundlesView: View {
                     }
 
                     Section("Animation from a preset") {
-                        // The preset carries its animation as well as its pattern, so
-                        // HapticLottieView needs neither a name nor a haptics argument.
                         HapticLottieView(preset: bundle.lottie)
                             .frame(height: 160)
                             .frame(maxWidth: .infinity)

--- a/iOS/PulsarLottie/README.md
+++ b/iOS/PulsarLottie/README.md
@@ -26,11 +26,23 @@ HapticLottieView("success", haptics: pattern, autoPlay: true)
   .frame(width: 200, height: 200)
 ```
 
+## Usage — from a bundle preset
+
+A `.pulsar` bundle preset carries its animation, pattern, duration and any synced audio, so the view needs nothing else:
+
+```swift
+let pack = try pulsar.loadBundleSync(AcmePack.descriptor)
+
+HapticLottieView(preset: pack.celebration)
+  .frame(width: 200, height: 200)
+```
+
 ## Usage — UIKit / attach to an existing view
 
 ```swift
 let animationView = LottieAnimationView(name: "success")
 let controller = PulsarLottie.bind(animationView, pulsar: pulsar, haptics: pattern)
+// …or from a bundle preset: PulsarLottie.bind(animationView, pulsar: pulsar, preset: pack.celebration)
 
 controller.play()
 controller.setTimestamp(1200) // seek both animation + haptics to 1.2s
@@ -40,7 +52,9 @@ controller.pause()
 ## Engine modes
 
 - **`.realtime`** (default) — a `CADisplayLink` makes the animation timeline the master clock, driving `currentProgress` and sampling the pattern into `RealtimeComposer.set` / `playDiscrete`. Honours pause / `setTimestamp` / loop.
-- **`.pattern`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity).
+- **`.pattern`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity), and the only mode that plays a preset's synced audio.
+
+`hapticMode` defaults to `.realtime`, except for a preset that carries audio, which starts in `.pattern` so that audio plays.
 
 There is **no playback-speed control** — the haptic timeline can't be rate-shifted coherently, so the animation runs at its authored speed.
 

--- a/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieController.swift
+++ b/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieController.swift
@@ -16,22 +16,26 @@ public enum HapticMode {
 /// Drives Pulsar haptics from a Lottie `LottieAnimationView`.
 ///
 /// Attach it to a `LottieAnimationView` you already use (or via
-/// ``PulsarLottie/bind(_:pulsar:haptics:mode:offsetMs:enabled:)``); the transport
-/// (`play`/`pause`/`resume`/`stop`/`reset`/`setTimestamp`/`setLoop`) steers both
-/// the animation and the haptics. In ``HapticMode/realtime`` a display link
-/// drives `currentProgress` and samples the pattern; in ``HapticMode/pattern`` a
-/// pre-parsed pattern is fired aligned to the start.
+/// ``PulsarLottie/bind(_:pulsar:preset:haptics:hapticMode:hapticOffset:hapticsEnabled:durationMs:)``);
+/// the transport (`play`/`pause`/`resume`/`stop`/`reset`/`setTimestamp`/`setLoop`)
+/// steers both the animation and the haptics. In ``HapticMode/realtime`` a display
+/// link drives `currentProgress` and samples the pattern; in ``HapticMode/pattern``
+/// a pre-parsed pattern is fired aligned to the start.
 public final class HapticLottieController: NSObject {
     private let animationView: LottieAnimationView
     private let sampled: SampledPattern?
     private let mode: HapticMode
-    private let offsetMs: Double
-    private let enabled: Bool
+    private let hapticOffset: Double
+    private let hapticsEnabled: Bool
+    private let explicitDurationMs: Double?
+    private let presetDurationMs: Double?
 
     private let useRealtime: Bool
     private let hasContinuous: Bool
     private let realtime: RealtimeComposer?
     private let pattern: PatternComposer?
+    /// Set when the preset plays itself, so the audio it was authored with plays too.
+    private let presetPlayback: PresetHandle?
 
     private var displayLink: CADisplayLink?
     private var timeMs: Double = 0
@@ -40,25 +44,40 @@ public final class HapticLottieController: NSObject {
     private var loop = false
 
     /// Creates a controller bound to `animationView`.
+    ///
+    /// Pass a bundle `preset` to take its pattern and authored duration, or `haptics`
+    /// for a pattern of your own — an explicit `haptics` wins. A preset that carries
+    /// audio plays through its own handle, which needs ``HapticMode/pattern``, so
+    /// `hapticMode` defaults to `.pattern` for one; pass it yourself to override.
     public init(
         animationView: LottieAnimationView,
         pulsar: Pulsar,
+        preset: PresetHandle? = nil,
         haptics: PatternData? = nil,
-        mode: HapticMode = .realtime,
-        offsetMs: Double = 0,
-        enabled: Bool = true
+        hapticMode: HapticMode? = nil,
+        hapticOffset: Double = 0,
+        hapticsEnabled: Bool = true,
+        durationMs: Double? = nil
     ) {
+        let resolved = haptics ?? preset?.pattern
+        let playsItself = haptics == nil && preset?.hasAudio == true
+        let mode = hapticMode ?? (playsItself ? .pattern : .realtime)
+
         self.animationView = animationView
         self.mode = mode
-        self.offsetMs = offsetMs
-        self.enabled = enabled
-        let realtimeMode = mode == .realtime && haptics != nil
+        self.hapticOffset = hapticOffset
+        self.hapticsEnabled = hapticsEnabled
+        self.explicitDurationMs = durationMs
+        self.presetDurationMs = preset.map { $0.duration }.flatMap { $0 > 0 ? $0 : nil }
+
+        let realtimeMode = mode == .realtime && resolved != nil
         self.useRealtime = realtimeMode
-        let flattened = haptics.flatMap { sampledPattern(from: $0) }
+        let flattened = resolved.map { sampledPattern(from: $0) }
         self.sampled = flattened
         self.hasContinuous = flattened?.hasContinuous ?? false
         self.realtime = realtimeMode ? pulsar.getRealtimeComposer() : nil
-        if !realtimeMode, let h = haptics {
+        self.presetPlayback = realtimeMode ? nil : (playsItself ? preset : nil)
+        if !realtimeMode, !playsItself, let h = resolved {
             let pc = pulsar.getPatternComposer()
             pc.parsePattern(hapticsData: h) // pre-parse / warm
             self.pattern = pc
@@ -72,7 +91,11 @@ public final class HapticLottieController: NSObject {
         displayLink?.invalidate()
     }
 
+    /// Clock length in ms: an explicit duration, else the preset's authored one, else the
+    /// Lottie composition once loaded, else the pattern's own length.
     private var durationMs: Double {
+        if let explicitDurationMs, explicitDurationMs > 0 { return explicitDurationMs }
+        if let presetDurationMs { return presetDurationMs }
         if let d = animationView.animation?.duration, d > 0 {
             return d * 1000.0
         }
@@ -187,8 +210,8 @@ public final class HapticLottieController: NSObject {
         timeMs = t
         if dur > 0 { animationView.currentProgress = CGFloat(t / dur) }
 
-        if enabled {
-            let ht = t + offsetMs
+        if hapticsEnabled {
+            let ht = t + hapticOffset
             if hasContinuous {
                 realtime?.set(
                     amplitude: clamp01(sampleEnvelope(s.amplitude, ht)),
@@ -208,14 +231,16 @@ public final class HapticLottieController: NSObject {
 
         if ended {
             stopDisplayLink()
-            if enabled && hasContinuous { realtime?.stop() }
+            if hapticsEnabled && hasContinuous { realtime?.stop() }
         }
     }
 
     private func fireHaptics() {
-        guard enabled, sampled != nil else { return }
+        guard hapticsEnabled else { return }
         if useRealtime {
             lastT = 0
+        } else if let presetPlayback {
+            presetPlayback.play()
         } else {
             pattern?.play()
         }
@@ -224,7 +249,9 @@ public final class HapticLottieController: NSObject {
     private func stopHaptics() {
         if useRealtime {
             lastT = 0
-            if enabled && hasContinuous { realtime?.stop() }
+            if hapticsEnabled && hasContinuous { realtime?.stop() }
+        } else if let presetPlayback {
+            presetPlayback.stop()
         } else {
             pattern?.stop()
         }
@@ -235,21 +262,27 @@ public final class HapticLottieController: NSObject {
 public enum PulsarLottie {
     /// Attach Pulsar haptics to `animationView` and return the controller that
     /// steers animation + haptics.
+    ///
+    ///     let controller = PulsarLottie.bind(view, pulsar: pulsar, preset: pack.celebration)
     public static func bind(
         _ animationView: LottieAnimationView,
         pulsar: Pulsar,
-        haptics: PatternData,
-        mode: HapticMode = .realtime,
-        offsetMs: Double = 0,
-        enabled: Bool = true
+        preset: PresetHandle? = nil,
+        haptics: PatternData? = nil,
+        hapticMode: HapticMode? = nil,
+        hapticOffset: Double = 0,
+        hapticsEnabled: Bool = true,
+        durationMs: Double? = nil
     ) -> HapticLottieController {
         HapticLottieController(
             animationView: animationView,
             pulsar: pulsar,
+            preset: preset,
             haptics: haptics,
-            mode: mode,
-            offsetMs: offsetMs,
-            enabled: enabled
+            hapticMode: hapticMode,
+            hapticOffset: hapticOffset,
+            hapticsEnabled: hapticsEnabled,
+            durationMs: durationMs
         )
     }
 }

--- a/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieController.swift
+++ b/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieController.swift
@@ -34,8 +34,7 @@ public final class HapticLottieController: NSObject {
     private let hasContinuous: Bool
     private let realtime: RealtimeComposer?
     private let pattern: PatternComposer?
-    /// Set when the preset plays itself, so the audio it was authored with plays too.
-    private let presetPlayback: PresetHandle?
+    private let audioPreset: PresetHandle?
 
     private var displayLink: CADisplayLink?
     private var timeMs: Double = 0
@@ -45,10 +44,9 @@ public final class HapticLottieController: NSObject {
 
     /// Creates a controller bound to `animationView`.
     ///
-    /// Pass a bundle `preset` to take its pattern and authored duration, or `haptics`
-    /// for a pattern of your own — an explicit `haptics` wins. A preset that carries
-    /// audio plays through its own handle, which needs ``HapticMode/pattern``, so
-    /// `hapticMode` defaults to `.pattern` for one; pass it yourself to override.
+    /// A bundle `preset` supplies the pattern and authored duration; an explicit
+    /// `haptics` overrides it. `hapticMode` defaults to `.realtime`, or to `.pattern`
+    /// for a preset carrying audio, which only sounds there.
     public init(
         animationView: LottieAnimationView,
         pulsar: Pulsar,
@@ -60,8 +58,8 @@ public final class HapticLottieController: NSObject {
         durationMs: Double? = nil
     ) {
         let resolved = haptics ?? preset?.pattern
-        let playsItself = haptics == nil && preset?.hasAudio == true
-        let mode = hapticMode ?? (playsItself ? .pattern : .realtime)
+        let playsOwnAudio = haptics == nil && preset?.hasAudio == true
+        let mode = hapticMode ?? (playsOwnAudio ? .pattern : .realtime)
 
         self.animationView = animationView
         self.mode = mode
@@ -76,8 +74,8 @@ public final class HapticLottieController: NSObject {
         self.sampled = flattened
         self.hasContinuous = flattened?.hasContinuous ?? false
         self.realtime = realtimeMode ? pulsar.getRealtimeComposer() : nil
-        self.presetPlayback = realtimeMode ? nil : (playsItself ? preset : nil)
-        if !realtimeMode, !playsItself, let h = resolved {
+        self.audioPreset = realtimeMode ? nil : (playsOwnAudio ? preset : nil)
+        if !realtimeMode, !playsOwnAudio, let h = resolved {
             let pc = pulsar.getPatternComposer()
             pc.parsePattern(hapticsData: h) // pre-parse / warm
             self.pattern = pc
@@ -239,8 +237,8 @@ public final class HapticLottieController: NSObject {
         guard hapticsEnabled else { return }
         if useRealtime {
             lastT = 0
-        } else if let presetPlayback {
-            presetPlayback.play()
+        } else if let audioPreset {
+            audioPreset.play()
         } else {
             pattern?.play()
         }
@@ -250,8 +248,8 @@ public final class HapticLottieController: NSObject {
         if useRealtime {
             lastT = 0
             if hapticsEnabled && hasContinuous { realtime?.stop() }
-        } else if let presetPlayback {
-            presetPlayback.stop()
+        } else if let audioPreset {
+            audioPreset.stop()
         } else {
             pattern?.stop()
         }

--- a/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieView.swift
+++ b/iOS/PulsarLottie/Sources/PulsarLottie/HapticLottieView.swift
@@ -6,13 +6,26 @@ import Pulsar
 ///
 /// A thin wrapper over `LottieAnimationView` + ``HapticLottieController``. Pass
 /// `haptics` to enable synced haptics; omit it for a plain animation.
+///
+/// A bundle preset supplies the animation, the pattern and the duration at once:
+///
+///     HapticLottieView(preset: pack.celebration)
 public struct HapticLottieView: UIViewRepresentable {
-    private let name: String
-    private let bundle: Bundle
+    /// Where the Lottie animation comes from.
+    private enum Animation {
+        /// A `.json` / `.lottie` resource in a bundle.
+        case named(String, Bundle)
+        /// Raw Lottie bytes, as carried by a bundle preset.
+        case data(Data)
+    }
+
+    private let animation: Animation
+    private let preset: PresetHandle?
     private let haptics: PatternData?
-    private let mode: HapticMode
+    private let hapticMode: HapticMode?
     private let hapticOffset: Double
     private let hapticsEnabled: Bool
+    private let durationMs: Double?
     private let autoPlay: Bool
     private let loopMode: LottieLoopMode
 
@@ -20,19 +33,50 @@ public struct HapticLottieView: UIViewRepresentable {
     public init(
         _ name: String,
         bundle: Bundle = .main,
+        preset: PresetHandle? = nil,
         haptics: PatternData? = nil,
-        mode: HapticMode = .realtime,
+        hapticMode: HapticMode? = nil,
         hapticOffset: Double = 0,
         hapticsEnabled: Bool = true,
+        durationMs: Double? = nil,
         autoPlay: Bool = true,
         loopMode: LottieLoopMode = .playOnce
     ) {
-        self.name = name
-        self.bundle = bundle
+        self.animation = .named(name, bundle)
+        self.preset = preset
         self.haptics = haptics
-        self.mode = mode
+        self.hapticMode = hapticMode
         self.hapticOffset = hapticOffset
         self.hapticsEnabled = hapticsEnabled
+        self.durationMs = durationMs
+        self.autoPlay = autoPlay
+        self.loopMode = loopMode
+    }
+
+    /// Render a bundle `preset`: its Lottie animation, its pattern and its authored
+    /// duration, with no separate `source`.
+    ///
+    /// A preset that carries audio plays that audio too, which needs
+    /// ``HapticMode/pattern`` — so `hapticMode` defaults to `.pattern` for one.
+    /// A preset with no animation renders nothing; check `hasAnimation`, or use the
+    /// `name:` initializer and pass the preset alongside it.
+    public init(
+        preset: PresetHandle,
+        haptics: PatternData? = nil,
+        hapticMode: HapticMode? = nil,
+        hapticOffset: Double = 0,
+        hapticsEnabled: Bool = true,
+        durationMs: Double? = nil,
+        autoPlay: Bool = true,
+        loopMode: LottieLoopMode = .playOnce
+    ) {
+        self.animation = .data(preset.animation?.data ?? Data())
+        self.preset = preset
+        self.haptics = haptics
+        self.hapticMode = hapticMode
+        self.hapticOffset = hapticOffset
+        self.hapticsEnabled = hapticsEnabled
+        self.durationMs = durationMs
         self.autoPlay = autoPlay
         self.loopMode = loopMode
     }
@@ -42,16 +86,24 @@ public struct HapticLottieView: UIViewRepresentable {
     }
 
     public func makeUIView(context: Context) -> LottieAnimationView {
-        let view = LottieAnimationView(name: name, bundle: bundle)
+        let view: LottieAnimationView
+        switch animation {
+        case let .named(name, bundle):
+            view = LottieAnimationView(name: name, bundle: bundle)
+        case let .data(data):
+            view = LottieAnimationView(animation: try? LottieAnimation.from(data: data))
+        }
         view.loopMode = loopMode
         view.contentMode = .scaleAspectFit
         let controller = HapticLottieController(
             animationView: view,
             pulsar: context.coordinator.pulsar,
+            preset: preset,
             haptics: haptics,
-            mode: mode,
-            offsetMs: hapticOffset,
-            enabled: hapticsEnabled
+            hapticMode: hapticMode,
+            hapticOffset: hapticOffset,
+            hapticsEnabled: hapticsEnabled,
+            durationMs: durationMs
         )
         context.coordinator.controller = controller
         if autoPlay { controller.play() }

--- a/iOS/PulsarLottie/Sources/PulsarLottie/Sampler.swift
+++ b/iOS/PulsarLottie/Sources/PulsarLottie/Sampler.swift
@@ -3,10 +3,8 @@ import Pulsar
 
 /// Reads a Pulsar ``PatternData`` into per-frame `RealtimeComposer` inputs.
 ///
-/// The core's `PatternData` exposes a public initializer but keeps its stored
-/// properties `internal`, so we read it through its public `Codable`
-/// conformance (encode → decode into a local mirror). No UIKit/CoreHaptics
-/// dependencies here, so it is trivially unit-testable.
+/// Flattening the pattern once up front keeps the display-link step to plain arithmetic over
+/// plain arrays. No UIKit/CoreHaptics dependencies here, so it is trivially unit-testable.
 
 /// A single point on a continuous envelope.
 struct EnvPoint {
@@ -30,37 +28,12 @@ struct SampledPattern {
     var hasContinuous: Bool { !amplitude.isEmpty && !frequency.isEmpty }
 }
 
-private struct PatternMirror: Decodable {
-    struct Value: Decodable {
-        let time: Double
-        let value: Float
-    }
-    struct Continuous: Decodable {
-        let amplitude: [Value]
-        let frequency: [Value]
-    }
-    struct Discrete: Decodable {
-        let time: Double
-        let amplitude: Float
-        let frequency: Float
-    }
-    let continuousPattern: Continuous
-    let discretePattern: [Discrete]
-}
-
-/// Flatten a `PatternData` into a ``SampledPattern`` via its `Codable` form.
-/// Returns `nil` only if encoding/decoding unexpectedly fails.
-func sampledPattern(from pattern: PatternData) -> SampledPattern? {
-    guard
-        let data = try? JSONEncoder().encode(pattern),
-        let mirror = try? JSONDecoder().decode(PatternMirror.self, from: data)
-    else {
-        return nil
-    }
-    return SampledPattern(
-        amplitude: mirror.continuousPattern.amplitude.map { EnvPoint(time: $0.time, value: $0.value) },
-        frequency: mirror.continuousPattern.frequency.map { EnvPoint(time: $0.time, value: $0.value) },
-        discrete: mirror.discretePattern.map { DiscEvent(time: $0.time, amplitude: $0.amplitude, frequency: $0.frequency) }
+/// Flatten a `PatternData` into a ``SampledPattern``.
+func sampledPattern(from pattern: PatternData) -> SampledPattern {
+    SampledPattern(
+        amplitude: pattern.continuousPattern.amplitude.map { EnvPoint(time: $0.time, value: $0.value) },
+        frequency: pattern.continuousPattern.frequency.map { EnvPoint(time: $0.time, value: $0.value) },
+        discrete: pattern.discretePattern.map { DiscEvent(time: $0.time, amplitude: $0.amplitude, frequency: $0.frequency) }
     )
 }
 

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/SamplerTests.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/SamplerTests.swift
@@ -27,8 +27,6 @@ final class SamplerTests: XCTestCase {
         XCTAssertEqual(sampleEnvelope([], 100), 0, accuracy: 1e-6)
     }
 
-    /// Verifies the Codable round-trip that reads a core `PatternData` whose
-    /// stored properties are `internal`.
     func testSampledPatternExtractsFromPatternData() {
         let pattern = PatternData(
             continuousPattern: ContinuousPattern(
@@ -41,8 +39,6 @@ final class SamplerTests: XCTestCase {
             ]
         )
         let s = sampledPattern(from: pattern)
-        XCTAssertNotNil(s)
-        guard let s else { return }
         XCTAssertEqual(s.amplitude.count, 2)
         XCTAssertEqual(s.amplitude[1].time, 800, accuracy: 1e-6)
         XCTAssertEqual(s.amplitude[1].value, 1, accuracy: 1e-6)

--- a/kmp/Pulsar/gradle/libs.versions.toml
+++ b/kmp/Pulsar/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ vanniktechMavenPublish = "0.34.0"
 androidxCore = "1.18.0"
 kotlinxCoroutines = "1.10.2"
 composeMultiplatform = "1.10.3"
+compottie = "2.0.0-rc04"
 kotlinxSerialization = "1.7.3"
 
 [libraries]
@@ -14,6 +15,8 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
+compottie = { module = "io.github.alexzhirkevich:compottie", version.ref = "compottie" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/bundle/PulsarBundle.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/bundle/PulsarBundle.kt
@@ -20,11 +20,23 @@ class BundleAnimation internal constructor(
  */
 class PresetHandle internal constructor(
     val id: String,
+    /** Human label the preset was authored under. */
+    val name: String,
     val duration: Long,
     val animation: BundleAnimation?,
+    /**
+     * The authored pattern. Read it to drive a timeline yourself — the Lottie SDK samples it per
+     * frame in realtime mode. [play] stays the pre-parsed, engine-native route.
+     */
+    val pattern: PatternData,
     private val haptics: Pulsar,
-    private val pattern: PatternData,
 ) {
+    /** Always `false` on KMP: synced bundle audio is not wired yet (see the class note). */
+    val hasAudio: Boolean get() = false
+
+    /** Whether the preset carries a Lottie animation, exposed as [animation]. */
+    val hasAnimation: Boolean get() = animation != null
+
     private var composer: PatternComposer? = null
 
     private fun ensureParsed() {
@@ -117,10 +129,11 @@ internal object BundleLoaderImpl {
             }
             handles[preset.id] = PresetHandle(
                 id = preset.id,
+                name = preset.name,
                 duration = (preset.duration ?: 0.0).toLong(),
                 animation = animation,
-                haptics = haptics,
                 pattern = pattern,
+                haptics = haptics,
             )
         }
         return LoadedBundle(manifest.id, manifest.hash ?: "", manifest.revision ?: 0, handles)

--- a/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
+++ b/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
@@ -1,6 +1,5 @@
 package com.swmansion.pulsar.kmp.app
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -28,11 +27,7 @@ import com.swmansion.pulsar.kmp.Pulsar
 import com.swmansion.pulsar.kmp.ValuePoint
 import com.swmansion.pulsar.kmp.app.bundles.HapticsBundle
 import com.swmansion.pulsar.lottie.HapticLottie
-import com.swmansion.pulsar.lottie.animationJson
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
-import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
-import io.github.alexzhirkevich.compottie.rememberLottieComposition
-import io.github.alexzhirkevich.compottie.rememberLottiePainter
 
 @Composable
 @Preview
@@ -189,30 +184,16 @@ fun App() {
                             "the animation drives the haptics (realtime mode).",
                         style = MaterialTheme.typography.bodySmall,
                     )
-                    val composition by rememberLottieComposition {
-                        LottieCompositionSpec.JsonString(VERIFIED_LOTTIE_JSON)
-                    }
-                    val progress by animateLottieCompositionAsState(
-                        composition,
-                        isPlaying = true,
-                    )
                     Box(
                         modifier = Modifier.fillMaxWidth(),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Image(
-                            painter = rememberLottiePainter(composition, progress = { progress }),
-                            contentDescription = "Verified",
-                            modifier = Modifier.size(160.dp),
-                        )
-                    }
-                    if (pulsar != null) {
                         HapticLottie(
-                            progress = progress,
-                            durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
-                            isPlaying = true,
+                            modifier = Modifier.size(160.dp),
+                            animation = LottieCompositionSpec.JsonString(VERIFIED_LOTTIE_JSON),
                             haptics = remember { verifiedLottiePattern() },
-                            pulsar = pulsar,
+                            contentDescription = "Verified",
+                            pulsar = pulsar ?: return@Box,
                         )
                     }
                 }
@@ -312,32 +293,19 @@ private fun BundleCard(pulsar: Pulsar?, onStatus: (String) -> Unit) {
                         onStatus("Played lottie from ${HapticsBundle.bundleId}")
                     }) { Text("Lottie") }
                 }
-                val animationJson = loaded.lottie.animationJson()
-                if (animationJson == null) {
+                if (!loaded.lottie.hasAnimation) {
                     Text("No animation bytes carried.", style = MaterialTheme.typography.bodySmall)
-                } else {
+                } else if (pulsar != null) {
                     Text(
-                        "The lottie preset carries its animation too. This package renders " +
-                            "nothing itself, so hand the JSON to your Compose Lottie renderer " +
-                            "and pass the preset to HapticLottie.",
+                        "The lottie preset carries its animation as well as its pattern, so " +
+                            "HapticLottie needs nothing else.",
                         style = MaterialTheme.typography.bodySmall,
                     )
-                    val composition by rememberLottieComposition {
-                        LottieCompositionSpec.JsonString(animationJson)
-                    }
-                    val progress by animateLottieCompositionAsState(composition, isPlaying = true)
                     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        Image(
-                            painter = rememberLottiePainter(composition, progress = { progress }),
-                            contentDescription = loaded.lottie.name,
-                            modifier = Modifier.size(160.dp),
-                        )
-                    }
-                    if (pulsar != null) {
                         HapticLottie(
-                            progress = progress,
-                            isPlaying = true,
+                            modifier = Modifier.size(160.dp),
                             preset = loaded.lottie,
+                            contentDescription = loaded.lottie.name,
                             pulsar = pulsar,
                         )
                     }

--- a/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
+++ b/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
@@ -28,6 +28,7 @@ import com.swmansion.pulsar.kmp.ValuePoint
 import com.swmansion.pulsar.kmp.app.bundles.HapticsBundle
 import com.swmansion.pulsar.lottie.HapticLottie
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+import io.github.alexzhirkevich.compottie.rememberLottieComposition
 
 @Composable
 @Preview
@@ -188,9 +189,12 @@ fun App() {
                         modifier = Modifier.fillMaxWidth(),
                         contentAlignment = Alignment.Center,
                     ) {
+                        val composition by rememberLottieComposition {
+                            LottieCompositionSpec.JsonString(VERIFIED_LOTTIE_JSON)
+                        }
                         HapticLottie(
+                            composition,
                             modifier = Modifier.size(160.dp),
-                            animation = LottieCompositionSpec.JsonString(VERIFIED_LOTTIE_JSON),
                             haptics = remember { verifiedLottiePattern() },
                             contentDescription = "Verified",
                             pulsar = pulsar ?: return@Box,

--- a/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
+++ b/kmp/PulsarApp/composeApp/src/commonMain/kotlin/com/swmansion/pulsar/kmp/app/App.kt
@@ -28,6 +28,7 @@ import com.swmansion.pulsar.kmp.Pulsar
 import com.swmansion.pulsar.kmp.ValuePoint
 import com.swmansion.pulsar.kmp.app.bundles.HapticsBundle
 import com.swmansion.pulsar.lottie.HapticLottie
+import com.swmansion.pulsar.lottie.animationJson
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
 import io.github.alexzhirkevich.compottie.rememberLottieComposition
@@ -208,7 +209,7 @@ fun App() {
                     if (pulsar != null) {
                         HapticLottie(
                             progress = progress,
-                            durationMillis = composition?.duration?.inWholeMilliseconds ?: 0L,
+                            durationMs = composition?.duration?.inWholeMilliseconds ?: 0L,
                             isPlaying = true,
                             haptics = remember { verifiedLottiePattern() },
                             pulsar = pulsar,
@@ -311,16 +312,36 @@ private fun BundleCard(pulsar: Pulsar?, onStatus: (String) -> Unit) {
                         onStatus("Played lottie from ${HapticsBundle.bundleId}")
                     }) { Text("Lottie") }
                 }
-                val animation = loaded.lottie.animation
-                Text(
-                    if (animation != null) {
-                        "The lottie preset also carries ${animation.data.size} bytes of animation " +
-                            "at ${animation.frameRate} fps for your own Lottie view."
-                    } else {
-                        "No animation bytes carried."
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                )
+                val animationJson = loaded.lottie.animationJson()
+                if (animationJson == null) {
+                    Text("No animation bytes carried.", style = MaterialTheme.typography.bodySmall)
+                } else {
+                    Text(
+                        "The lottie preset carries its animation too. This package renders " +
+                            "nothing itself, so hand the JSON to your Compose Lottie renderer " +
+                            "and pass the preset to HapticLottie.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    val composition by rememberLottieComposition {
+                        LottieCompositionSpec.JsonString(animationJson)
+                    }
+                    val progress by animateLottieCompositionAsState(composition, isPlaying = true)
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        Image(
+                            painter = rememberLottiePainter(composition, progress = { progress }),
+                            contentDescription = loaded.lottie.name,
+                            modifier = Modifier.size(160.dp),
+                        )
+                    }
+                    if (pulsar != null) {
+                        HapticLottie(
+                            progress = progress,
+                            isPlaying = true,
+                            preset = loaded.lottie,
+                            pulsar = pulsar,
+                        )
+                    }
+                }
             }
         }
     }

--- a/kmp/PulsarLottie/README.md
+++ b/kmp/PulsarLottie/README.md
@@ -14,7 +14,7 @@ commonMain.dependencies {
 
 ## Usage
 
-Render the animation however you like and pass its `progress` / `durationMillis` / `isPlaying` to `HapticLottie`:
+Render the animation however you like and pass its `progress` / `durationMs` / `isPlaying` to `HapticLottie`:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.HapticLottie
@@ -29,7 +29,7 @@ fun Success(pattern: PatternData, playing: Boolean) {
 
     HapticLottie(
         progress = progress,
-        durationMillis = composition?.durationMillis?.toLong() ?: 0,
+        durationMs = composition?.durationMillis?.toLong() ?: 0,
         isPlaying = playing,
         haptics = pattern,
     )
@@ -40,18 +40,29 @@ fun Success(pattern: PatternData, playing: Boolean) {
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `haptics` | `PatternData?` | – | Pattern to sync. `null` disables. |
-| `mode` | `HapticMode` | `Realtime` | `Realtime` (progress-driven) or `Pattern` (aligned-start). |
-| `hapticOffsetMs` | `Long` | `0` | Shift haptics ± relative to the animation. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and authored duration. |
+| `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern. |
+| `hapticMode` | `HapticMode?` | `REALTIME` | `REALTIME` (progress-driven) or `PATTERN` (aligned-start). |
+| `hapticOffset` | `Long` | `0` | Shift haptics ± relative to the animation. |
 | `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
+| `durationMs` | `Long` | `0` | Animation length in ms; `0` falls back to the preset's or pattern's own length. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your platform-initialized instance. |
+
+A `.pulsar` bundle preset supplies the pattern and duration; this package renders nothing itself, so hand its animation to your renderer with `preset.animationJson()`:
+
+```kotlin
+val composition by rememberLottieComposition {
+    LottieCompositionSpec.JsonString(pack.celebration.animationJson()!!)
+}
+HapticLottie(progress = progress, isPlaying = playing, preset = pack.celebration)
+```
 
 Prefer to drive it yourself? Use `HapticLottieEngine` directly — a pure, framework-agnostic engine (`setPlaying`, `onProgress`, `stop`).
 
 ## Engine modes
 
-- **`Realtime`** (default) — the animation progress is the master clock; the pattern is sampled into `RealtimeComposer.set` / `playDiscrete`. Honours pause / seek / loop.
-- **`Pattern`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity).
+- **`REALTIME`** (default) — the animation progress is the master clock; the pattern is sampled into `RealtimeComposer.set` / `playDiscrete`. Honours pause / seek / loop.
+- **`PATTERN`** — the pre-parsed pattern plays whole via `PatternComposer`, aligned to the start (best native fidelity).
 
 There is **no playback-speed control** — the haptic timeline can't be rate-shifted coherently, so the animation runs at its authored speed.
 

--- a/kmp/PulsarLottie/README.md
+++ b/kmp/PulsarLottie/README.md
@@ -2,7 +2,8 @@
 
 Play [Pulsar](https://github.com/software-mansion/pulsar) haptics **in sync with a Lottie animation** in Compose Multiplatform (Android + iOS).
 
-Built on the `pulsar-kmp` core (reuses its haptic engine — no haptics reimplemented). It follows your Lottie **progress**, so it works with any Compose Lottie renderer (e.g. [compottie](https://github.com/alexzhirkevich/compottie)) — this package depends only on `compose-runtime`, not on a specific Lottie library.
+Built on the `pulsar-kmp` core (reuses its haptic engine — no haptics reimplemented) and
+[compottie](https://github.com/alexzhirkevich/compottie) for rendering.
 
 ## Install
 
@@ -14,50 +15,65 @@ commonMain.dependencies {
 
 ## Usage
 
-Render the animation however you like and pass its `progress` / `durationMs` / `isPlaying` to `HapticLottie`:
+A `.pulsar` bundle preset carries its animation, pattern and duration, so `HapticLottie` needs
+nothing else:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.HapticLottie
-import io.github.alexzhirkevich.compottie.*
 
-@Composable
-fun Success(pattern: PatternData, playing: Boolean) {
-    val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
-    val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
-
-    Image(painter = rememberLottiePainter(composition, progress = { progress }), contentDescription = null)
-
-    HapticLottie(
-        progress = progress,
-        durationMs = composition?.durationMillis?.toLong() ?: 0,
-        isPlaying = playing,
-        haptics = pattern,
-    )
-}
+HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
 ```
+
+Bring your own of each with `animation` and `haptics`:
+
+```kotlin
+HapticLottie(
+    animation = LottieCompositionSpec.JsonString(json),
+    haptics = pattern,
+    modifier = Modifier.size(200.dp),
+)
+```
+
+## Rendering with something else
+
+`HapticLottieSync` draws nothing and follows the `progress` you feed it, so it works with any
+Compose Lottie renderer:
+
+```kotlin
+val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
+
+Image(painter = rememberLottiePainter(composition, progress = { progress }), contentDescription = null)
+
+HapticLottieSync(
+    progress = progress,
+    isPlaying = playing,
+    haptics = pattern,
+    durationMs = composition?.duration?.inWholeMilliseconds ?: 0,
+)
+```
+
+`preset.animationJson()` hands a preset's Lottie to your renderer as a JSON string.
 
 ## Options
 
+Both composables take the same haptic arguments:
+
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the pattern and authored duration. |
+| `preset` | `PresetHandle?` | `null` | Bundle preset supplying the animation, pattern and authored duration. |
 | `haptics` | `PatternData?` | `null` | Pattern to sync. Overrides the preset's pattern. |
 | `hapticMode` | `HapticMode?` | `REALTIME` | `REALTIME` (progress-driven) or `PATTERN` (aligned-start). |
 | `hapticOffset` | `Long` | `0` | Shift haptics ± relative to the animation. |
 | `hapticsEnabled` | `Boolean` | `true` | Turn haptics off without touching the animation. |
-| `durationMs` | `Long` | `0` | Animation length in ms; `0` falls back to the preset's or pattern's own length. |
+| `durationMs` | `Long` | `0` | Clock length in ms; `0` derives it from the preset, composition, then pattern. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your platform-initialized instance. |
 
-A `.pulsar` bundle preset supplies the pattern and duration; this package renders nothing itself, so hand its animation to your renderer with `preset.animationJson()`:
+`HapticLottie` adds `animation`, `modifier`, `isPlaying`, `iterations`, `contentDescription` and
+`contentScale`; `HapticLottieSync` takes `progress` and `isPlaying` instead.
 
-```kotlin
-val composition by rememberLottieComposition {
-    LottieCompositionSpec.JsonString(pack.celebration.animationJson()!!)
-}
-HapticLottie(progress = progress, isPlaying = playing, preset = pack.celebration)
-```
-
-Prefer to drive it yourself? Use `HapticLottieEngine` directly — a pure, framework-agnostic engine (`setPlaying`, `onProgress`, `stop`).
+Prefer to drive it yourself? `HapticLottieEngine` is the pure, framework-agnostic engine behind
+both (`setPlaying`, `onProgress`, `stop`).
 
 ## Engine modes
 

--- a/kmp/PulsarLottie/README.md
+++ b/kmp/PulsarLottie/README.md
@@ -15,8 +15,8 @@ commonMain.dependencies {
 
 ## Usage
 
-A `.pulsar` bundle preset carries its animation, pattern and duration, so `HapticLottie` needs
-nothing else:
+A `.pulsar` bundle preset carries its animation, pattern and duration, so `HapticLottie` loads
+the composition for you:
 
 ```kotlin
 import com.swmansion.pulsar.lottie.HapticLottie
@@ -24,26 +24,24 @@ import com.swmansion.pulsar.lottie.HapticLottie
 HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
 ```
 
-Bring your own of each with `animation` and `haptics`:
+Otherwise it takes the same `LottieComposition` you already hand to compottie's
+`rememberLottiePainter`, so an existing screen only swaps its `Image`:
 
 ```kotlin
-HapticLottie(
-    animation = LottieCompositionSpec.JsonString(json),
-    haptics = pattern,
-    modifier = Modifier.size(200.dp),
-)
+val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+
+HapticLottie(composition, haptics = pattern, modifier = Modifier.size(200.dp))
 ```
 
 ## Rendering with something else
 
-`HapticLottieSync` draws nothing and follows the `progress` you feed it, so it works with any
-Compose Lottie renderer:
+`HapticLottieSync` draws nothing and follows the `progress` you feed it, so it adds haptics to any
+Compose Lottie renderer without touching how it draws:
 
 ```kotlin
-val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
 val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
 
-Image(painter = rememberLottiePainter(composition, progress = { progress }), contentDescription = null)
+Image(rememberLottiePainter(composition, progress = { progress }), contentDescription = null)
 
 HapticLottieSync(
     progress = progress,
@@ -69,8 +67,9 @@ Both composables take the same haptic arguments:
 | `durationMs` | `Long` | `0` | Clock length in ms; `0` derives it from the preset, composition, then pattern. |
 | `pulsar` | `Pulsar` | `Pulsar.create()` | Provide your platform-initialized instance. |
 
-`HapticLottie` adds `animation`, `modifier`, `isPlaying`, `iterations`, `contentDescription` and
-`contentScale`; `HapticLottieSync` takes `progress` and `isPlaying` instead.
+`HapticLottie` adds `composition` (or `preset`), `modifier`, `isPlaying`, `iterations`,
+`contentDescription`, `alignment` and `contentScale`; `HapticLottieSync` takes `progress` and
+`isPlaying` instead.
 
 Prefer to drive it yourself? `HapticLottieEngine` is the pure, framework-agnostic engine behind
 both (`setPlaying`, `onProgress`, `stop`).

--- a/kmp/PulsarLottie/build.gradle.kts
+++ b/kmp/PulsarLottie/build.gradle.kts
@@ -30,6 +30,9 @@ kotlin {
             // the core's PatternData types are visible in this library's public API.
             api(project(":library"))
             implementation(libs.compose.runtime)
+            implementation(libs.compose.foundation)
+            // `api` so LottieCompositionSpec is usable in HapticLottie's own signature.
+            api(libs.compottie)
         }
 
         commonTest.dependencies {

--- a/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
+++ b/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
@@ -7,42 +7,32 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import com.swmansion.pulsar.kmp.PatternData
 import com.swmansion.pulsar.kmp.Pulsar
 import com.swmansion.pulsar.kmp.bundle.PresetHandle
+import io.github.alexzhirkevich.compottie.LottieComposition
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
 import io.github.alexzhirkevich.compottie.rememberLottieComposition
 import io.github.alexzhirkevich.compottie.rememberLottiePainter
 
 /**
- * Renders a Lottie animation and plays Pulsar haptics locked to its timeline.
- *
- * A bundle [preset] supplies the animation, the pattern and the authored duration at once:
+ * Renders a bundle [preset]'s Lottie animation and plays its haptics locked to the timeline.
  *
  * ```kotlin
  * HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
  * ```
  *
- * Pass [animation] and [haptics] instead to bring your own of each:
- *
- * ```kotlin
- * HapticLottie(
- *     animation = LottieCompositionSpec.JsonString(json),
- *     haptics = pattern,
- * )
- * ```
- *
- * Renders through [compottie](https://github.com/alexzhirkevich/compottie). To drive a renderer
- * of your own, use [HapticLottieSync], which follows a progress value and draws nothing.
+ * The preset supplies the animation, the pattern and the authored duration; [haptics] and
+ * [durationMs] override its own. Renders an empty `Box` when the preset carries no animation.
  */
 @Composable
 fun HapticLottie(
+    preset: PresetHandle,
     modifier: Modifier = Modifier,
-    preset: PresetHandle? = null,
-    animation: LottieCompositionSpec? = null,
     haptics: PatternData? = null,
     hapticMode: HapticMode? = null,
     hapticOffset: Long = 0,
@@ -51,18 +41,66 @@ fun HapticLottie(
     isPlaying: Boolean = true,
     iterations: Int = 1,
     contentDescription: String? = null,
+    alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     pulsar: Pulsar = remember { Pulsar.create() },
 ) {
-    val spec = remember(animation, preset) {
-        animation ?: preset?.animationJson()?.let(LottieCompositionSpec::JsonString)
-    }
-    if (spec == null) {
+    val json = remember(preset) { preset.animationJson() }
+    if (json == null) {
         Box(modifier)
         return
     }
+    val composition by rememberLottieComposition(json) { LottieCompositionSpec.JsonString(json) }
 
-    val composition by rememberLottieComposition(spec) { spec }
+    HapticLottie(
+        composition = composition,
+        modifier = modifier,
+        preset = preset,
+        haptics = haptics,
+        hapticMode = hapticMode,
+        hapticOffset = hapticOffset,
+        hapticsEnabled = hapticsEnabled,
+        durationMs = durationMs,
+        isPlaying = isPlaying,
+        iterations = iterations,
+        contentDescription = contentDescription,
+        alignment = alignment,
+        contentScale = contentScale,
+        pulsar = pulsar,
+    )
+}
+
+/**
+ * Renders [composition] and plays Pulsar haptics locked to its timeline.
+ *
+ * A drop-in for compottie's own render call — it takes the same [LottieComposition] you would
+ * hand to `rememberLottiePainter`, so an existing screen only swaps the `Image`:
+ *
+ * ```kotlin
+ * val composition by rememberLottieComposition { LottieCompositionSpec.JsonString(json) }
+ *
+ * HapticLottie(composition, haptics = pattern, modifier = Modifier.size(200.dp))
+ * ```
+ *
+ * Pass neither [preset] nor [haptics] to render without haptics.
+ */
+@Composable
+fun HapticLottie(
+    composition: LottieComposition?,
+    modifier: Modifier = Modifier,
+    preset: PresetHandle? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    hapticOffset: Long = 0,
+    hapticsEnabled: Boolean = true,
+    durationMs: Long = 0,
+    isPlaying: Boolean = true,
+    iterations: Int = 1,
+    contentDescription: String? = null,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    pulsar: Pulsar = remember { Pulsar.create() },
+) {
     val progress by animateLottieCompositionAsState(
         composition,
         isPlaying = isPlaying,
@@ -73,6 +111,7 @@ fun HapticLottie(
         painter = rememberLottiePainter(composition, progress = { progress }),
         contentDescription = contentDescription,
         modifier = modifier,
+        alignment = alignment,
         contentScale = contentScale,
     )
 
@@ -92,13 +131,14 @@ fun HapticLottie(
 /**
  * Plays Pulsar haptics in sync with a Lottie animation rendered by something else.
  *
- * Place it next to your own renderer and feed it the same [progress], [durationMs] and
- * [isPlaying]:
+ * Add it next to your own renderer and feed it the same [progress], [durationMs] and
+ * [isPlaying] — nothing about the existing rendering changes:
  *
  * ```kotlin
  * val composition by rememberLottieComposition { /* spec */ }
  * val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
- * Image(painter = rememberLottiePainter(composition, progress = { progress }), null)
+ * Image(rememberLottiePainter(composition, progress = { progress }), null)
+ *
  * HapticLottieSync(
  *     progress = progress,
  *     isPlaying = playing,
@@ -107,9 +147,7 @@ fun HapticLottie(
  * )
  * ```
  *
- * It emits no UI of its own — it holds the haptic engine across recompositions and reacts to
- * [progress]. Prefer [HapticLottie] unless you render with something other than compottie.
- * Pass neither [preset] nor [haptics] to disable.
+ * It emits no UI of its own. Pass neither [preset] nor [haptics] to disable.
  */
 @Composable
 fun HapticLottieSync(

--- a/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
+++ b/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
@@ -1,48 +1,118 @@
 package com.swmansion.pulsar.lottie
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.swmansion.pulsar.kmp.PatternData
 import com.swmansion.pulsar.kmp.Pulsar
 import com.swmansion.pulsar.kmp.bundle.PresetHandle
+import io.github.alexzhirkevich.compottie.LottieCompositionSpec
+import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
+import io.github.alexzhirkevich.compottie.rememberLottieComposition
+import io.github.alexzhirkevich.compottie.rememberLottiePainter
 
 /**
- * Plays Pulsar haptics in sync with a Lottie animation in Compose Multiplatform.
+ * Renders a Lottie animation and plays Pulsar haptics locked to its timeline.
  *
- * Place it next to your Lottie renderer (e.g. compottie's `Image` /
- * `animateLottieCompositionAsState`) and feed it the same [progress],
- * [durationMs], and [isPlaying]:
+ * A bundle [preset] supplies the animation, the pattern and the authored duration at once:
+ *
+ * ```kotlin
+ * HapticLottie(preset = pack.celebration, modifier = Modifier.size(200.dp))
+ * ```
+ *
+ * Pass [animation] and [haptics] instead to bring your own of each:
+ *
+ * ```kotlin
+ * HapticLottie(
+ *     animation = LottieCompositionSpec.JsonString(json),
+ *     haptics = pattern,
+ * )
+ * ```
+ *
+ * Renders through [compottie](https://github.com/alexzhirkevich/compottie). To drive a renderer
+ * of your own, use [HapticLottieSync], which follows a progress value and draws nothing.
+ */
+@Composable
+fun HapticLottie(
+    modifier: Modifier = Modifier,
+    preset: PresetHandle? = null,
+    animation: LottieCompositionSpec? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    hapticOffset: Long = 0,
+    hapticsEnabled: Boolean = true,
+    durationMs: Long = 0,
+    isPlaying: Boolean = true,
+    iterations: Int = 1,
+    contentDescription: String? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    pulsar: Pulsar = remember { Pulsar.create() },
+) {
+    val spec = remember(animation, preset) {
+        animation ?: preset?.animationJson()?.let(LottieCompositionSpec::JsonString)
+    }
+    if (spec == null) {
+        Box(modifier)
+        return
+    }
+
+    val composition by rememberLottieComposition(spec) { spec }
+    val progress by animateLottieCompositionAsState(
+        composition,
+        isPlaying = isPlaying,
+        iterations = iterations,
+    )
+
+    Image(
+        painter = rememberLottiePainter(composition, progress = { progress }),
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+    )
+
+    HapticLottieSync(
+        progress = progress,
+        isPlaying = isPlaying,
+        preset = preset,
+        haptics = haptics,
+        hapticMode = hapticMode,
+        hapticOffset = hapticOffset,
+        hapticsEnabled = hapticsEnabled,
+        durationMs = if (durationMs > 0) durationMs else composition?.duration?.inWholeMilliseconds ?: 0,
+        pulsar = pulsar,
+    )
+}
+
+/**
+ * Plays Pulsar haptics in sync with a Lottie animation rendered by something else.
+ *
+ * Place it next to your own renderer and feed it the same [progress], [durationMs] and
+ * [isPlaying]:
  *
  * ```kotlin
  * val composition by rememberLottieComposition { /* spec */ }
  * val progress by animateLottieCompositionAsState(composition, isPlaying = playing)
  * Image(painter = rememberLottiePainter(composition, progress = { progress }), null)
- * HapticLottie(
+ * HapticLottieSync(
  *     progress = progress,
- *     durationMs = composition?.durationMillis?.toLong() ?: 0,
  *     isPlaying = playing,
  *     haptics = pattern,
+ *     durationMs = composition?.duration?.inWholeMilliseconds ?: 0,
  * )
  * ```
  *
- * A bundle [preset] supplies the pattern and the authored duration, so only
- * [progress] and [isPlaying] are left to wire. Render its animation with
- * [animationJson] — this package is renderer-agnostic and draws nothing itself:
- *
- * ```kotlin
- * val composition by rememberLottieComposition {
- *     LottieCompositionSpec.JsonString(pack.celebration.animationJson()!!)
- * }
- * HapticLottie(progress = progress, isPlaying = playing, preset = pack.celebration)
- * ```
- *
- * It holds the haptic engine across recompositions and emits as [progress]
- * advances. Pass neither [preset] nor [haptics] to disable.
+ * It emits no UI of its own — it holds the haptic engine across recompositions and reacts to
+ * [progress]. Prefer [HapticLottie] unless you render with something other than compottie.
+ * Pass neither [preset] nor [haptics] to disable.
  */
 @Composable
-fun HapticLottie(
+fun HapticLottieSync(
     progress: Float,
     isPlaying: Boolean,
     preset: PresetHandle? = null,

--- a/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
+++ b/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottie.kt
@@ -6,13 +6,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import com.swmansion.pulsar.kmp.PatternData
 import com.swmansion.pulsar.kmp.Pulsar
+import com.swmansion.pulsar.kmp.bundle.PresetHandle
 
 /**
  * Plays Pulsar haptics in sync with a Lottie animation in Compose Multiplatform.
  *
  * Place it next to your Lottie renderer (e.g. compottie's `Image` /
  * `animateLottieCompositionAsState`) and feed it the same [progress],
- * [durationMillis], and [isPlaying]:
+ * [durationMs], and [isPlaying]:
  *
  * ```kotlin
  * val composition by rememberLottieComposition { /* spec */ }
@@ -20,34 +21,53 @@ import com.swmansion.pulsar.kmp.Pulsar
  * Image(painter = rememberLottiePainter(composition, progress = { progress }), null)
  * HapticLottie(
  *     progress = progress,
- *     durationMillis = composition?.durationMillis?.toLong() ?: 0,
+ *     durationMs = composition?.durationMillis?.toLong() ?: 0,
  *     isPlaying = playing,
  *     haptics = pattern,
  * )
  * ```
  *
+ * A bundle [preset] supplies the pattern and the authored duration, so only
+ * [progress] and [isPlaying] are left to wire. Render its animation with
+ * [animationJson] — this package is renderer-agnostic and draws nothing itself:
+ *
+ * ```kotlin
+ * val composition by rememberLottieComposition {
+ *     LottieCompositionSpec.JsonString(pack.celebration.animationJson()!!)
+ * }
+ * HapticLottie(progress = progress, isPlaying = playing, preset = pack.celebration)
+ * ```
+ *
  * It holds the haptic engine across recompositions and emits as [progress]
- * advances. Pass `haptics = null` to disable.
+ * advances. Pass neither [preset] nor [haptics] to disable.
  */
 @Composable
 fun HapticLottie(
     progress: Float,
-    durationMillis: Long,
     isPlaying: Boolean,
-    haptics: PatternData?,
-    mode: HapticMode = HapticMode.Realtime,
-    hapticOffsetMs: Long = 0,
+    preset: PresetHandle? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    hapticOffset: Long = 0,
     hapticsEnabled: Boolean = true,
+    durationMs: Long = 0,
     pulsar: Pulsar = remember { Pulsar.create() },
 ) {
-    val engine = remember(pulsar, haptics, mode, hapticOffsetMs, hapticsEnabled) {
-        HapticLottieEngine(pulsar, haptics, mode, hapticOffsetMs, hapticsEnabled)
+    val engine = remember(pulsar, preset, haptics, hapticMode, hapticOffset, hapticsEnabled) {
+        HapticLottieEngine(
+            pulsar = pulsar,
+            preset = preset,
+            haptics = haptics,
+            hapticMode = hapticMode,
+            hapticOffset = hapticOffset,
+            hapticsEnabled = hapticsEnabled,
+        )
     }
     LaunchedEffect(engine, isPlaying) {
         engine.setPlaying(isPlaying)
     }
-    LaunchedEffect(engine, progress, durationMillis) {
-        engine.onProgress(progress, durationMillis)
+    LaunchedEffect(engine, progress, durationMs) {
+        engine.onProgress(progress, durationMs)
     }
     DisposableEffect(engine) {
         onDispose { engine.stop() }

--- a/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngine.kt
+++ b/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngine.kt
@@ -34,8 +34,8 @@ fun PresetHandle.animationJson(): String? = animation?.data?.decodeToString()
  * Compose): [HapticLottie] wires a Compose Lottie animation to it, but you can
  * drive it from any progress source.
  *
- * Pass a bundle [preset] to take its pattern and authored duration, or [haptics] for
- * a pattern of your own — an explicit [haptics] wins.
+ * A bundle [preset] supplies the pattern and authored duration; an explicit [haptics]
+ * overrides it.
  */
 class HapticLottieEngine(
     pulsar: Pulsar,
@@ -47,8 +47,8 @@ class HapticLottieEngine(
     durationMs: Long? = null,
 ) {
     private val pattern: PatternData? = haptics ?: preset?.pattern
-    private val playsItself = haptics == null && preset?.hasAudio == true
-    private val mode = hapticMode ?: if (playsItself) HapticMode.PATTERN else HapticMode.REALTIME
+    private val playsOwnAudio = haptics == null && preset?.hasAudio == true
+    private val mode = hapticMode ?: if (playsOwnAudio) HapticMode.PATTERN else HapticMode.REALTIME
 
     private val useRealtime = mode == HapticMode.REALTIME && pattern != null
     private val hasContinuous = pattern != null &&
@@ -58,11 +58,10 @@ class HapticLottieEngine(
     private val realtime: RealtimeComposer? =
         if (useRealtime) pulsar.getRealtimeComposer() else null
 
-    /** Set when the preset plays itself, so the audio it was authored with plays too. */
-    private val presetPlayback: PresetHandle? = if (!useRealtime && playsItself) preset else null
+    private val audioPreset: PresetHandle? = if (!useRealtime && playsOwnAudio) preset else null
 
     private val composer: PatternComposer? =
-        if (!useRealtime && !playsItself && pattern != null) {
+        if (!useRealtime && !playsOwnAudio && pattern != null) {
             pulsar.getPatternComposer().also { it.parsePattern(pattern) } // pre-parse / warm
         } else {
             null
@@ -89,7 +88,7 @@ class HapticLottieEngine(
         if (isPlaying) {
             lastT = 0
             if (!useRealtime && hapticsEnabled) {
-                if (presetPlayback != null) presetPlayback.play() else composer?.play()
+                if (audioPreset != null) audioPreset.play() else composer?.play()
             }
         } else {
             stop()
@@ -126,7 +125,7 @@ class HapticLottieEngine(
         lastT = 0
         when {
             useRealtime -> if (hasContinuous) realtime?.stop()
-            presetPlayback != null -> presetPlayback.stop()
+            audioPreset != null -> audioPreset.stop()
             else -> composer?.stop()
         }
     }

--- a/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngine.kt
+++ b/kmp/PulsarLottie/src/commonMain/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngine.kt
@@ -4,6 +4,7 @@ import com.swmansion.pulsar.kmp.PatternComposer
 import com.swmansion.pulsar.kmp.PatternData
 import com.swmansion.pulsar.kmp.Pulsar
 import com.swmansion.pulsar.kmp.RealtimeComposer
+import com.swmansion.pulsar.kmp.bundle.PresetHandle
 
 /** How the haptics are produced while the animation plays. */
 enum class HapticMode {
@@ -12,70 +13,107 @@ enum class HapticMode {
      * progress update into `RealtimeComposer` events. Honours pause/seek/loop.
      * Requires a [PatternData] source.
      */
-    Realtime,
+    REALTIME,
 
     /**
      * A whole pattern is played once via `PatternComposer`, aligned to the start
      * (best native fidelity). Seek/pause on the haptic side are best-effort.
      */
-    Pattern,
+    PATTERN,
 }
+
+/**
+ * The Lottie JSON a bundle preset was authored against, as a string — ready for a
+ * Compose Lottie renderer (e.g. compottie's `LottieCompositionSpec.JsonString`).
+ * `null` when the preset carries no animation.
+ */
+fun PresetHandle.animationJson(): String? = animation?.data?.decodeToString()
 
 /**
  * Pure haptic-sync engine driven by animation progress. Framework-agnostic (no
  * Compose): [HapticLottie] wires a Compose Lottie animation to it, but you can
  * drive it from any progress source.
+ *
+ * Pass a bundle [preset] to take its pattern and authored duration, or [haptics] for
+ * a pattern of your own — an explicit [haptics] wins.
  */
 class HapticLottieEngine(
     pulsar: Pulsar,
-    private val haptics: PatternData?,
-    private val mode: HapticMode = HapticMode.Realtime,
-    private val offsetMs: Long = 0,
-    private val enabled: Boolean = true,
+    preset: PresetHandle? = null,
+    haptics: PatternData? = null,
+    hapticMode: HapticMode? = null,
+    private val hapticOffset: Long = 0,
+    private val hapticsEnabled: Boolean = true,
+    durationMs: Long? = null,
 ) {
-    private val useRealtime = mode == HapticMode.Realtime && haptics != null
-    private val hasContinuous = haptics != null &&
-        haptics.continuousPattern.amplitude.isNotEmpty() &&
-        haptics.continuousPattern.frequency.isNotEmpty()
+    private val pattern: PatternData? = haptics ?: preset?.pattern
+    private val playsItself = haptics == null && preset?.hasAudio == true
+    private val mode = hapticMode ?: if (playsItself) HapticMode.PATTERN else HapticMode.REALTIME
+
+    private val useRealtime = mode == HapticMode.REALTIME && pattern != null
+    private val hasContinuous = pattern != null &&
+        pattern.continuousPattern.amplitude.isNotEmpty() &&
+        pattern.continuousPattern.frequency.isNotEmpty()
 
     private val realtime: RealtimeComposer? =
         if (useRealtime) pulsar.getRealtimeComposer() else null
-    private val pattern: PatternComposer? =
-        if (!useRealtime && haptics != null) {
-            pulsar.getPatternComposer().also { it.parsePattern(haptics) } // pre-parse / warm
+
+    /** Set when the preset plays itself, so the audio it was authored with plays too. */
+    private val presetPlayback: PresetHandle? = if (!useRealtime && playsItself) preset else null
+
+    private val composer: PatternComposer? =
+        if (!useRealtime && !playsItself && pattern != null) {
+            pulsar.getPatternComposer().also { it.parsePattern(pattern) } // pre-parse / warm
         } else {
             null
         }
 
+    /**
+     * Clock length in ms: an explicit duration, else the preset's authored one, else the
+     * length passed to [onProgress], else the pattern's own length.
+     */
+    private val fixedDurationMs: Long? =
+        durationMs?.takeIf { it > 0L } ?: preset?.duration?.takeIf { it > 0L }
+    private val fallbackDurationMs: Long = pattern?.let { patternDurationMs(it) } ?: 0L
+
+    /** The clock length this engine resolved, for a caller that has no duration of its own. */
+    val resolvedDurationMs: Long get() = fixedDurationMs ?: fallbackDurationMs
+
     private var lastT: Long = 0
     private var playing = false
 
-    /** Notify a play/pause transition. In `pattern` mode fires the buffered pattern. */
+    /** Notify a play/pause transition. In `PATTERN` mode fires the buffered pattern. */
     fun setPlaying(isPlaying: Boolean) {
         if (isPlaying == playing) return
         playing = isPlaying
         if (isPlaying) {
             lastT = 0
-            if (!useRealtime) pattern?.play()
+            if (!useRealtime && hapticsEnabled) {
+                if (presetPlayback != null) presetPlayback.play() else composer?.play()
+            }
         } else {
             stop()
         }
     }
 
-    /** Feed the current animation [progress] (0..1) and total [durationMs]. */
-    fun onProgress(progress: Float, durationMs: Long) {
-        if (!enabled || !useRealtime || haptics == null || !playing) return
-        val t = (progress.toDouble() * durationMs).toLong()
-        val ht = t + offsetMs
+    /**
+     * Feed the current animation [progress] (0..1). [durationMs] is the animation's own
+     * length; pass 0 (the default) to use the duration this engine already resolved.
+     */
+    fun onProgress(progress: Float, durationMs: Long = 0) {
+        if (!hapticsEnabled || !useRealtime || pattern == null || !playing) return
+        val dur = fixedDurationMs ?: durationMs.takeIf { it > 0L } ?: fallbackDurationMs
+        val t = (progress.toDouble() * dur).toLong()
+        val ht = t + hapticOffset
         if (hasContinuous) {
             realtime?.set(
-                clamp01(sampleEnvelope(haptics.continuousPattern.amplitude, ht)),
-                clamp01(sampleEnvelope(haptics.continuousPattern.frequency, ht)),
+                clamp01(sampleEnvelope(pattern.continuousPattern.amplitude, ht)),
+                clamp01(sampleEnvelope(pattern.continuousPattern.frequency, ht)),
             )
         }
         var prev = lastT
         if (t < prev) prev = 0 // wrapped on loop
-        for (e in haptics.discretePattern) {
+        for (e in pattern.discretePattern) {
             if (e.time > prev && e.time <= t) {
                 realtime?.playDiscrete(clamp01(e.amplitude), clamp01(e.frequency))
             }
@@ -86,10 +124,10 @@ class HapticLottieEngine(
     /** Stop haptics and reset the discrete window. */
     fun stop() {
         lastT = 0
-        if (useRealtime) {
-            if (hasContinuous) realtime?.stop()
-        } else {
-            pattern?.stop()
+        when {
+            useRealtime -> if (hasContinuous) realtime?.stop()
+            presetPlayback != null -> presetPlayback.stop()
+            else -> composer?.stop()
         }
     }
 }

--- a/react-native/react-native-pulsar-lottie/README.md
+++ b/react-native/react-native-pulsar-lottie/README.md
@@ -59,20 +59,24 @@ function Celebration() {
 The preset fills in three things, each still overridable on its own: `source` from its Lottie,
 `haptics` from its pattern, and `durationMs` from its authored length.
 
+A preset authored with **audio** plays that audio too, through its own native handle. That needs
+`pattern` mode, so such a preset defaults to `hapticMode="pattern"` instead of `realtime`; passing
+`hapticMode` yourself always wins. The sound only reaches the device on the asset-backed load path
+(`loadBundleSync(true)` or `loadBundleAsync()`).
+
 Only JSON Lotties are embedded in the generated TypeScript module. A preset authored as a
 dotLottie reports `hasAnimation: true` but carries no `animation` — pass `source` yourself there.
 If neither is available the view renders nothing and warns once, rather than crashing.
 
-For the hook API, a preset works today without any extra option:
-`useHapticLottie({ haptics: preset.pattern })`.
+For the hook API, a preset is its own option: `useHapticLottie({ preset })`.
 
 ## Haptic props
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `preset` | `PresetHandle` | – | A bundle preset supplying `source` + `haptics` + `durationMs` at once. |
-| `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger fn (`pattern` mode only). |
-| `hapticMode` | `'realtime' \| 'pattern'` | `'realtime'` | Engine mode — see below. |
+| `haptics` | `Pattern \| () => void` | – | Pattern to sync, or a preset trigger fn (`pattern` mode only). Overrides the preset's pattern. |
+| `hapticMode` | `'realtime' \| 'pattern'` | derived | Engine mode — `'realtime'`, or `'pattern'` for a preset with audio. See below. |
 | `hapticOffset` | `number` (ms) | `0` | Shift haptics ± relative to the animation (device tuning). |
 | `hapticsEnabled` | `boolean` | `true` | Turn haptics off without touching the animation. |
 | `durationMs` | `number` | derived | `realtime` clock length. Derived from the preset's duration, else the Lottie JSON (`fr`/`ip`/`op`), else the pattern. |
@@ -80,7 +84,7 @@ For the hook API, a preset works today without any extra option:
 ## Engine modes
 
 - **`realtime`** (default) — the animation timeline is the master clock. A Reanimated frame callback drives the Lottie `progress` on the UI thread and samples your pattern into `RealtimeComposer` events. Honours `pause`, `setTimestamp`, `loop`, and segments coherently. Requires a `Pattern` source. Continuous fidelity is realtime-grade (coarser on Android). **No playback-speed control** — the haptic timeline can't be rate-shifted coherently, so the animation runs at its authored speed.
-- **`pattern`** — the pattern (or a preset) plays whole via `PatternComposer`, aligned to the animation start (best native fidelity). Limitations: `pause` stops the haptic, and there is no mid-pattern seek. Best for short, mostly start-aligned animations.
+- **`pattern`** — the pattern (or a preset) plays whole via `PatternComposer`, aligned to the animation start (best native fidelity), and it is the only mode that plays a preset's synced audio. Limitations: `pause` stops the haptic, and there is no mid-pattern seek. Best for short, mostly start-aligned animations.
 
 ## Imperative control
 
@@ -99,6 +103,7 @@ If you'd rather not swap the component, `useHapticLottie` fires a pattern/preset
 
 ```tsx
 const haptics = useHapticLottie({ haptics: pattern });
+// …or straight from a bundle preset, audio included: useHapticLottie({ preset: Pack.celebration })
 // call haptics.play() next to your lottieRef.play(); haptics.stop() on pause.
 ```
 

--- a/react-native/react-native-pulsar-lottie/src/HapticLottieView.tsx
+++ b/react-native/react-native-pulsar-lottie/src/HapticLottieView.tsx
@@ -36,6 +36,7 @@ const RealtimeHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     const {
       haptics,
       preset: _preset,
+      presetPlayback: _presetPlayback,
       hapticMode: _hapticMode,
       hapticOffset = 0,
       hapticsEnabled = true,
@@ -199,6 +200,7 @@ const PatternHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     const {
       haptics,
       preset: _preset,
+      presetPlayback,
       hapticMode: _hapticMode,
       hapticOffset: _hapticOffset,
       hapticsEnabled = true,
@@ -211,25 +213,31 @@ const PatternHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     } = props;
 
     const lottieRef = useRef<LottieView>(null);
-    const isPattern = typeof haptics === 'object' && haptics !== null;
+    // A preset that plays itself needs no JS composer — the native handle owns its
+    // pattern and the audio authored alongside it.
+    const isPattern = !presetPlayback && typeof haptics === 'object' && haptics !== null;
     const composer = usePatternComposer(isPattern ? (haptics as Pattern) : undefined);
 
     const fireHaptics = useCallback(() => {
-      if (!hapticsEnabled || !haptics) {
+      if (!hapticsEnabled) {
         return;
       }
-      if (typeof haptics === 'function') {
+      if (presetPlayback) {
+        presetPlayback.play();
+      } else if (typeof haptics === 'function') {
         haptics();
-      } else if (composer.isParsed()) {
+      } else if (haptics && composer.isParsed()) {
         composer.play();
       }
-    }, [haptics, hapticsEnabled, composer]);
+    }, [haptics, hapticsEnabled, composer, presetPlayback]);
 
     const stopHaptics = useCallback(() => {
-      if (isPattern) {
+      if (presetPlayback) {
+        presetPlayback.stop();
+      } else if (isPattern) {
         composer.stop();
       }
-    }, [isPattern, composer]);
+    }, [isPattern, composer, presetPlayback]);
 
     useImperativeHandle(
       ref,
@@ -301,9 +309,8 @@ export const HapticLottieView = forwardRef<HapticLottieRef, HapticLottieProps>(
       // A preset with no animation and no explicit source — nothing to render.
       return null;
     }
-    const mode = resolved.hapticMode ?? 'realtime';
     const isPattern = typeof resolved.haptics === 'object' && resolved.haptics !== null;
-    if (mode !== 'pattern' && isPattern) {
+    if (resolved.hapticMode !== 'pattern' && isPattern) {
       return <RealtimeHapticLottie ref={ref} {...resolved} />;
     }
     return <PatternHapticLottie ref={ref} {...resolved} />;

--- a/react-native/react-native-pulsar-lottie/src/HapticLottieView.tsx
+++ b/react-native/react-native-pulsar-lottie/src/HapticLottieView.tsx
@@ -14,7 +14,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { usePatternComposer, useRealtimeComposer } from 'react-native-pulsar';
 import type { Pattern } from 'react-native-pulsar';
-import type { HapticLottieProps, HapticLottieRef } from './types';
+import type { HapticLottieProps, HapticLottieRef, HapticSource } from './types';
 import { resolvePreset, type ResolvedProps } from './internal/resolvePreset';
 import {
   clamp,
@@ -24,6 +24,11 @@ import {
 } from './internal/sampler';
 
 const AnimatedLottieView = Animated.createAnimatedComponent(LottieView);
+
+/** Narrows a {@link HapticSource} to the `Pattern` half — the only one realtime can sample. */
+function asPattern(haptics: HapticSource | undefined): Pattern | undefined {
+  return typeof haptics === 'object' && haptics !== null ? haptics : undefined;
+}
 
 /**
  * `realtime` engine: the animation timeline is the master clock. A Reanimated
@@ -36,7 +41,7 @@ const RealtimeHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     const {
       haptics,
       preset: _preset,
-      presetPlayback: _presetPlayback,
+      audioPreset: _audioPreset,
       hapticMode: _hapticMode,
       hapticOffset = 0,
       hapticsEnabled = true,
@@ -200,7 +205,7 @@ const PatternHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     const {
       haptics,
       preset: _preset,
-      presetPlayback,
+      audioPreset,
       hapticMode: _hapticMode,
       hapticOffset: _hapticOffset,
       hapticsEnabled = true,
@@ -213,31 +218,29 @@ const PatternHapticLottie = forwardRef<HapticLottieRef, ResolvedProps>(
     } = props;
 
     const lottieRef = useRef<LottieView>(null);
-    // A preset that plays itself needs no JS composer — the native handle owns its
-    // pattern and the audio authored alongside it.
-    const isPattern = !presetPlayback && typeof haptics === 'object' && haptics !== null;
-    const composer = usePatternComposer(isPattern ? (haptics as Pattern) : undefined);
+    const composedPattern = audioPreset ? undefined : asPattern(haptics);
+    const composer = usePatternComposer(composedPattern);
 
     const fireHaptics = useCallback(() => {
       if (!hapticsEnabled) {
         return;
       }
-      if (presetPlayback) {
-        presetPlayback.play();
+      if (audioPreset) {
+        audioPreset.play();
       } else if (typeof haptics === 'function') {
         haptics();
-      } else if (haptics && composer.isParsed()) {
+      } else if (composedPattern && composer.isParsed()) {
         composer.play();
       }
-    }, [haptics, hapticsEnabled, composer, presetPlayback]);
+    }, [haptics, hapticsEnabled, composer, composedPattern, audioPreset]);
 
     const stopHaptics = useCallback(() => {
-      if (presetPlayback) {
-        presetPlayback.stop();
-      } else if (isPattern) {
+      if (audioPreset) {
+        audioPreset.stop();
+      } else if (composedPattern) {
         composer.stop();
       }
-    }, [isPattern, composer, presetPlayback]);
+    }, [composedPattern, composer, audioPreset]);
 
     useImperativeHandle(
       ref,
@@ -309,8 +312,8 @@ export const HapticLottieView = forwardRef<HapticLottieRef, HapticLottieProps>(
       // A preset with no animation and no explicit source — nothing to render.
       return null;
     }
-    const isPattern = typeof resolved.haptics === 'object' && resolved.haptics !== null;
-    if (resolved.hapticMode !== 'pattern' && isPattern) {
+    const samplable = asPattern(resolved.haptics) !== undefined;
+    if (resolved.hapticMode !== 'pattern' && samplable) {
       return <RealtimeHapticLottie ref={ref} {...resolved} />;
     }
     return <PatternHapticLottie ref={ref} {...resolved} />;

--- a/react-native/react-native-pulsar-lottie/src/__tests__/resolvePreset.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/resolvePreset.test.ts
@@ -33,7 +33,7 @@ test('a preset supplies source, haptics and duration', () => {
   assert.equal(out?.haptics, pattern);
   assert.equal(out?.durationMs, 1500);
   assert.equal(out?.hapticMode, 'realtime');
-  assert.equal(out?.presetPlayback, undefined);
+  assert.equal(out?.audioPreset, undefined);
 });
 
 test('a preset with audio plays itself, in pattern mode, so its audio plays too', () => {
@@ -41,7 +41,7 @@ test('a preset with audio plays itself, in pattern mode, so its audio plays too'
   const out = resolvePreset({ preset: p } as HapticLottieProps);
 
   assert.equal(out?.hapticMode, 'pattern');
-  assert.equal(out?.presetPlayback, p, 'the handle itself is passed through, so its identity is stable');
+  assert.equal(out?.audioPreset, p, 'the handle itself is passed through, so its identity is stable');
 });
 
 test('an explicit hapticMode wins over an audio preset default', () => {
@@ -59,7 +59,7 @@ test('explicit haptics keep an audio preset from playing itself', () => {
     haptics: pattern,
   } as unknown as HapticLottieProps);
 
-  assert.equal(out?.presetPlayback, undefined);
+  assert.equal(out?.audioPreset, undefined);
 });
 
 test('explicit props win over the preset', () => {

--- a/react-native/react-native-pulsar-lottie/src/__tests__/resolvePreset.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/resolvePreset.test.ts
@@ -32,6 +32,34 @@ test('a preset supplies source, haptics and duration', () => {
   assert.equal(out?.source, lottie);
   assert.equal(out?.haptics, pattern);
   assert.equal(out?.durationMs, 1500);
+  assert.equal(out?.hapticMode, 'realtime');
+  assert.equal(out?.presetPlayback, undefined);
+});
+
+test('a preset with audio plays itself, in pattern mode, so its audio plays too', () => {
+  const p = preset('audio', { hasAudio: true });
+  const out = resolvePreset({ preset: p } as HapticLottieProps);
+
+  assert.equal(out?.hapticMode, 'pattern');
+  assert.equal(out?.presetPlayback, p, 'the handle itself is passed through, so its identity is stable');
+});
+
+test('an explicit hapticMode wins over an audio preset default', () => {
+  const out = resolvePreset({
+    preset: preset('audio-override', { hasAudio: true }),
+    hapticMode: 'realtime',
+  } as HapticLottieProps);
+
+  assert.equal(out?.hapticMode, 'realtime');
+});
+
+test('explicit haptics keep an audio preset from playing itself', () => {
+  const out = resolvePreset({
+    preset: preset('audio-haptics', { hasAudio: true }),
+    haptics: pattern,
+  } as unknown as HapticLottieProps);
+
+  assert.equal(out?.presetPlayback, undefined);
 });
 
 test('explicit props win over the preset', () => {
@@ -48,9 +76,13 @@ test('explicit props win over the preset', () => {
   assert.equal(out?.haptics, pattern);
 });
 
-test('props pass through untouched when there is no preset', () => {
+test('props pass through with the default mode when there is no preset', () => {
   const props = { source: lottie, haptics: pattern } as unknown as HapticLottieProps;
-  assert.equal(resolvePreset(props), props);
+  const out = resolvePreset(props);
+
+  assert.equal(out?.source, lottie);
+  assert.equal(out?.haptics, pattern);
+  assert.equal(out?.hapticMode, 'realtime');
 });
 
 test('a binary-path preset falls back to its own play trigger', () => {

--- a/react-native/react-native-pulsar-lottie/src/internal/resolvePreset.ts
+++ b/react-native/react-native-pulsar-lottie/src/internal/resolvePreset.ts
@@ -1,9 +1,23 @@
 import type { LottieViewProps } from 'lottie-react-native';
-import type { HapticConfig, HapticLottieProps, HapticSource } from '../types';
+import type { HapticConfig, HapticLottieProps, HapticMode, HapticSource } from '../types';
 
-/** `HapticLottieProps` with `source` decided, so the engines never re-check the preset. */
+/** The native play/stop pair of a preset whose audio the view should let it play itself. */
+export interface PresetPlayback {
+  play: () => void;
+  stop: () => void;
+}
+
+/**
+ * `HapticLottieProps` with `source` and `hapticMode` decided, so the engines never
+ * re-check the preset.
+ */
 export type ResolvedProps = Omit<LottieViewProps, 'source'> &
-  HapticConfig & { source: LottieViewProps['source'] };
+  HapticConfig & {
+    source: LottieViewProps['source'];
+    hapticMode: HapticMode;
+    /** Set when the preset itself should play, so its synced audio plays with the haptics. */
+    presetPlayback?: PresetPlayback;
+  };
 
 const warned = new Set<string>();
 
@@ -15,11 +29,21 @@ function warnOnce(key: string, message: string): void {
   console.warn(`[react-native-pulsar-lottie] ${message}`);
 }
 
+/**
+ * The mode a preset defaults to. A preset that was authored with audio only sounds
+ * in `pattern` mode — realtime sampling drives the vibrator per frame and has no
+ * audio track to follow — so an audio preset starts there unless asked otherwise.
+ */
+function defaultMode(preset: HapticConfig['preset']): HapticMode {
+  return preset?.hasAudio ? 'pattern' : 'realtime';
+}
+
 /** Folds a `preset` into the props. Explicit props win. `null` means there is nothing to render. */
 export function resolvePreset(props: HapticLottieProps): ResolvedProps | null {
   const { preset } = props;
   if (!preset) {
-    return props as ResolvedProps; // the prop union guarantees `source` without a preset
+    // The prop union guarantees `source` without a preset.
+    return { ...props, hapticMode: props.hapticMode ?? 'realtime' } as ResolvedProps;
   }
 
   const source = props.source ?? (preset.animation?.source as LottieViewProps['source']);
@@ -38,10 +62,17 @@ export function resolvePreset(props: HapticLottieProps): ResolvedProps | null {
   // `preset.play` is the fallback when the pattern lives natively: a trigger, fired once at start.
   const haptics: HapticSource | undefined = props.haptics ?? preset.pattern ?? preset.play;
 
+  // An audio preset the caller did not override plays through its own handle, so the native
+  // engine drives the haptics and the synced audio together. The handle itself is passed
+  // through, so its identity stays stable across re-renders.
+  const presetPlayback = props.haptics === undefined && preset.hasAudio ? preset : undefined;
+
   return {
     ...props,
     source,
     haptics,
+    presetPlayback,
+    hapticMode: props.hapticMode ?? defaultMode(preset),
     durationMs: props.durationMs ?? preset.duration,
   } as ResolvedProps;
 }

--- a/react-native/react-native-pulsar-lottie/src/internal/resolvePreset.ts
+++ b/react-native/react-native-pulsar-lottie/src/internal/resolvePreset.ts
@@ -1,11 +1,6 @@
 import type { LottieViewProps } from 'lottie-react-native';
+import type { PresetHandle } from 'react-native-pulsar';
 import type { HapticConfig, HapticLottieProps, HapticMode, HapticSource } from '../types';
-
-/** The native play/stop pair of a preset whose audio the view should let it play itself. */
-export interface PresetPlayback {
-  play: () => void;
-  stop: () => void;
-}
 
 /**
  * `HapticLottieProps` with `source` and `hapticMode` decided, so the engines never
@@ -15,8 +10,8 @@ export type ResolvedProps = Omit<LottieViewProps, 'source'> &
   HapticConfig & {
     source: LottieViewProps['source'];
     hapticMode: HapticMode;
-    /** Set when the preset itself should play, so its synced audio plays with the haptics. */
-    presetPlayback?: PresetPlayback;
+    /** The preset to play through its own native handle, so its audio plays with the haptics. */
+    audioPreset?: PresetHandle;
   };
 
 const warned = new Set<string>();
@@ -29,20 +24,15 @@ function warnOnce(key: string, message: string): void {
   console.warn(`[react-native-pulsar-lottie] ${message}`);
 }
 
-/**
- * The mode a preset defaults to. A preset that was authored with audio only sounds
- * in `pattern` mode — realtime sampling drives the vibrator per frame and has no
- * audio track to follow — so an audio preset starts there unless asked otherwise.
- */
-function defaultMode(preset: HapticConfig['preset']): HapticMode {
-  return preset?.hasAudio ? 'pattern' : 'realtime';
+/** A preset's audio only sounds when the preset itself plays, which only `pattern` mode does. */
+function playsOwnAudio(props: HapticLottieProps, preset: PresetHandle): boolean {
+  return props.haptics === undefined && preset.hasAudio;
 }
 
 /** Folds a `preset` into the props. Explicit props win. `null` means there is nothing to render. */
 export function resolvePreset(props: HapticLottieProps): ResolvedProps | null {
   const { preset } = props;
   if (!preset) {
-    // The prop union guarantees `source` without a preset.
     return { ...props, hapticMode: props.hapticMode ?? 'realtime' } as ResolvedProps;
   }
 
@@ -61,18 +51,14 @@ export function resolvePreset(props: HapticLottieProps): ResolvedProps | null {
 
   // `preset.play` is the fallback when the pattern lives natively: a trigger, fired once at start.
   const haptics: HapticSource | undefined = props.haptics ?? preset.pattern ?? preset.play;
-
-  // An audio preset the caller did not override plays through its own handle, so the native
-  // engine drives the haptics and the synced audio together. The handle itself is passed
-  // through, so its identity stays stable across re-renders.
-  const presetPlayback = props.haptics === undefined && preset.hasAudio ? preset : undefined;
+  const playsAudio = playsOwnAudio(props, preset);
 
   return {
     ...props,
     source,
     haptics,
-    presetPlayback,
-    hapticMode: props.hapticMode ?? defaultMode(preset),
+    audioPreset: playsAudio ? preset : undefined,
+    hapticMode: props.hapticMode ?? (playsAudio ? 'pattern' : 'realtime'),
     durationMs: props.durationMs ?? preset.duration,
   } as ResolvedProps;
 }

--- a/react-native/react-native-pulsar-lottie/src/types.ts
+++ b/react-native/react-native-pulsar-lottie/src/types.ts
@@ -27,11 +27,14 @@ export interface HapticConfig {
   /**
    * Supplies `source`, `haptics` and `durationMs` at once; each is still overridable on its own.
    * A preset whose `animation` is undefined needs an explicit `source`.
+   *
+   * A preset that carries audio also plays that audio, which needs `pattern` mode — so one
+   * defaults to `pattern` rather than `realtime`. Set `hapticMode` yourself to override.
    */
   preset?: PresetHandle;
   /** Haptic content to sync with the animation. Omit for a plain `LottieView`. */
   haptics?: HapticSource;
-  /** Engine mode. Defaults to `realtime`. */
+  /** Engine mode. Defaults to `realtime`, or to `pattern` for a `preset` that carries audio. */
   hapticMode?: HapticMode;
   /** Device tuning: shift haptics by ±ms relative to the animation. Default 0. */
   hapticOffset?: number;

--- a/react-native/react-native-pulsar-lottie/src/types.ts
+++ b/react-native/react-native-pulsar-lottie/src/types.ts
@@ -27,9 +27,6 @@ export interface HapticConfig {
   /**
    * Supplies `source`, `haptics` and `durationMs` at once; each is still overridable on its own.
    * A preset whose `animation` is undefined needs an explicit `source`.
-   *
-   * A preset that carries audio also plays that audio, which needs `pattern` mode — so one
-   * defaults to `pattern` rather than `realtime`. Set `hapticMode` yourself to override.
    */
   preset?: PresetHandle;
   /** Haptic content to sync with the animation. Omit for a plain `LottieView`. */

--- a/react-native/react-native-pulsar-lottie/src/useHapticLottie.ts
+++ b/react-native/react-native-pulsar-lottie/src/useHapticLottie.ts
@@ -1,13 +1,10 @@
 import { useCallback } from 'react';
 import { usePatternComposer } from 'react-native-pulsar';
-import type { Pattern, PresetHandle } from 'react-native-pulsar';
+import type { PresetHandle } from 'react-native-pulsar';
 import type { HapticSource } from './types';
 
 export interface UseHapticLottieOptions {
-  /**
-   * A bundle preset to fire with the animation. Supplies `haptics` from its pattern, and
-   * plays its synced audio too when it was authored with any.
-   */
+  /** Bundle preset to fire: its pattern, plus its synced audio when it has any. */
   preset?: PresetHandle;
   /** Pattern or preset trigger to fire with the animation. Overrides `preset`. */
   haptics?: HapticSource;
@@ -36,32 +33,32 @@ export interface HapticLottieHandle {
 export function useHapticLottie(options: UseHapticLottieOptions): HapticLottieHandle {
   const { preset, hapticsEnabled = true } = options;
   const haptics = options.haptics ?? preset?.pattern;
-  // An audio preset the caller did not override plays through its own handle, so the native
-  // engine drives the haptics and the synced audio together.
-  const usePresetPlayback = options.haptics === undefined && !!preset?.hasAudio;
-  const isPattern = !usePresetPlayback && typeof haptics === 'object' && haptics !== null;
-  const composer = usePatternComposer(isPattern ? (haptics as Pattern) : undefined);
+  const audioPreset =
+    options.haptics === undefined && preset?.hasAudio ? preset : undefined;
+  const composedPattern =
+    !audioPreset && typeof haptics === 'object' && haptics !== null ? haptics : undefined;
+  const composer = usePatternComposer(composedPattern);
 
   const play = useCallback(() => {
     if (!hapticsEnabled) {
       return;
     }
-    if (usePresetPlayback) {
-      preset?.play();
+    if (audioPreset) {
+      audioPreset.play();
     } else if (typeof haptics === 'function') {
       haptics();
-    } else if (haptics && composer.isParsed()) {
+    } else if (composedPattern && composer.isParsed()) {
       composer.play();
     }
-  }, [haptics, hapticsEnabled, composer, preset, usePresetPlayback]);
+  }, [haptics, hapticsEnabled, composer, composedPattern, audioPreset]);
 
   const stop = useCallback(() => {
-    if (usePresetPlayback) {
-      preset?.stop();
-    } else if (isPattern) {
+    if (audioPreset) {
+      audioPreset.stop();
+    } else if (composedPattern) {
       composer.stop();
     }
-  }, [isPattern, composer, preset, usePresetPlayback]);
+  }, [composedPattern, composer, audioPreset]);
 
-  return { play, stop, isReady: isPattern ? composer.isParsed() : true };
+  return { play, stop, isReady: composedPattern ? composer.isParsed() : true };
 }

--- a/react-native/react-native-pulsar-lottie/src/useHapticLottie.ts
+++ b/react-native/react-native-pulsar-lottie/src/useHapticLottie.ts
@@ -1,10 +1,15 @@
 import { useCallback } from 'react';
 import { usePatternComposer } from 'react-native-pulsar';
-import type { Pattern } from 'react-native-pulsar';
+import type { Pattern, PresetHandle } from 'react-native-pulsar';
 import type { HapticSource } from './types';
 
 export interface UseHapticLottieOptions {
-  /** Pattern or preset trigger to fire with the animation. */
+  /**
+   * A bundle preset to fire with the animation. Supplies `haptics` from its pattern, and
+   * plays its synced audio too when it was authored with any.
+   */
+  preset?: PresetHandle;
+  /** Pattern or preset trigger to fire with the animation. Overrides `preset`. */
   haptics?: HapticSource;
   /** Disable firing without unwiring. Default `true`. */
   hapticsEnabled?: boolean;
@@ -29,26 +34,34 @@ export interface HapticLottieHandle {
  * `realtime` sync with seek/loop, use {@link HapticLottieView}.
  */
 export function useHapticLottie(options: UseHapticLottieOptions): HapticLottieHandle {
-  const { haptics, hapticsEnabled = true } = options;
-  const isPattern = typeof haptics === 'object' && haptics !== null;
+  const { preset, hapticsEnabled = true } = options;
+  const haptics = options.haptics ?? preset?.pattern;
+  // An audio preset the caller did not override plays through its own handle, so the native
+  // engine drives the haptics and the synced audio together.
+  const usePresetPlayback = options.haptics === undefined && !!preset?.hasAudio;
+  const isPattern = !usePresetPlayback && typeof haptics === 'object' && haptics !== null;
   const composer = usePatternComposer(isPattern ? (haptics as Pattern) : undefined);
 
   const play = useCallback(() => {
-    if (!hapticsEnabled || !haptics) {
+    if (!hapticsEnabled) {
       return;
     }
-    if (typeof haptics === 'function') {
+    if (usePresetPlayback) {
+      preset?.play();
+    } else if (typeof haptics === 'function') {
       haptics();
-    } else if (composer.isParsed()) {
+    } else if (haptics && composer.isParsed()) {
       composer.play();
     }
-  }, [haptics, hapticsEnabled, composer]);
+  }, [haptics, hapticsEnabled, composer, preset, usePresetPlayback]);
 
   const stop = useCallback(() => {
-    if (isPattern) {
+    if (usePresetPlayback) {
+      preset?.stop();
+    } else if (isPattern) {
       composer.stop();
     }
-  }, [isPattern, composer]);
+  }, [isPattern, composer, preset, usePresetPlayback]);
 
   return { play, stop, isReady: isPattern ? composer.isParsed() : true };
 }


### PR DESCRIPTION
## What & why

Two related problems with the Pulsar Lottie SDKs:

1. **The five packages had drifted apart.** The same concept went by `mode` / `hapticMode`, `offsetMs` / `hapticOffset` / `hapticOffsetMs`, `enabled` / `hapticsEnabled`, `durationMs` / `durationMillis` depending on which SDK you opened — and `durationMs`, which the shared docs already promised, only existed on React Native and KMP.
2. **Passing a `.pulsar` bundle preset straight into the view only worked on React Native**, and even there its authored audio never played.

This unifies the API and makes the preset path work on all five.

## Unified API

Every entry point now takes the same six haptic arguments under the same names — `preset`, `haptics`, `hapticMode`, `hapticOffset`, `hapticsEnabled`, `durationMs` — and the same transport (`play`/`pause`/`resume`/`stop`/`reset`/`setTimestamp`, plus `setLoop` where the package owns the animation).

| | iOS | Android | React Native | KMP | Flutter |
| --- | --- | --- | --- | --- | --- |
| Drop-in view | `HapticLottieView` | `HapticLottieView` | `HapticLottieView` | `HapticLottie` | `HapticLottie` |
| Controller | `HapticLottieController` | `HapticLottieController` | `HapticLottieRef` | `HapticLottieEngine` | `HapticLottieController` |
| Attach to your own view | `PulsarLottie.bind` | `LottieAnimationView.bindHaptics` | `useHapticLottie` | `HapticLottieEngine` | `HapticLottieController(animationController:)` |

**Renames** (all packages are `0.1.0`, none published with these names in use):

- iOS / Android / Flutter controllers: `mode` → `hapticMode`, `offsetMs` → `hapticOffset`, `enabled` → `hapticsEnabled`
- KMP: `hapticOffsetMs` → `hapticOffset`, `durationMillis` → `durationMs`, `HapticMode.Realtime`/`Pattern` → `REALTIME`/`PATTERN` (matching Android)
- Android: `HapticLottieView.setHaptics` → `bindHaptics`, matching the extension and iOS's `bind`
- `durationMs` added to iOS, Android and Flutter

## Bundle presets on every SDK

The blocker was in the **core** SDKs, not the Lottie layer: `PresetHandle` kept its `PatternData` private on iOS/Android/KMP and exposed nothing but `play`/`stop` on Flutter, so the Lottie layer had nothing to sample in realtime mode.

`PresetHandle` now uniformly carries `id`, `name`, `duration`, `pattern`, `animation`, `hasAudio`, `hasAnimation`, `play()`, `stop()`. Flutter needed a new `Pulsar_bundlePresets` bridge method (both native halves) to carry that metadata into Dart; `loadBundleAsync` takes `includeAnimations: false` to skip the Lottie bytes when nothing will render them.

Passing a preset then supplies the animation, the pattern and the duration — each still individually overridable:

```swift
HapticLottieView(preset: pack.celebration)                 // iOS
```
```kotlin
view.bindHaptics(pulsar, preset = bundle.celebration)      // Android
```
```dart
HapticLottie.preset(bundle.celebration, autoPlay: true)    // Flutter
```
```tsx
<HapticLottieView preset={Pack.celebration} autoPlay />    {/* React Native */}
```

KMP renders nothing by design, so it gets `preset.animationJson()` to hand to your own Compose renderer, and `HapticLottie(preset = …)` for the haptics.

## Preset audio was broken, React Native included

`resolvePreset` always preferred the JS pattern over the preset's native handle, so a preset's authored sound never played through the Lottie view on **any** platform. A preset that carries audio now plays through its own handle, so the engine drives haptics and audio together.

Audio only exists in `pattern` mode — the sound is a track the engine plays alongside a compiled pattern, and realtime sampling has nothing to play it against — so **a preset with audio defaults to `pattern` instead of `realtime`**. An explicit `hapticMode` always wins, and passing your own `haptics` takes the preset out of the picture. This is the one bit of implicit behaviour in the change and is called out in the overview doc and every platform page.

## Incidental

- **iOS `PatternData` fields are now public.** The Lottie sampler had been encoding to JSON and decoding into a mirror struct purely to read `internal` stored properties from another module. Widening access is additive and lets the sampler (and the Flutter bridge) read them directly.
- **Two pre-existing failures fixed** in `flutter/pulsar`, which kept its `dart analyze` and `flutter test` red and would have hidden regressions here: a stale `Sound.toMap` assertion (missing `start`/`duration`) and a `PulsarPlatform` test mock missing `loadBundle`, `disposeBundle` and `patternParsePatternWithSound`.

## Docs & examples

All six Lottie doc pages plus the four core SDK pages, all five package READMEs, and all five example apps. The overview gains a **shared API** table and a cross-platform **bundle presets** section, replacing the old "React Native drops it into the view; elsewhere you get the bytes" caveat. Each demo app now renders the example bundle's `lottie` preset end to end.

## Reviewer notes

- ⚠️ **The Lottie packages now need the next core release.** They call `PresetHandle.pattern` / `hasAudio`, which no published core carries. They build against local sources (the in-repo default per `USE_LOCAL_PULSAR_ANDROID` / `USE_LOCAL_PULSAR_IOS`); against published deps, `react-native-pulsar@1.7.0`, `pulsar_haptics 0.1.0` and `PulsarHaptics 1.4.0` don't resolve. I deliberately left `sdk-versions.json` alone since version bumps look like a separate, deliberate release step here — happy to bump and run `npm run sync:versions` if that should ride along.
- The Flutter example's Podfile has no local-`PulsarHaptics` override (the podspec comment claims one exists), so `flutter build ios` there fails on the *pre-existing* bundle bridge. I verified the iOS bridge by adding a temporary `pod 'PulsarHaptics', :path => …` override and reverted it. Worth fixing separately.
- `flutter/PulsarApp/test/widget_test.dart` is still red — it references `MyApp(pulsar:)` and `PulsarFacade`, neither of which exists in `main.dart` any more. Unrelated to this change and wants a real decision about what it should assert, so I left it.

## Verification

All run locally against local core sources:

- **Android** — `:Pulsar:assembleDebug`, `:PulsarLottie:assembleDebug`, `:PulsarLottie:testDebugUnitTest`, `:app:assembleDebug`
- **KMP** — `:PulsarLottie:assemble`, `testAndroidHostTest`, `iosSimulatorArm64Test`, `:composeApp:assembleDebug`
- **iOS** — core package tests (58 tests, 11 suites), `PulsarLottie` tests (6), example app build
- **Flutter** — `flutter/pulsar` analyze + 8 tests; `PulsarLottie` analyze + 13 tests (7 new); Android plugin compiled via example APK; iOS plugin compiled via example simulator build
- **React Native** — `react-native-pulsar-lottie` 9 tests (4 new) + `tsc` clean
- **Docs** — `npm run build` (41 pages)
