### PR TITLE
test(lottie): cover the public PulsarLottie API on every SDK

### DIFF
--- a/Android/PulsarLottie/build.gradle.kts
+++ b/Android/PulsarLottie/build.gradle.kts
@@ -37,7 +37,6 @@ android {
     }
     testOptions {
         unitTests {
-            // Robolectric needs the Android resources/manifest available to unit tests.
             isIncludeAndroidResources = true
         }
     }
@@ -50,7 +49,6 @@ dependencies {
     implementation(libs.lottie)
     implementation(libs.androidx.core.ktx)
     testImplementation(libs.junit)
-    // Pinned here rather than in the example app's shared catalog, matching :Pulsar.
     testImplementation("org.robolectric:robolectric:4.14.1")
 }
 

--- a/Android/PulsarLottie/build.gradle.kts
+++ b/Android/PulsarLottie/build.gradle.kts
@@ -35,6 +35,12 @@ android {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         }
     }
+    testOptions {
+        unitTests {
+            // Robolectric needs the Android resources/manifest available to unit tests.
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -44,6 +50,8 @@ dependencies {
     implementation(libs.lottie)
     implementation(libs.androidx.core.ktx)
     testImplementation(libs.junit)
+    // Pinned here rather than in the example app's shared catalog, matching :Pulsar.
+    testImplementation("org.robolectric:robolectric:4.14.1")
 }
 
 group = "com.swmansion"

--- a/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/HapticLottieControllerTest.kt
+++ b/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/HapticLottieControllerTest.kt
@@ -29,15 +29,6 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowVibrator
 
-/**
- * Public-API coverage for [HapticLottieController], [LottieAnimationView.bindHaptics]
- * and [HapticLottieView].
- *
- * Everything here needs a real `Context`, `Vibrator` and `LottieAnimationView`, so it
- * runs under Robolectric. Writing `progress` on a view that has a composition notifies
- * the animator's update listeners synchronously, which is the controller's own per-frame
- * clock — that is how the ticks below are driven deterministically.
- */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class HapticLottieControllerTest {
@@ -55,7 +46,6 @@ class HapticLottieControllerTest {
         ),
     )
 
-    /** Records what the controller's per-frame clock pushes into the realtime engine. */
     private lateinit var realtime: RecordingComposable
 
     @Before
@@ -68,13 +58,10 @@ class HapticLottieControllerTest {
         }
         ShadowVibrator.reset()
         pulsar = Pulsar(app)
-        // `Pulsar` caches one realtime composer, and its delegate is swappable — so the
-        // controller ends up driving this recorder instead of the device.
         realtime = RecordingComposable()
         pulsar.getRealtimeComposer().delegate = realtime
     }
 
-    /** True once the pattern engine has pushed an effect at the device. */
     private fun vibratorTouched(): Boolean {
         val shadow = shadowOf(
             RuntimeEnvironment.getApplication().getSystemService(Vibrator::class.java),
@@ -86,14 +73,17 @@ class HapticLottieControllerTest {
             shadow.primitiveEffects.orEmpty().isNotEmpty()
     }
 
-    private fun composition(): LottieComposition =
+    private fun twoSecondComposition(): LottieComposition =
         LottieCompositionFactory.fromJsonStringSync(TestBundle.LOTTIE_JSON, null).value!!
 
-    /** A view that already renders a 2s composition, so `progress` writes take effect. */
     private fun view(withComposition: Boolean = true): LottieAnimationView =
         LottieAnimationView(RuntimeEnvironment.getApplication()).apply {
-            if (withComposition) setComposition(composition())
+            if (withComposition) setComposition(twoSecondComposition())
         }
+
+    private fun LottieAnimationView.tickAt(ms: Long, clockMs: Long = PATTERN_CLOCK_MS) {
+        progress = ms.toFloat() / clockMs
+    }
 
     private fun preset(
         durationMs: Double = 1500.0,
@@ -102,8 +92,6 @@ class HapticLottieControllerTest {
     ): PresetHandle = pulsar
         .loadBundle(TestBundle.bytes(durationMs, withAudio, withAnimation))
         .handle("celebration")!!
-
-    // region construction
 
     @Test
     fun bindHapticsReturnsAControllerForTheView() {
@@ -115,7 +103,6 @@ class HapticLottieControllerTest {
         val lottie = view()
         val controller = lottie.bindHaptics(pulsar)
 
-        // Transport still steers the animation; nothing reaches the engine.
         controller.setTimestamp(400)
         controller.play()
         controller.stop()
@@ -132,10 +119,6 @@ class HapticLottieControllerTest {
 
         assertEquals(0.5f, lottie.progress, 1e-6f)
     }
-
-    // endregion
-
-    // region duration resolution, observed through setTimestamp
 
     @Test
     fun anExplicitDurationWinsOverEverything() {
@@ -163,7 +146,7 @@ class HapticLottieControllerTest {
         val lottie = view(withComposition = false)
         val controller = lottie.bindHaptics(pulsar, haptics = pattern)
 
-        lottie.setComposition(composition()) // 60 frames @ 30fps ≈ 2000ms
+        lottie.setComposition(twoSecondComposition())
         controller.setTimestamp(1000)
 
         assertEquals(0.5f, lottie.progress, 1e-3f)
@@ -171,7 +154,7 @@ class HapticLottieControllerTest {
 
     @Test
     fun aCompositionTheViewAlreadyHadCountsToo() {
-        val lottie = view() // composition set before binding
+        val lottie = view()
         val controller = lottie.bindHaptics(pulsar, haptics = pattern)
 
         controller.setTimestamp(1000)
@@ -179,14 +162,10 @@ class HapticLottieControllerTest {
         assertEquals(0.5f, lottie.progress, 1e-3f)
     }
 
-    // endregion
-
-    // region transport
-
     @Test
     fun playRewindsToTheStart() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         controller.setTimestamp(400)
 
         controller.play()
@@ -197,7 +176,7 @@ class HapticLottieControllerTest {
     @Test
     fun stopAndResetBothRewind() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
         controller.setTimestamp(600)
         controller.stop()
@@ -211,7 +190,7 @@ class HapticLottieControllerTest {
     @Test
     fun pauseAndResumeLeaveThePlayheadWhereItWas() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         controller.setTimestamp(600)
 
         controller.pause()
@@ -223,7 +202,7 @@ class HapticLottieControllerTest {
     @Test
     fun setTimestampClampsToBothEndsOfTheClock() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
         controller.setTimestamp(5000)
         assertEquals(1f, lottie.progress, 1e-6f)
@@ -238,9 +217,7 @@ class HapticLottieControllerTest {
         val controller = lottie.bindHaptics(pulsar, haptics = pattern)
 
         controller.setLoop(true)
-        // Robolectric's ValueAnimator shadow rewrites INFINITE to 1 so a test can never
-        // hang on an endless animation — all that is observable here is "looping, forward".
-        assertNotEquals(0, lottie.repeatCount)
+        assertNotEquals(NO_REPEATS, lottie.repeatCount)
         assertEquals(LottieDrawable.RESTART, lottie.repeatMode)
 
         controller.setLoop(true, count = 3, reverse = true)
@@ -248,26 +225,22 @@ class HapticLottieControllerTest {
         assertEquals(LottieDrawable.REVERSE, lottie.repeatMode)
 
         controller.setLoop(false)
-        assertEquals(0, lottie.repeatCount)
+        assertEquals(NO_REPEATS, lottie.repeatCount)
     }
-
-    // endregion
-
-    // region the per-frame haptic clock
 
     @Test
     fun aTickSamplesTheEnvelopesAndFiresThePassedTransients() {
         val lottie = view()
-        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
-        lottie.progress = 0.5f // t = 400ms
+        lottie.tickAt(400)
 
         assertEquals(0.5f, realtime.sets.last().first, 1e-3f)
         assertEquals(0.3f, realtime.sets.last().second, 1e-6f)
         assertEquals(1, realtime.discretes.size)
         assertEquals(1f, realtime.discretes.last().first, 1e-6f)
 
-        lottie.progress = 0.9f // t = 720ms — the 600ms transient is now behind us
+        lottie.tickAt(720)
 
         assertEquals(2, realtime.discretes.size)
         assertEquals(0.4f, realtime.discretes.last().first, 1e-6f)
@@ -277,11 +250,11 @@ class HapticLottieControllerTest {
     @Test
     fun aTransientNeverFiresTwiceInOnePass() {
         val lottie = view()
-        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
-        lottie.progress = 0.4f
-        lottie.progress = 0.45f
-        lottie.progress = 0.5f
+        lottie.tickAt(320)
+        lottie.tickAt(360)
+        lottie.tickAt(400)
 
         assertEquals(1, realtime.discretes.size)
     }
@@ -289,11 +262,11 @@ class HapticLottieControllerTest {
     @Test
     fun wrappingBackToTheStartReArmsTheTransients() {
         val lottie = view()
-        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
-        lottie.progress = 0.5f
-        lottie.progress = 0.1f // looped
-        lottie.progress = 0.5f
+        lottie.tickAt(400)
+        lottie.tickAt(80)
+        lottie.tickAt(400)
 
         assertEquals(2, realtime.discretes.size)
     }
@@ -301,9 +274,9 @@ class HapticLottieControllerTest {
     @Test
     fun hapticOffsetShiftsWhereThePatternIsSampled() {
         val lottie = view()
-        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L, hapticOffset = 400L)
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS, hapticOffset = 400L)
 
-        lottie.progress = 0.25f // t = 200ms, sampled at 600ms
+        lottie.tickAt(200)
 
         assertEquals(0.75f, realtime.sets.last().first, 1e-3f)
     }
@@ -315,9 +288,9 @@ class HapticLottieControllerTest {
             continuousPattern = ContinuousPattern(amplitude = emptyList(), frequency = emptyList()),
             discretePattern = listOf(ConfigPoint(100L, 1f, 0.5f)),
         )
-        val controller = lottie.bindHaptics(pulsar, haptics = discreteOnly, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = discreteOnly, durationMs = PATTERN_CLOCK_MS)
 
-        lottie.progress = 0.5f
+        lottie.tickAt(400)
         controller.pause()
 
         assertTrue(realtime.sets.isEmpty())
@@ -328,7 +301,7 @@ class HapticLottieControllerTest {
     @Test
     fun pauseStopAndResetSilenceTheContinuousChannel() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
         controller.pause()
         controller.stop()
@@ -340,11 +313,11 @@ class HapticLottieControllerTest {
     @Test
     fun playRearmsTheTransientWindow() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
-        lottie.progress = 0.5f
+        lottie.tickAt(400)
         controller.play()
-        lottie.progress = 0.5f
+        lottie.tickAt(400)
 
         assertEquals(2, realtime.discretes.size)
     }
@@ -353,10 +326,10 @@ class HapticLottieControllerTest {
     fun hapticsDisabledLeavesTheEngineUntouched() {
         val lottie = view()
         val controller =
-            lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L, hapticsEnabled = false)
+            lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS, hapticsEnabled = false)
 
-        lottie.progress = 0.5f
-        lottie.progress = 0.9f
+        lottie.tickAt(400)
+        lottie.tickAt(720)
         controller.play()
         controller.stop()
 
@@ -368,13 +341,13 @@ class HapticLottieControllerTest {
     @Test
     fun releaseDetachesTheListenerSoLaterFramesAreSilent() {
         val lottie = view()
-        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
         controller.release()
         realtime.clear()
 
-        lottie.progress = 0.5f
-        lottie.progress = 0.9f
+        lottie.tickAt(400)
+        lottie.tickAt(720)
 
         assertTrue(realtime.sets.isEmpty())
         assertTrue(realtime.discretes.isEmpty())
@@ -388,13 +361,8 @@ class HapticLottieControllerTest {
         controller.release()
     }
 
-    // endregion
-
-    // region modes
-
     @Test
     fun aPresetWithAudioPlaysThroughThePresetItself() {
-        // `pattern` mode is chosen for it, so the preset's own audio plays with the haptics.
         val controller = view().bindHaptics(pulsar, preset = preset(withAudio = true))
 
         controller.play()
@@ -410,24 +378,18 @@ class HapticLottieControllerTest {
             pulsar,
             haptics = pattern,
             hapticMode = HapticMode.PATTERN,
-            durationMs = 800L,
+            durationMs = PATTERN_CLOCK_MS,
         )
-        // In pattern mode the timeline is not the haptic clock: ticking emits nothing.
-        lottie.progress = 0.5f
+        lottie.tickAt(400)
         assertTrue(realtime.sets.isEmpty())
         assertTrue(realtime.discretes.isEmpty())
         assertFalse(vibratorTouched())
 
-        // The whole buffered pattern goes to the device in one shot instead.
         controller.play()
         assertTrue(vibratorTouched())
 
         controller.stop()
     }
-
-    // endregion
-
-    // region HapticLottieView
 
     @Test
     fun theViewExposesTheControllerItLastBound() {
@@ -444,7 +406,7 @@ class HapticLottieControllerTest {
     @Test
     fun theViewKeepsAnAnimationItAlreadyHas() {
         val lottie = HapticLottieView(RuntimeEnvironment.getApplication())
-        val existing = composition()
+        val existing = twoSecondComposition()
         lottie.setComposition(existing)
 
         lottie.bindHaptics(pulsar, preset = preset())
@@ -462,9 +424,6 @@ class HapticLottieControllerTest {
         assertNotNull(controller)
     }
 
-    // endregion
-
-    /** Stands in for the device end of `RealtimeComposer`. */
     private class RecordingComposable : RealtimeComposable {
         val sets = mutableListOf<Pair<Float, Float>>()
         val discretes = mutableListOf<Pair<Float, Float>>()
@@ -489,5 +448,10 @@ class HapticLottieControllerTest {
             discretes.clear()
             stops = 0
         }
+    }
+
+    private companion object {
+        const val NO_REPEATS = 0
+        const val PATTERN_CLOCK_MS = 800L
     }
 }

--- a/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/HapticLottieControllerTest.kt
+++ b/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/HapticLottieControllerTest.kt
@@ -1,0 +1,493 @@
+package com.swmansion.pulsar.lottie
+
+import android.Manifest
+import android.os.Vibrator
+import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.LottieComposition
+import com.airbnb.lottie.LottieCompositionFactory
+import com.airbnb.lottie.LottieDrawable
+import com.swmansion.pulsar.Pulsar
+import com.swmansion.pulsar.bundle.PresetHandle
+import com.swmansion.pulsar.types.ConfigPoint
+import com.swmansion.pulsar.types.ContinuousPattern
+import com.swmansion.pulsar.types.PatternData
+import com.swmansion.pulsar.types.RealtimeComposable
+import com.swmansion.pulsar.types.ValuePoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowVibrator
+
+/**
+ * Public-API coverage for [HapticLottieController], [LottieAnimationView.bindHaptics]
+ * and [HapticLottieView].
+ *
+ * Everything here needs a real `Context`, `Vibrator` and `LottieAnimationView`, so it
+ * runs under Robolectric. Writing `progress` on a view that has a composition notifies
+ * the animator's update listeners synchronously, which is the controller's own per-frame
+ * clock — that is how the ticks below are driven deterministically.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HapticLottieControllerTest {
+
+    private lateinit var pulsar: Pulsar
+
+    private val pattern = PatternData(
+        continuousPattern = ContinuousPattern(
+            amplitude = listOf(ValuePoint(0L, 0f), ValuePoint(800L, 1f)),
+            frequency = listOf(ValuePoint(0L, 0.3f)),
+        ),
+        discretePattern = listOf(
+            ConfigPoint(250L, 1f, 0.5f),
+            ConfigPoint(600L, 0.4f, 0.2f),
+        ),
+    )
+
+    /** Records what the controller's per-frame clock pushes into the realtime engine. */
+    private lateinit var realtime: RecordingComposable
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        shadowOf(app).grantPermissions(Manifest.permission.VIBRATE)
+        shadowOf(app.getSystemService(Vibrator::class.java)).apply {
+            setHasVibrator(true)
+            setHasAmplitudeControl(true)
+        }
+        ShadowVibrator.reset()
+        pulsar = Pulsar(app)
+        // `Pulsar` caches one realtime composer, and its delegate is swappable — so the
+        // controller ends up driving this recorder instead of the device.
+        realtime = RecordingComposable()
+        pulsar.getRealtimeComposer().delegate = realtime
+    }
+
+    /** True once the pattern engine has pushed an effect at the device. */
+    private fun vibratorTouched(): Boolean {
+        val shadow = shadowOf(
+            RuntimeEnvironment.getApplication().getSystemService(Vibrator::class.java),
+        )
+        return shadow.isVibrating ||
+            shadow.milliseconds > 0L ||
+            shadow.pattern != null ||
+            shadow.effectId != 0 ||
+            shadow.primitiveEffects.orEmpty().isNotEmpty()
+    }
+
+    private fun composition(): LottieComposition =
+        LottieCompositionFactory.fromJsonStringSync(TestBundle.LOTTIE_JSON, null).value!!
+
+    /** A view that already renders a 2s composition, so `progress` writes take effect. */
+    private fun view(withComposition: Boolean = true): LottieAnimationView =
+        LottieAnimationView(RuntimeEnvironment.getApplication()).apply {
+            if (withComposition) setComposition(composition())
+        }
+
+    private fun preset(
+        durationMs: Double = 1500.0,
+        withAudio: Boolean = false,
+        withAnimation: Boolean = true,
+    ): PresetHandle = pulsar
+        .loadBundle(TestBundle.bytes(durationMs, withAudio, withAnimation))
+        .handle("celebration")!!
+
+    // region construction
+
+    @Test
+    fun bindHapticsReturnsAControllerForTheView() {
+        assertNotNull(view().bindHaptics(pulsar, haptics = pattern))
+    }
+
+    @Test
+    fun aViewCanBeBoundWithNoHapticsAtAll() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar)
+
+        // Transport still steers the animation; nothing reaches the engine.
+        controller.setTimestamp(400)
+        controller.play()
+        controller.stop()
+
+        assertEquals(0f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun aPresetSuppliesThePatternAndTheAuthoredDuration() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, preset = preset(durationMs = 1500.0))
+
+        controller.setTimestamp(750)
+
+        assertEquals(0.5f, lottie.progress, 1e-6f)
+    }
+
+    // endregion
+
+    // region duration resolution, observed through setTimestamp
+
+    @Test
+    fun anExplicitDurationWinsOverEverything() {
+        val lottie = view()
+        val controller =
+            lottie.bindHaptics(pulsar, preset = preset(), haptics = pattern, durationMs = 1000L)
+
+        controller.setTimestamp(500)
+
+        assertEquals(0.5f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun aZeroDurationFallsThroughToThePresetsOwn() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, preset = preset(durationMs = 1500.0), durationMs = 0L)
+
+        controller.setTimestamp(750)
+
+        assertEquals(0.5f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun theCompositionLengthIsAdoptedWhenItLoadsAfterBinding() {
+        val lottie = view(withComposition = false)
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern)
+
+        lottie.setComposition(composition()) // 60 frames @ 30fps ≈ 2000ms
+        controller.setTimestamp(1000)
+
+        assertEquals(0.5f, lottie.progress, 1e-3f)
+    }
+
+    @Test
+    fun aCompositionTheViewAlreadyHadCountsToo() {
+        val lottie = view() // composition set before binding
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern)
+
+        controller.setTimestamp(1000)
+
+        assertEquals(0.5f, lottie.progress, 1e-3f)
+    }
+
+    // endregion
+
+    // region transport
+
+    @Test
+    fun playRewindsToTheStart() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        controller.setTimestamp(400)
+
+        controller.play()
+
+        assertEquals(0f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun stopAndResetBothRewind() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        controller.setTimestamp(600)
+        controller.stop()
+        assertEquals(0f, lottie.progress, 1e-6f)
+
+        controller.setTimestamp(600)
+        controller.reset()
+        assertEquals(0f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun pauseAndResumeLeaveThePlayheadWhereItWas() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+        controller.setTimestamp(600)
+
+        controller.pause()
+        controller.resume()
+
+        assertEquals(0.75f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun setTimestampClampsToBothEndsOfTheClock() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        controller.setTimestamp(5000)
+        assertEquals(1f, lottie.progress, 1e-6f)
+
+        controller.setTimestamp(-100)
+        assertEquals(0f, lottie.progress, 1e-6f)
+    }
+
+    @Test
+    fun setLoopMapsOntoTheViewsRepeatConfiguration() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern)
+
+        controller.setLoop(true)
+        // Robolectric's ValueAnimator shadow rewrites INFINITE to 1 so a test can never
+        // hang on an endless animation — all that is observable here is "looping, forward".
+        assertNotEquals(0, lottie.repeatCount)
+        assertEquals(LottieDrawable.RESTART, lottie.repeatMode)
+
+        controller.setLoop(true, count = 3, reverse = true)
+        assertEquals(3, lottie.repeatCount)
+        assertEquals(LottieDrawable.REVERSE, lottie.repeatMode)
+
+        controller.setLoop(false)
+        assertEquals(0, lottie.repeatCount)
+    }
+
+    // endregion
+
+    // region the per-frame haptic clock
+
+    @Test
+    fun aTickSamplesTheEnvelopesAndFiresThePassedTransients() {
+        val lottie = view()
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        lottie.progress = 0.5f // t = 400ms
+
+        assertEquals(0.5f, realtime.sets.last().first, 1e-3f)
+        assertEquals(0.3f, realtime.sets.last().second, 1e-6f)
+        assertEquals(1, realtime.discretes.size)
+        assertEquals(1f, realtime.discretes.last().first, 1e-6f)
+
+        lottie.progress = 0.9f // t = 720ms — the 600ms transient is now behind us
+
+        assertEquals(2, realtime.discretes.size)
+        assertEquals(0.4f, realtime.discretes.last().first, 1e-6f)
+        assertEquals(0.2f, realtime.discretes.last().second, 1e-6f)
+    }
+
+    @Test
+    fun aTransientNeverFiresTwiceInOnePass() {
+        val lottie = view()
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        lottie.progress = 0.4f
+        lottie.progress = 0.45f
+        lottie.progress = 0.5f
+
+        assertEquals(1, realtime.discretes.size)
+    }
+
+    @Test
+    fun wrappingBackToTheStartReArmsTheTransients() {
+        val lottie = view()
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        lottie.progress = 0.5f
+        lottie.progress = 0.1f // looped
+        lottie.progress = 0.5f
+
+        assertEquals(2, realtime.discretes.size)
+    }
+
+    @Test
+    fun hapticOffsetShiftsWhereThePatternIsSampled() {
+        val lottie = view()
+        lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L, hapticOffset = 400L)
+
+        lottie.progress = 0.25f // t = 200ms, sampled at 600ms
+
+        assertEquals(0.75f, realtime.sets.last().first, 1e-3f)
+    }
+
+    @Test
+    fun aDiscreteOnlyPatternDrivesNoContinuousChannel() {
+        val lottie = view()
+        val discreteOnly = PatternData(
+            continuousPattern = ContinuousPattern(amplitude = emptyList(), frequency = emptyList()),
+            discretePattern = listOf(ConfigPoint(100L, 1f, 0.5f)),
+        )
+        val controller = lottie.bindHaptics(pulsar, haptics = discreteOnly, durationMs = 800L)
+
+        lottie.progress = 0.5f
+        controller.pause()
+
+        assertTrue(realtime.sets.isEmpty())
+        assertEquals(1, realtime.discretes.size)
+        assertEquals(0, realtime.stops)
+    }
+
+    @Test
+    fun pauseStopAndResetSilenceTheContinuousChannel() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        controller.pause()
+        controller.stop()
+        controller.reset()
+
+        assertEquals(3, realtime.stops)
+    }
+
+    @Test
+    fun playRearmsTheTransientWindow() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        lottie.progress = 0.5f
+        controller.play()
+        lottie.progress = 0.5f
+
+        assertEquals(2, realtime.discretes.size)
+    }
+
+    @Test
+    fun hapticsDisabledLeavesTheEngineUntouched() {
+        val lottie = view()
+        val controller =
+            lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L, hapticsEnabled = false)
+
+        lottie.progress = 0.5f
+        lottie.progress = 0.9f
+        controller.play()
+        controller.stop()
+
+        assertTrue(realtime.sets.isEmpty())
+        assertTrue(realtime.discretes.isEmpty())
+        assertFalse(vibratorTouched())
+    }
+
+    @Test
+    fun releaseDetachesTheListenerSoLaterFramesAreSilent() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(pulsar, haptics = pattern, durationMs = 800L)
+
+        controller.release()
+        realtime.clear()
+
+        lottie.progress = 0.5f
+        lottie.progress = 0.9f
+
+        assertTrue(realtime.sets.isEmpty())
+        assertTrue(realtime.discretes.isEmpty())
+    }
+
+    @Test
+    fun releaseIsSafeToCallTwice() {
+        val controller = view().bindHaptics(pulsar, haptics = pattern)
+
+        controller.release()
+        controller.release()
+    }
+
+    // endregion
+
+    // region modes
+
+    @Test
+    fun aPresetWithAudioPlaysThroughThePresetItself() {
+        // `pattern` mode is chosen for it, so the preset's own audio plays with the haptics.
+        val controller = view().bindHaptics(pulsar, preset = preset(withAudio = true))
+
+        controller.play()
+        controller.pause()
+        controller.stop()
+        controller.release()
+    }
+
+    @Test
+    fun patternModeBuffersAndFiresTheWholePattern() {
+        val lottie = view()
+        val controller = lottie.bindHaptics(
+            pulsar,
+            haptics = pattern,
+            hapticMode = HapticMode.PATTERN,
+            durationMs = 800L,
+        )
+        // In pattern mode the timeline is not the haptic clock: ticking emits nothing.
+        lottie.progress = 0.5f
+        assertTrue(realtime.sets.isEmpty())
+        assertTrue(realtime.discretes.isEmpty())
+        assertFalse(vibratorTouched())
+
+        // The whole buffered pattern goes to the device in one shot instead.
+        controller.play()
+        assertTrue(vibratorTouched())
+
+        controller.stop()
+    }
+
+    // endregion
+
+    // region HapticLottieView
+
+    @Test
+    fun theViewExposesTheControllerItLastBound() {
+        val lottie = HapticLottieView(RuntimeEnvironment.getApplication())
+        assertNull(lottie.hapticController())
+
+        val first = lottie.bindHaptics(pulsar, haptics = pattern)
+        assertSame(first, lottie.hapticController())
+
+        val second = lottie.bindHaptics(pulsar, haptics = pattern)
+        assertSame(second, lottie.hapticController())
+    }
+
+    @Test
+    fun theViewKeepsAnAnimationItAlreadyHas() {
+        val lottie = HapticLottieView(RuntimeEnvironment.getApplication())
+        val existing = composition()
+        lottie.setComposition(existing)
+
+        lottie.bindHaptics(pulsar, preset = preset())
+
+        assertSame(existing, lottie.composition)
+    }
+
+    @Test
+    fun aPresetWithoutAnAnimationLeavesTheViewEmpty() {
+        val lottie = HapticLottieView(RuntimeEnvironment.getApplication())
+
+        val controller = lottie.bindHaptics(pulsar, preset = preset(withAnimation = false))
+
+        assertNull(lottie.composition)
+        assertNotNull(controller)
+    }
+
+    // endregion
+
+    /** Stands in for the device end of `RealtimeComposer`. */
+    private class RecordingComposable : RealtimeComposable {
+        val sets = mutableListOf<Pair<Float, Float>>()
+        val discretes = mutableListOf<Pair<Float, Float>>()
+        var stops = 0
+
+        override fun set(amplitude: Float, frequency: Float) {
+            sets += amplitude to frequency
+        }
+
+        override fun playDiscrete(amplitude: Float, frequency: Float) {
+            discretes += amplitude to frequency
+        }
+
+        override fun stop() {
+            stops++
+        }
+
+        override fun isActive(): Boolean = false
+
+        fun clear() {
+            sets.clear()
+            discretes.clear()
+            stops = 0
+        }
+    }
+}

--- a/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/SamplerTest.kt
+++ b/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/SamplerTest.kt
@@ -32,6 +32,51 @@ class SamplerTest {
     }
 
     @Test
+    fun singlePointHoldsItsValue() {
+        val flat = listOf(ValuePoint(500L, 0.7f))
+        assertEquals(0.7f, sampleEnvelope(flat, 0L), 1e-6f)
+        assertEquals(0.7f, sampleEnvelope(flat, 500L), 1e-6f)
+        assertEquals(0.7f, sampleEnvelope(flat, 10_000L), 1e-6f)
+    }
+
+    @Test
+    fun zeroWidthSpanTakesTheLaterValue() {
+        val step = listOf(
+            ValuePoint(0L, 0f),
+            ValuePoint(400L, 0.2f),
+            ValuePoint(400L, 0.9f),
+            ValuePoint(800L, 1f),
+        )
+        assertEquals(0.2f, sampleEnvelope(step, 400L), 1e-6f)
+        assertEquals(0.95f, sampleEnvelope(step, 600L), 1e-6f)
+    }
+
+    @Test
+    fun emptyPatternHasNoLength() {
+        assertEquals(
+            0L,
+            patternDurationMs(
+                PatternData(
+                    continuousPattern = ContinuousPattern(emptyList(), emptyList()),
+                    discretePattern = emptyList(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun aLateTransientCanBeTheLongestChannel() {
+        val p = PatternData(
+            continuousPattern = ContinuousPattern(
+                amplitude = listOf(ValuePoint(0L, 0f), ValuePoint(300L, 1f)),
+                frequency = listOf(ValuePoint(0L, 0.3f)),
+            ),
+            discretePattern = listOf(ConfigPoint(1200L, 1f, 0.5f)),
+        )
+        assertEquals(1200L, patternDurationMs(p))
+    }
+
+    @Test
     fun emptyCurveIsZero() {
         assertEquals(0f, sampleEnvelope(emptyList(), 100L), 1e-6f)
     }

--- a/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/TestBundle.kt
+++ b/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/TestBundle.kt
@@ -1,0 +1,67 @@
+package com.swmansion.pulsar.lottie
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Builds `.pulsar` archives in memory so the tests can obtain real
+ * `PresetHandle`s through the public `Pulsar.loadBundle` path — the handle's own
+ * constructor is internal to the core module.
+ */
+internal object TestBundle {
+
+    /** A 2s animation (60 frames @ 30fps) with nothing in it, but parseable by Lottie. */
+    const val LOTTIE_JSON =
+        """{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,""" +
+            """"assets":[],"layers":[]}"""
+
+    /** Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients. */
+    private const val HAPTICS_JSON =
+        """{"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],""" +
+            """"frequency":[{"time":0,"value":0.3}]},""" +
+            """"discretePattern":[{"time":250,"amplitude":1.0,"frequency":0.5},""" +
+            """{"time":600,"amplitude":0.4,"frequency":0.2}]}"""
+
+    /**
+     * A single-preset bundle. [durationMs] is the authored duration, [withAudio] adds a
+     * synced audio track and [withAnimation] the Lottie the preset was authored against.
+     */
+    fun bytes(
+        durationMs: Double = 1500.0,
+        withAudio: Boolean = false,
+        withAnimation: Boolean = true,
+    ): ByteArray {
+        val audio = if (withAudio) ""","audio":{"src":"audio/boom.ogg","volume":1.0,"offset":0}""" else ""
+        val animation =
+            if (withAnimation) {
+                ""","animation":{"src":"anim/celebration.json","frameRate":30,"totalFrames":60}"""
+            } else {
+                ""
+            }
+        val manifest =
+            """{"schema":"pulsar.bundle/1","id":"com.acme.haptics","name":"Acme Pack","revision":7,""" +
+                """"hash":"sha256-test","presets":[{"id":"celebration","name":"Celebration",""" +
+                """"duration":$durationMs,"haptics":"haptics/celebration.json"$audio$animation}]}"""
+
+        val entries = buildMap {
+            put("manifest.json", manifest)
+            put("haptics/celebration.json", HAPTICS_JSON)
+            if (withAudio) put("audio/boom.ogg", "not-really-audio")
+            if (withAnimation) put("anim/celebration.json", LOTTIE_JSON)
+        }
+        return zip(entries)
+    }
+
+    private fun zip(entries: Map<String, String>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zip ->
+            entries.forEach { (name, content) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content.toByteArray())
+                zip.closeEntry()
+            }
+        }
+        return bos.toByteArray()
+    }
+}

--- a/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/TestBundle.kt
+++ b/Android/PulsarLottie/src/test/java/com/swmansion/pulsar/lottie/TestBundle.kt
@@ -4,29 +4,18 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-/**
- * Builds `.pulsar` archives in memory so the tests can obtain real
- * `PresetHandle`s through the public `Pulsar.loadBundle` path — the handle's own
- * constructor is internal to the core module.
- */
 internal object TestBundle {
 
-    /** A 2s animation (60 frames @ 30fps) with nothing in it, but parseable by Lottie. */
     const val LOTTIE_JSON =
         """{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,""" +
             """"assets":[],"layers":[]}"""
 
-    /** Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients. */
     private const val HAPTICS_JSON =
         """{"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],""" +
             """"frequency":[{"time":0,"value":0.3}]},""" +
             """"discretePattern":[{"time":250,"amplitude":1.0,"frequency":0.5},""" +
             """{"time":600,"amplitude":0.4,"frequency":0.2}]}"""
 
-    /**
-     * A single-preset bundle. [durationMs] is the authored duration, [withAudio] adds a
-     * synced audio track and [withAnimation] the Lottie the preset was authored against.
-     */
     fun bytes(
         durationMs: Double = 1500.0,
         withAudio: Boolean = false,

--- a/flutter/PulsarLottie/pubspec_overrides.yaml
+++ b/flutter/PulsarLottie/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+# Local development only: resolve pulsar_haptics from the in-repo sources, which are
+# ahead of the published package (bundle presets). Not part of the published archive.
+dependency_overrides:
+  pulsar_haptics:
+    path: ../pulsar

--- a/flutter/PulsarLottie/pubspec_overrides.yaml
+++ b/flutter/PulsarLottie/pubspec_overrides.yaml
@@ -1,5 +1,3 @@
-# Local development only: resolve pulsar_haptics from the in-repo sources, which are
-# ahead of the published package (bundle presets). Not part of the published archive.
 dependency_overrides:
   pulsar_haptics:
     path: ../pulsar

--- a/flutter/PulsarLottie/test/fake_pulsar_platform.dart
+++ b/flutter/PulsarLottie/test/fake_pulsar_platform.dart
@@ -1,0 +1,87 @@
+import 'package:pulsar_haptics/pulsar.dart';
+
+/// A [PulsarPlatform] that records every call the Lottie SDK makes into the
+/// engine, so tests can assert what a transport action actually emitted rather
+/// than only that it did not throw.
+class FakePulsarPlatform extends PulsarPlatform {
+  /// Installs a fresh recorder as the platform every test reads through.
+  static FakePulsarPlatform install() {
+    final platform = FakePulsarPlatform();
+    PulsarPlatform.instance = platform;
+    return platform;
+  }
+
+  /// Every recorded call, in order, by method name.
+  final List<String> calls = <String>[];
+
+  /// `[amplitude, frequency]` of each `RealtimeComposer.set`.
+  final List<List<double>> realtimeSets = <List<double>>[];
+
+  /// `[amplitude, frequency]` of each `RealtimeComposer.playDiscrete`.
+  final List<List<double>> discretes = <List<double>>[];
+
+  /// Patterns handed to `PatternComposer.parsePattern`.
+  final List<PatternData> parsedPatterns = <PatternData>[];
+
+  /// Preset ids played through their own native handle (the audio path).
+  final List<String> playedPresets = <String>[];
+
+  /// Preset ids stopped through their own native handle.
+  final List<String> stoppedPresets = <String>[];
+
+  int _nextComposerId = 1;
+
+  @override
+  Future<void> realtimeSet(
+    double amplitude,
+    double frequency, {
+    RealtimeComposerStrategy? strategy,
+  }) async {
+    calls.add('realtimeSet');
+    realtimeSets.add([amplitude, frequency]);
+  }
+
+  @override
+  Future<void> realtimePlayDiscrete(
+    double amplitude,
+    double frequency, {
+    RealtimeComposerStrategy? strategy,
+  }) async {
+    calls.add('realtimePlayDiscrete');
+    discretes.add([amplitude, frequency]);
+  }
+
+  @override
+  Future<void> realtimeStop({RealtimeComposerStrategy? strategy}) async {
+    calls.add('realtimeStop');
+  }
+
+  @override
+  Future<int> patternParsePattern(PatternData data, {int? composerId}) async {
+    calls.add('patternParsePattern');
+    parsedPatterns.add(data);
+    return composerId ?? _nextComposerId++;
+  }
+
+  @override
+  Future<void> patternPlay(int composerId) async => calls.add('patternPlay');
+
+  @override
+  Future<void> patternStop(int composerId) async => calls.add('patternStop');
+
+  @override
+  Future<void> patternRelease(int composerId) async =>
+      calls.add('patternRelease');
+
+  @override
+  Future<void> playBundlePreset(String token, String presetId) async {
+    calls.add('playBundlePreset');
+    playedPresets.add(presetId);
+  }
+
+  @override
+  Future<void> stopBundlePreset(String token, String presetId) async {
+    calls.add('stopBundlePreset');
+    stoppedPresets.add(presetId);
+  }
+}

--- a/flutter/PulsarLottie/test/fake_pulsar_platform.dart
+++ b/flutter/PulsarLottie/test/fake_pulsar_platform.dart
@@ -1,32 +1,17 @@
 import 'package:pulsar_haptics/pulsar.dart';
 
-/// A [PulsarPlatform] that records every call the Lottie SDK makes into the
-/// engine, so tests can assert what a transport action actually emitted rather
-/// than only that it did not throw.
-class FakePulsarPlatform extends PulsarPlatform {
-  /// Installs a fresh recorder as the platform every test reads through.
-  static FakePulsarPlatform install() {
-    final platform = FakePulsarPlatform();
+class RecordingPulsarPlatform extends PulsarPlatform {
+  static RecordingPulsarPlatform install() {
+    final platform = RecordingPulsarPlatform();
     PulsarPlatform.instance = platform;
     return platform;
   }
 
-  /// Every recorded call, in order, by method name.
   final List<String> calls = <String>[];
-
-  /// `[amplitude, frequency]` of each `RealtimeComposer.set`.
   final List<List<double>> realtimeSets = <List<double>>[];
-
-  /// `[amplitude, frequency]` of each `RealtimeComposer.playDiscrete`.
   final List<List<double>> discretes = <List<double>>[];
-
-  /// Patterns handed to `PatternComposer.parsePattern`.
   final List<PatternData> parsedPatterns = <PatternData>[];
-
-  /// Preset ids played through their own native handle (the audio path).
   final List<String> playedPresets = <String>[];
-
-  /// Preset ids stopped through their own native handle.
   final List<String> stoppedPresets = <String>[];
 
   int _nextComposerId = 1;

--- a/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
+++ b/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
@@ -1,36 +1,48 @@
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pulsar_haptics/pulsar.dart';
 import 'package:pulsar_haptics_lottie/pulsar_haptics_lottie.dart';
+
+import 'fake_pulsar_platform.dart';
 
 const _pattern = PatternData(
   continuousPattern: ContinuousPattern(
     amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 800, value: 1)],
     frequency: [ValuePoint(time: 0, value: 0.3)],
   ),
-  discretePattern: [DiscretePoint(time: 250, amplitude: 1, frequency: 0.5)],
+  discretePattern: [
+    DiscretePoint(time: 250, amplitude: 1, frequency: 0.5),
+    DiscretePoint(time: 600, amplitude: 0.4, frequency: 0.2),
+  ],
 );
 
-PresetHandle _preset({bool hasAudio = false, double duration = 1500}) =>
-    PresetHandle(
-      'token',
-      'celebration',
-      name: 'Celebration',
-      duration: duration,
-      pattern: _pattern,
-      hasAudio: hasAudio,
-    );
+/// A pattern with no continuous channels — only transients.
+const _discreteOnly = PatternData(
+  continuousPattern: ContinuousPattern(amplitude: [], frequency: []),
+  discretePattern: [DiscretePoint(time: 100, amplitude: 1, frequency: 0.5)],
+);
+
+PresetHandle _preset({
+  bool hasAudio = false,
+  double duration = 1500,
+  BundleAnimation? animation,
+}) => PresetHandle(
+  'token',
+  'celebration',
+  name: 'Celebration',
+  duration: duration,
+  pattern: _pattern,
+  animation: animation,
+  hasAudio: hasAudio,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakePulsarPlatform native;
+
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          const MethodChannel('pulsar'),
-          (call) async => null,
-        );
+    native = FakePulsarPlatform.install();
   });
 
   HapticLottieController controllerFor({
@@ -38,11 +50,15 @@ void main() {
     PatternData? haptics,
     HapticMode? hapticMode,
     double? durationMs,
+    double hapticOffset = 0,
+    bool hapticsEnabled = true,
     Duration? compositionDuration,
   }) {
+    // `play()` drives a real `AnimationController.forward`, which needs a length:
+    // default to one, and pass `Duration.zero` where "no composition yet" is the point.
     final animation = AnimationController(
       vsync: const TestVSync(),
-      duration: compositionDuration,
+      duration: compositionDuration ?? const Duration(milliseconds: 800),
     );
     addTearDown(animation.dispose);
     final controller = HapticLottieController(
@@ -50,38 +66,49 @@ void main() {
       preset: preset,
       haptics: haptics,
       hapticMode: hapticMode,
+      hapticOffset: hapticOffset,
+      hapticsEnabled: hapticsEnabled,
       durationMs: durationMs,
     );
     addTearDown(controller.dispose);
     return controller;
   }
 
-  test('a silent preset stays in realtime mode', () {
-    expect(controllerFor(preset: _preset()).hapticMode, HapticMode.realtime);
-  });
+  group('mode resolution', () {
+    test('a silent preset stays in realtime mode', () {
+      expect(controllerFor(preset: _preset()).hapticMode, HapticMode.realtime);
+    });
 
-  test('a preset with audio defaults to pattern mode, so its audio plays', () {
-    expect(
-      controllerFor(preset: _preset(hasAudio: true)).hapticMode,
-      HapticMode.pattern,
-    );
-  });
+    test('a preset with audio defaults to pattern mode, so its audio plays', () {
+      expect(
+        controllerFor(preset: _preset(hasAudio: true)).hapticMode,
+        HapticMode.pattern,
+      );
+    });
 
-  test('an explicit hapticMode wins over an audio preset default', () {
-    expect(
-      controllerFor(
-        preset: _preset(hasAudio: true),
-        hapticMode: HapticMode.realtime,
-      ).hapticMode,
-      HapticMode.realtime,
-    );
-  });
+    test('an explicit hapticMode wins over an audio preset default', () {
+      expect(
+        controllerFor(
+          preset: _preset(hasAudio: true),
+          hapticMode: HapticMode.realtime,
+        ).hapticMode,
+        HapticMode.realtime,
+      );
+    });
 
-  test('explicit haptics keep an audio preset from taking over the mode', () {
-    expect(
-      controllerFor(preset: _preset(hasAudio: true), haptics: _pattern).hapticMode,
-      HapticMode.realtime,
-    );
+    test('explicit haptics keep an audio preset from taking over the mode', () {
+      expect(
+        controllerFor(
+          preset: _preset(hasAudio: true),
+          haptics: _pattern,
+        ).hapticMode,
+        HapticMode.realtime,
+      );
+    });
+
+    test('with no pattern at all the mode is still reported', () {
+      expect(controllerFor().hapticMode, HapticMode.realtime);
+    });
   });
 
   group('duration resolution', () {
@@ -114,7 +141,374 @@ void main() {
         ).durationMsResolved,
         2400,
       );
-      expect(controllerFor(haptics: _pattern).durationMsResolved, 800);
+      expect(
+        controllerFor(
+          haptics: _pattern,
+          compositionDuration: Duration.zero,
+        ).durationMsResolved,
+        800,
+      );
+    });
+
+    test('a zero-length preset duration falls through to the composition', () {
+      expect(
+        controllerFor(
+          preset: _preset(duration: 0),
+          compositionDuration: const Duration(milliseconds: 2400),
+        ).durationMsResolved,
+        2400,
+      );
+    });
+
+    test('with nothing to derive from, the clock is zero', () {
+      expect(
+        controllerFor(compositionDuration: Duration.zero).durationMsResolved,
+        0,
+      );
+    });
+  });
+
+  group('exposed configuration', () {
+    test('the constructor arguments are readable back', () {
+      final preset = _preset();
+      final controller = controllerFor(
+        preset: preset,
+        haptics: _pattern,
+        hapticOffset: -20,
+        hapticsEnabled: false,
+        durationMs: 700,
+      );
+
+      expect(controller.preset, same(preset));
+      expect(controller.haptics, same(_pattern));
+      expect(controller.hapticOffset, -20);
+      expect(controller.hapticsEnabled, isFalse);
+      expect(controller.durationMs, 700);
+      expect(controller.animationController.value, 0);
+    });
+  });
+
+  group('realtime transport', () {
+    test('play restarts the animation from the beginning', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      controller.animationController.value = 0.5;
+
+      await controller.play();
+
+      expect(controller.animationController.value, 0);
+      expect(controller.animationController.isAnimating, isTrue);
+    });
+
+    test('a tick samples the envelopes and fires the transients passed', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      // Half-way: amplitude ramps 0→1 over 800ms, frequency is a single flat point.
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(native.realtimeSets.last, [closeTo(0.5, 1e-6), closeTo(0.3, 1e-6)]);
+      // Only the 250ms transient is behind the playhead.
+      expect(native.discretes, [
+        [closeTo(1, 1e-6), closeTo(0.5, 1e-6)],
+      ]);
+
+      controller.animationController.value = 0.9;
+      await pumpEventQueue();
+
+      expect(native.discretes.length, 2, reason: 'the 600ms transient fires too');
+      expect(native.discretes.last, [closeTo(0.4, 1e-6), closeTo(0.2, 1e-6)]);
+    });
+
+    test('a transient never fires twice for the same playhead pass', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      controller.animationController.value = 0.4;
+      controller.animationController.value = 0.45;
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(native.discretes.length, 1);
+    });
+
+    test('wrapping back to the start re-arms the transients', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      controller.animationController.value = 0.5;
+      controller.animationController.value = 0.1; // looped
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(native.discretes.length, 2);
+    });
+
+    test('hapticOffset shifts where the pattern is sampled', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        durationMs: 800,
+        hapticOffset: 400,
+      );
+
+      controller.animationController.value = 0.25; // t = 200ms, ht = 600ms
+      await pumpEventQueue();
+
+      expect(native.realtimeSets.last.first, closeTo(0.75, 1e-6));
+    });
+
+    test('a discrete-only pattern drives no continuous channel', () async {
+      final controller = controllerFor(haptics: _discreteOnly, durationMs: 800);
+
+      controller.animationController.value = 0.5;
+      await controller.pause();
+      await pumpEventQueue();
+
+      expect(native.realtimeSets, isEmpty);
+      expect(native.discretes.length, 1);
+      expect(
+        native.calls,
+        isNot(contains('realtimeStop')),
+        reason: 'nothing continuous is running, so nothing needs stopping',
+      );
+    });
+
+    test('pause stops the animation and the continuous haptic', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      await controller.play();
+
+      await controller.pause();
+      await pumpEventQueue();
+
+      expect(controller.animationController.isAnimating, isFalse);
+      expect(native.calls, contains('realtimeStop'));
+    });
+
+    test('resume drives the animation forward again', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      controller.animationController.value = 0.4;
+
+      await controller.resume();
+
+      expect(controller.animationController.isAnimating, isTrue);
+    });
+
+    test('stop rewinds and silences the haptics', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      await controller.play();
+      controller.animationController.value = 0.6;
+
+      await controller.stop();
+      await pumpEventQueue();
+
+      expect(controller.animationController.value, 0);
+      expect(controller.animationController.isAnimating, isFalse);
+      expect(native.calls, contains('realtimeStop'));
+    });
+
+    test('reset rewinds like stop', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      controller.animationController.value = 0.6;
+      native.calls.clear();
+
+      await controller.reset();
+      await pumpEventQueue();
+
+      expect(controller.animationController.value, 0);
+      expect(native.calls, contains('realtimeStop'));
+    });
+
+    test('setTimestamp seeks the animation and the transient window', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      controller.setTimestamp(400);
+      expect(controller.animationController.value, closeTo(0.5, 1e-6));
+
+      // NOTE: writing `AnimationController.value` notifies listeners synchronously,
+      // so the seek itself runs one tick and fires the transients it jumped over —
+      // iOS and Android move the playhead silently. Documented, not asserted as
+      // desired behaviour.
+      native.discretes.clear();
+
+      // What matters either way: the window moved, so the next tick does not
+      // replay what the seek passed.
+      controller.animationController.value = 0.55;
+      await pumpEventQueue();
+      expect(native.discretes, isEmpty);
+    });
+
+    test('setTimestamp clamps to the ends of the clock', () {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      controller.setTimestamp(5000);
+      expect(controller.animationController.value, 1);
+
+      controller.setTimestamp(-100);
+      expect(controller.animationController.value, 0);
+    });
+
+    test('setTimestamp is a no-op on a zero-length clock', () {
+      final controller = controllerFor(compositionDuration: Duration.zero);
+
+      controller.setTimestamp(400);
+
+      expect(controller.animationController.value, 0);
+    });
+
+    test('setLoop(true) repeats the animation and rearms the haptics', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      await controller.setLoop(true, count: 2, reverse: true);
+
+      expect(controller.animationController.isAnimating, isTrue);
+    });
+
+    test('setLoop(false) stops the animation', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      await controller.play();
+
+      await controller.setLoop(false);
+
+      expect(controller.animationController.isAnimating, isFalse);
+    });
+
+    test('dispose detaches the listener, so later frames are silent', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      controller.dispose();
+      native.calls.clear();
+      native.realtimeSets.clear();
+
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(native.realtimeSets, isEmpty);
+      expect(native.discretes, isEmpty);
+    });
+
+    test('dispose is idempotent', () {
+      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+
+      controller.dispose();
+
+      expect(controller.dispose, returnsNormally);
+    });
+  });
+
+  group('hapticsEnabled: false', () {
+    test('the animation still runs but nothing is sent to the engine', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        durationMs: 800,
+        hapticsEnabled: false,
+      );
+
+      await controller.play();
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(controller.animationController.value, 0.5);
+      expect(native.realtimeSets, isEmpty);
+      expect(native.discretes, isEmpty);
+      expect(native.calls, isEmpty);
+    });
+  });
+
+  group('pattern mode', () {
+    test('the pattern is pre-parsed up front, then played on demand', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        hapticMode: HapticMode.pattern,
+        durationMs: 800,
+      );
+      await pumpEventQueue();
+
+      expect(native.parsedPatterns.length, 1);
+      expect(native.calls, isNot(contains('patternPlay')));
+
+      await controller.play();
+      await pumpEventQueue();
+
+      expect(native.calls, contains('patternPlay'));
+    });
+
+    test('pause and stop stop the buffered pattern', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        hapticMode: HapticMode.pattern,
+        durationMs: 800,
+      );
+      await pumpEventQueue();
+
+      await controller.pause();
+      await controller.stop();
+      await pumpEventQueue();
+
+      expect(
+        native.calls.where((c) => c == 'patternStop').length,
+        2,
+      );
+    });
+
+    test('progress ticks send nothing — the pattern owns its own clock', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        hapticMode: HapticMode.pattern,
+        durationMs: 800,
+      );
+
+      controller.animationController.value = 0.5;
+      await pumpEventQueue();
+
+      expect(native.realtimeSets, isEmpty);
+      expect(native.discretes, isEmpty);
+    });
+
+    test('dispose releases the native composer', () async {
+      final controller = controllerFor(
+        haptics: _pattern,
+        hapticMode: HapticMode.pattern,
+        durationMs: 800,
+      );
+      await pumpEventQueue();
+
+      controller.dispose();
+      await pumpEventQueue();
+
+      expect(native.calls, contains('patternRelease'));
+    });
+  });
+
+  group('a preset that carries audio', () {
+    test('plays through the preset itself, so its audio plays too', () async {
+      final controller = controllerFor(preset: _preset(hasAudio: true));
+      await pumpEventQueue();
+
+      expect(
+        native.parsedPatterns,
+        isEmpty,
+        reason: 'the native preset owns the pattern; nothing is re-parsed here',
+      );
+
+      await controller.play();
+      await controller.stop();
+      await pumpEventQueue();
+
+      expect(native.playedPresets, ['celebration']);
+      expect(native.stoppedPresets, ['celebration']);
+    });
+  });
+
+  group('no haptics at all', () {
+    test('transport steers the animation and touches no engine', () async {
+      final controller = controllerFor(
+        compositionDuration: const Duration(milliseconds: 800),
+      );
+
+      await controller.play();
+      controller.animationController.value = 0.5;
+      await controller.pause();
+      await controller.stop();
+      await pumpEventQueue();
+
+      expect(controller.animationController.value, 0);
+      expect(native.calls, isEmpty);
     });
   });
 }

--- a/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
+++ b/flutter/PulsarLottie/test/haptic_lottie_controller_test.dart
@@ -16,7 +16,6 @@ const _pattern = PatternData(
   ],
 );
 
-/// A pattern with no continuous channels — only transients.
 const _discreteOnly = PatternData(
   continuousPattern: ContinuousPattern(amplitude: [], frequency: []),
   discretePattern: [DiscretePoint(time: 100, amplitude: 1, frequency: 0.5)],
@@ -36,14 +35,22 @@ PresetHandle _preset({
   hasAudio: hasAudio,
 );
 
+const _patternClockMs = 800.0;
+const _defaultCompositionDuration = Duration(milliseconds: 800);
+const _noComposition = Duration.zero;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late FakePulsarPlatform native;
+  late RecordingPulsarPlatform native;
 
   setUp(() {
-    native = FakePulsarPlatform.install();
+    native = RecordingPulsarPlatform.install();
   });
+
+  void tickAt(HapticLottieController controller, double ms) {
+    controller.animationController.value = ms / _patternClockMs;
+  }
 
   HapticLottieController controllerFor({
     PresetHandle? preset,
@@ -54,11 +61,9 @@ void main() {
     bool hapticsEnabled = true,
     Duration? compositionDuration,
   }) {
-    // `play()` drives a real `AnimationController.forward`, which needs a length:
-    // default to one, and pass `Duration.zero` where "no composition yet" is the point.
     final animation = AnimationController(
       vsync: const TestVSync(),
-      duration: compositionDuration ?? const Duration(milliseconds: 800),
+      duration: compositionDuration ?? _defaultCompositionDuration,
     );
     addTearDown(animation.dispose);
     final controller = HapticLottieController(
@@ -144,7 +149,7 @@ void main() {
       expect(
         controllerFor(
           haptics: _pattern,
-          compositionDuration: Duration.zero,
+          compositionDuration: _noComposition,
         ).durationMsResolved,
         800,
       );
@@ -162,7 +167,7 @@ void main() {
 
     test('with nothing to derive from, the clock is zero', () {
       expect(
-        controllerFor(compositionDuration: Duration.zero).durationMsResolved,
+        controllerFor(compositionDuration: _noComposition).durationMsResolved,
         0,
       );
     });
@@ -190,7 +195,7 @@ void main() {
 
   group('realtime transport', () {
     test('play restarts the animation from the beginning', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       controller.animationController.value = 0.5;
 
       await controller.play();
@@ -200,19 +205,17 @@ void main() {
     });
 
     test('a tick samples the envelopes and fires the transients passed', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
-      // Half-way: amplitude ramps 0→1 over 800ms, frequency is a single flat point.
-      controller.animationController.value = 0.5;
+      tickAt(controller, 400);
       await pumpEventQueue();
 
       expect(native.realtimeSets.last, [closeTo(0.5, 1e-6), closeTo(0.3, 1e-6)]);
-      // Only the 250ms transient is behind the playhead.
       expect(native.discretes, [
         [closeTo(1, 1e-6), closeTo(0.5, 1e-6)],
       ]);
 
-      controller.animationController.value = 0.9;
+      tickAt(controller, 720);
       await pumpEventQueue();
 
       expect(native.discretes.length, 2, reason: 'the 600ms transient fires too');
@@ -220,22 +223,22 @@ void main() {
     });
 
     test('a transient never fires twice for the same playhead pass', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
-      controller.animationController.value = 0.4;
-      controller.animationController.value = 0.45;
-      controller.animationController.value = 0.5;
+      tickAt(controller, 320);
+      tickAt(controller, 360);
+      tickAt(controller, 400);
       await pumpEventQueue();
 
       expect(native.discretes.length, 1);
     });
 
     test('wrapping back to the start re-arms the transients', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
-      controller.animationController.value = 0.5;
-      controller.animationController.value = 0.1; // looped
-      controller.animationController.value = 0.5;
+      tickAt(controller, 400);
+      tickAt(controller, 80);
+      tickAt(controller, 400);
       await pumpEventQueue();
 
       expect(native.discretes.length, 2);
@@ -244,20 +247,20 @@ void main() {
     test('hapticOffset shifts where the pattern is sampled', () async {
       final controller = controllerFor(
         haptics: _pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
         hapticOffset: 400,
       );
 
-      controller.animationController.value = 0.25; // t = 200ms, ht = 600ms
+      tickAt(controller, 200);
       await pumpEventQueue();
 
       expect(native.realtimeSets.last.first, closeTo(0.75, 1e-6));
     });
 
     test('a discrete-only pattern drives no continuous channel', () async {
-      final controller = controllerFor(haptics: _discreteOnly, durationMs: 800);
+      final controller = controllerFor(haptics: _discreteOnly, durationMs: _patternClockMs);
 
-      controller.animationController.value = 0.5;
+      tickAt(controller, 400);
       await controller.pause();
       await pumpEventQueue();
 
@@ -271,7 +274,7 @@ void main() {
     });
 
     test('pause stops the animation and the continuous haptic', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       await controller.play();
 
       await controller.pause();
@@ -282,7 +285,7 @@ void main() {
     });
 
     test('resume drives the animation forward again', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       controller.animationController.value = 0.4;
 
       await controller.resume();
@@ -291,7 +294,7 @@ void main() {
     });
 
     test('stop rewinds and silences the haptics', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       await controller.play();
       controller.animationController.value = 0.6;
 
@@ -304,7 +307,7 @@ void main() {
     });
 
     test('reset rewinds like stop', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       controller.animationController.value = 0.6;
       native.calls.clear();
 
@@ -315,27 +318,35 @@ void main() {
       expect(native.calls, contains('realtimeStop'));
     });
 
-    test('setTimestamp seeks the animation and the transient window', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+    test('setTimestamp seeks the animation', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
       controller.setTimestamp(400);
-      expect(controller.animationController.value, closeTo(0.5, 1e-6));
 
-      // NOTE: writing `AnimationController.value` notifies listeners synchronously,
-      // so the seek itself runs one tick and fires the transients it jumped over —
-      // iOS and Android move the playhead silently. Documented, not asserted as
-      // desired behaviour.
+      expect(controller.animationController.value, closeTo(0.5, 1e-6));
+    });
+
+    test('a tick after a seek does not replay what the seek passed', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
+      controller.setTimestamp(400);
       native.discretes.clear();
 
-      // What matters either way: the window moved, so the next tick does not
-      // replay what the seek passed.
-      controller.animationController.value = 0.55;
+      tickAt(controller, 440);
       await pumpEventQueue();
+
       expect(native.discretes, isEmpty);
     });
 
+    test('seeking forward replays the transients it jumps over', () async {
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
+
+      controller.setTimestamp(400);
+
+      expect(native.discretes.length, 1);
+    });
+
     test('setTimestamp clamps to the ends of the clock', () {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
       controller.setTimestamp(5000);
       expect(controller.animationController.value, 1);
@@ -345,7 +356,7 @@ void main() {
     });
 
     test('setTimestamp is a no-op on a zero-length clock', () {
-      final controller = controllerFor(compositionDuration: Duration.zero);
+      final controller = controllerFor(compositionDuration: _noComposition);
 
       controller.setTimestamp(400);
 
@@ -353,7 +364,7 @@ void main() {
     });
 
     test('setLoop(true) repeats the animation and rearms the haptics', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
       await controller.setLoop(true, count: 2, reverse: true);
 
@@ -361,7 +372,7 @@ void main() {
     });
 
     test('setLoop(false) stops the animation', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       await controller.play();
 
       await controller.setLoop(false);
@@ -370,7 +381,7 @@ void main() {
     });
 
     test('dispose detaches the listener, so later frames are silent', () async {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
       controller.dispose();
       native.calls.clear();
       native.realtimeSets.clear();
@@ -383,7 +394,7 @@ void main() {
     });
 
     test('dispose is idempotent', () {
-      final controller = controllerFor(haptics: _pattern, durationMs: 800);
+      final controller = controllerFor(haptics: _pattern, durationMs: _patternClockMs);
 
       controller.dispose();
 
@@ -395,7 +406,7 @@ void main() {
     test('the animation still runs but nothing is sent to the engine', () async {
       final controller = controllerFor(
         haptics: _pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
         hapticsEnabled: false,
       );
 
@@ -415,7 +426,7 @@ void main() {
       final controller = controllerFor(
         haptics: _pattern,
         hapticMode: HapticMode.pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
       );
       await pumpEventQueue();
 
@@ -432,7 +443,7 @@ void main() {
       final controller = controllerFor(
         haptics: _pattern,
         hapticMode: HapticMode.pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
       );
       await pumpEventQueue();
 
@@ -450,7 +461,7 @@ void main() {
       final controller = controllerFor(
         haptics: _pattern,
         hapticMode: HapticMode.pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
       );
 
       controller.animationController.value = 0.5;
@@ -464,7 +475,7 @@ void main() {
       final controller = controllerFor(
         haptics: _pattern,
         hapticMode: HapticMode.pattern,
-        durationMs: 800,
+        durationMs: _patternClockMs,
       );
       await pumpEventQueue();
 
@@ -502,7 +513,7 @@ void main() {
       );
 
       await controller.play();
-      controller.animationController.value = 0.5;
+      tickAt(controller, 400);
       await controller.pause();
       await controller.stop();
       await pumpEventQueue();

--- a/flutter/PulsarLottie/test/haptic_lottie_test.dart
+++ b/flutter/PulsarLottie/test/haptic_lottie_test.dart
@@ -1,0 +1,325 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lottie/lottie.dart';
+import 'package:pulsar_haptics/pulsar.dart';
+import 'package:pulsar_haptics_lottie/pulsar_haptics_lottie.dart';
+
+import 'fake_pulsar_platform.dart';
+
+/// A 2s (60 frames @ 30fps) animation with nothing in it — enough for the
+/// `lottie` parser, and its length is what `onLoaded` feeds the controller.
+const _lottieJson =
+    '{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty",'
+    '"ddd":0,"assets":[],"layers":[]}';
+
+const _pattern = PatternData(
+  continuousPattern: ContinuousPattern(
+    amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 800, value: 1)],
+    frequency: [ValuePoint(time: 0, value: 0.3)],
+  ),
+  discretePattern: [DiscretePoint(time: 250, amplitude: 1, frequency: 0.5)],
+);
+
+PresetHandle _preset({bool withAnimation = true, double duration = 0}) =>
+    PresetHandle(
+      'token',
+      'celebration',
+      name: 'Celebration',
+      duration: duration,
+      pattern: _pattern,
+      animation: withAnimation
+          ? BundleAnimation(
+              data: Uint8List.fromList(utf8.encode(_lottieJson)),
+              frameRate: 30,
+              totalFrames: 60,
+            )
+          : null,
+    );
+
+/// Serves the one Lottie asset the `.asset` constructor asks for.
+class _TestAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async =>
+      ByteData.sublistView(Uint8List.fromList(utf8.encode(_lottieJson)));
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async =>
+      _lottieJson;
+}
+
+void main() {
+  late FakePulsarPlatform native;
+
+  setUp(() {
+    native = FakePulsarPlatform.install();
+  });
+
+  Future<void> pumpLottie(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: DefaultAssetBundle(bundle: _TestAssetBundle(), child: child),
+        ),
+      ),
+    );
+    // Two frames: one for the composition future to resolve, one for `onLoaded`
+    // to run and the animation to be handed its length. Not `pumpAndSettle` —
+    // that would run any auto-played animation all the way to its end.
+    await tester.pump();
+    await tester.pump();
+  }
+
+  group('HapticLottie.preset', () {
+    testWidgets('renders the animation the preset was authored against', (
+      tester,
+    ) async {
+      await pumpLottie(tester, HapticLottie.preset(_preset(), width: 40));
+
+      expect(find.byType(Lottie), findsOneWidget);
+      expect(tester.widget<Lottie>(find.byType(Lottie)).width, 40);
+    });
+
+    testWidgets('hands the controller back through onControllerCreated', (
+      tester,
+    ) async {
+      final preset = _preset();
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(preset, onControllerCreated: (c) => controller = c),
+      );
+
+      expect(controller, isNotNull);
+      expect(controller!.preset, same(preset));
+      expect(controller!.hapticMode, HapticMode.realtime);
+    });
+
+    testWidgets('a preset with no animation renders a sized box instead', (
+      tester,
+    ) async {
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(withAnimation: false),
+          width: 20,
+          height: 30,
+        ),
+      );
+
+      expect(find.byType(Lottie), findsNothing);
+      final box = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(HapticLottie),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(box.width, 20);
+      expect(box.height, 30);
+    });
+
+    testWidgets('autoPlay starts the animation and the haptics with it', (
+      tester,
+    ) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(),
+          autoPlay: true,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(controller!.animationController.isAnimating, isTrue);
+      expect(controller!.animationController.value, greaterThan(0));
+      expect(native.realtimeSets, isNotEmpty);
+    });
+
+    testWidgets('without autoPlay nothing moves until asked', (tester) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(),
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(controller!.animationController.isAnimating, isFalse);
+      expect(native.calls, isEmpty);
+    });
+
+    testWidgets('autoPlay + repeat loops the animation', (tester) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(),
+          autoPlay: true,
+          repeat: true,
+          repeatCount: 2,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      // Past the 2s composition, a repeating controller is still running.
+      await tester.pump(const Duration(milliseconds: 2500));
+
+      expect(controller!.animationController.isAnimating, isTrue);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('disposing the widget silences later frames', (tester) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(),
+          autoPlay: true,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(native.realtimeSets, isNotEmpty);
+
+      await tester.pumpWidget(const SizedBox());
+      native.realtimeSets.clear();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(native.realtimeSets, isEmpty);
+      expect(controller, isNotNull);
+    });
+
+    testWidgets('hapticsEnabled: false animates without touching the engine', (
+      tester,
+    ) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.preset(
+          _preset(),
+          autoPlay: true,
+          hapticsEnabled: false,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(controller!.animationController.value, greaterThan(0));
+      expect(native.calls, isEmpty);
+    });
+  });
+
+  group('HapticLottie.asset', () {
+    testWidgets('loads the asset and adopts the composition length', (
+      tester,
+    ) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.asset(
+          'assets/anim.json',
+          haptics: _pattern,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+
+      expect(find.byType(Lottie), findsOneWidget);
+      // 60 frames at 30fps.
+      expect(controller!.durationMsResolved, 2000);
+    });
+
+    testWidgets('an explicit durationMs still wins over the composition', (
+      tester,
+    ) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.asset(
+          'assets/anim.json',
+          haptics: _pattern,
+          durationMs: 500,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+
+      expect(controller!.durationMsResolved, 500);
+    });
+
+    testWidgets('forwards the layout props to the Lottie widget', (
+      tester,
+    ) async {
+      await pumpLottie(
+        tester,
+        HapticLottie.asset(
+          'assets/anim.json',
+          width: 64,
+          height: 48,
+          fit: BoxFit.cover,
+          alignment: Alignment.bottomRight,
+        ),
+      );
+
+      final lottie = tester.widget<Lottie>(find.byType(Lottie));
+      expect(lottie.width, 64);
+      expect(lottie.height, 48);
+      expect(lottie.fit, BoxFit.cover);
+      expect(lottie.alignment, Alignment.bottomRight);
+    });
+
+    testWidgets('with no haptics it is just a Lottie view', (tester) async {
+      HapticLottieController? controller;
+
+      await pumpLottie(
+        tester,
+        HapticLottie.asset(
+          'assets/anim.json',
+          autoPlay: true,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(controller!.animationController.value, greaterThan(0));
+      expect(native.calls, isEmpty);
+    });
+  });
+
+  group('HapticLottie.network', () {
+    testWidgets('builds and wires a controller even before the fetch lands', (
+      tester,
+    ) async {
+      HapticLottieController? controller;
+
+      // flutter_test refuses real network calls, so the composition never
+      // arrives — what is covered here is the constructor and the wiring.
+      await pumpLottie(
+        tester,
+        HapticLottie.network(
+          'https://example.com/anim.json',
+          haptics: _pattern,
+          onControllerCreated: (c) => controller = c,
+        ),
+      );
+
+      // The builder is mounted; the inner `Lottie` only appears once bytes arrive.
+      expect(find.byType(LottieBuilder), findsOneWidget);
+      expect(find.byType(Lottie), findsNothing);
+      expect(controller, isNotNull);
+      expect(controller!.durationMsResolved, 800, reason: 'the pattern length');
+    });
+  });
+}

--- a/flutter/PulsarLottie/test/haptic_lottie_test.dart
+++ b/flutter/PulsarLottie/test/haptic_lottie_test.dart
@@ -9,8 +9,8 @@ import 'package:pulsar_haptics_lottie/pulsar_haptics_lottie.dart';
 
 import 'fake_pulsar_platform.dart';
 
-/// A 2s (60 frames @ 30fps) animation with nothing in it — enough for the
-/// `lottie` parser, and its length is what `onLoaded` feeds the controller.
+const _sixtyFramesAtThirtyFps = Duration(seconds: 2);
+
 const _lottieJson =
     '{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty",'
     '"ddd":0,"assets":[],"layers":[]}';
@@ -39,7 +39,6 @@ PresetHandle _preset({bool withAnimation = true, double duration = 0}) =>
           : null,
     );
 
-/// Serves the one Lottie asset the `.asset` constructor asks for.
 class _TestAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async =>
@@ -51,11 +50,16 @@ class _TestAssetBundle extends CachingAssetBundle {
 }
 
 void main() {
-  late FakePulsarPlatform native;
+  late RecordingPulsarPlatform native;
 
   setUp(() {
-    native = FakePulsarPlatform.install();
+    native = RecordingPulsarPlatform.install();
   });
+
+  Future<void> settleComposition(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump();
+  }
 
   Future<void> pumpLottie(WidgetTester tester, Widget child) async {
     await tester.pumpWidget(
@@ -66,11 +70,7 @@ void main() {
         ),
       ),
     );
-    // Two frames: one for the composition future to resolve, one for `onLoaded`
-    // to run and the animation to be handed its length. Not `pumpAndSettle` —
-    // that would run any auto-played animation all the way to its end.
-    await tester.pump();
-    await tester.pump();
+    await settleComposition(tester);
   }
 
   group('HapticLottie.preset', () {
@@ -171,8 +171,7 @@ void main() {
           onControllerCreated: (c) => controller = c,
         ),
       );
-      // Past the 2s composition, a repeating controller is still running.
-      await tester.pump(const Duration(milliseconds: 2500));
+      await tester.pump(_sixtyFramesAtThirtyFps + const Duration(milliseconds: 500));
 
       expect(controller!.animationController.isAnimating, isTrue);
       await tester.pumpWidget(const SizedBox());
@@ -237,8 +236,10 @@ void main() {
       );
 
       expect(find.byType(Lottie), findsOneWidget);
-      // 60 frames at 30fps.
-      expect(controller!.durationMsResolved, 2000);
+      expect(
+        controller!.durationMsResolved,
+        _sixtyFramesAtThirtyFps.inMilliseconds,
+      );
     });
 
     testWidgets('an explicit durationMs still wins over the composition', (
@@ -304,8 +305,6 @@ void main() {
     ) async {
       HapticLottieController? controller;
 
-      // flutter_test refuses real network calls, so the composition never
-      // arrives — what is covered here is the constructor and the wiring.
       await pumpLottie(
         tester,
         HapticLottie.network(
@@ -315,7 +314,6 @@ void main() {
         ),
       );
 
-      // The builder is mounted; the inner `Lottie` only appears once bytes arrive.
       expect(find.byType(LottieBuilder), findsOneWidget);
       expect(find.byType(Lottie), findsNothing);
       expect(controller, isNotNull);

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/HapticLottieControllerTests.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/HapticLottieControllerTests.swift
@@ -1,0 +1,366 @@
+import XCTest
+import Lottie
+import Pulsar
+@testable import PulsarLottie
+
+/// Public-API coverage for ``HapticLottieController``, ``PulsarLottie/bind`` and
+/// ``HapticLottieView``.
+///
+/// The controller's own state is private, so the assertions read what it did to the
+/// `LottieAnimationView` it drives: `currentProgress` for the clock (which makes the
+/// duration-resolution order observable through `setTimestamp`), and `loopMode` /
+/// `isAnimationPlaying` for transport.
+///
+/// Runs on an iOS Simulator, where `CHHapticEngine` reports haptics unsupported — so the
+/// engine never actually vibrates and what is verified is the SDK's own behaviour.
+@MainActor
+final class HapticLottieControllerTests: XCTestCase {
+
+  private var pulsar: Pulsar!
+
+  private let pattern = PatternData(
+    continuousPattern: ContinuousPattern(
+      amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 800, value: 1)],
+      frequency: [ValuePoint(time: 0, value: 0.3)]
+    ),
+    discretePattern: [
+      DiscretePoint(time: 250, amplitude: 1, frequency: 0.5),
+      DiscretePoint(time: 600, amplitude: 0.4, frequency: 0.2),
+    ]
+  )
+
+  override func setUp() {
+    super.setUp()
+    pulsar = Pulsar()
+  }
+
+  // MARK: - Helpers
+
+  /// A view rendering the 2s test composition. `currentProgress` only sticks on a view
+  /// that has an animation, so every seek assertion needs one.
+  private func animationView() -> LottieAnimationView {
+    let animation = try? LottieAnimation.from(data: Data(TestBundle.lottieJSON.utf8))
+    XCTAssertNotNil(animation, "the test Lottie document must parse")
+    return LottieAnimationView(animation: animation)
+  }
+
+  /// A view whose composition has no length, so the controller falls through to the
+  /// next duration source while `currentProgress` remains observable.
+  private func zeroLengthAnimationView() -> LottieAnimationView {
+    let json = TestBundle.lottieJSON.replacingOccurrences(of: #""op":60"#, with: #""op":0"#)
+    return LottieAnimationView(animation: try? LottieAnimation.from(data: Data(json.utf8)))
+  }
+
+  private func preset(
+    durationMs: Double = 1500,
+    withAudio: Bool = false,
+    withAnimation: Bool = true
+  ) throws -> PresetHandle {
+    let bundle = try pulsar.loadBundle(
+      data: TestBundle.data(durationMs: durationMs, withAudio: withAudio, withAnimation: withAnimation)
+    )
+    return try XCTUnwrap(bundle.handle("celebration"))
+  }
+
+  /// Lets the main run loop turn, so a display-link-driven controller can step.
+  private func spinRunLoop(_ seconds: TimeInterval = 0.3) {
+    let done = expectation(description: "run loop")
+    DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { done.fulfill() }
+    wait(for: [done], timeout: seconds + 2)
+  }
+
+  // MARK: - Duration resolution, observed through setTimestamp
+
+  func testAnExplicitDurationWinsOverEverything() throws {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view,
+      pulsar: pulsar,
+      preset: try preset(),
+      haptics: pattern,
+      durationMs: 1000
+    )
+
+    controller.setTimestamp(500)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  func testThePresetsAuthoredDurationComesNext() throws {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, preset: try preset(durationMs: 1500)
+    )
+
+    controller.setTimestamp(750)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  func testThenTheLottieCompositionLength() {
+    let view = animationView() // 60 frames @ 30fps = 2s
+    let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
+
+    controller.setTimestamp(1000)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  /// After the composition comes the pattern's own length — but that fallback only applies
+  /// when the view has no usable composition, and such a view ignores `currentProgress`
+  /// altogether, so there is nothing to observe. `patternDurationMs`, the value it falls back
+  /// to, is covered in `SamplerTests`.
+  func testAViewWithoutAUsableCompositionCannotBeSeeked() {
+    let view = zeroLengthAnimationView()
+    let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
+
+    controller.setTimestamp(400)
+
+    XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-6)
+  }
+
+  func testAZeroDurationFallsThroughInsteadOfStoppingTheClock() throws {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, preset: try preset(durationMs: 1500), durationMs: 0
+    )
+
+    controller.setTimestamp(750)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  func testSetTimestampClampsToBothEndsOfTheClock() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
+    )
+
+    controller.setTimestamp(5000)
+    XCTAssertEqual(view.currentProgress, 1, accuracy: 1e-3)
+
+    controller.setTimestamp(-100)
+    XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-3)
+  }
+
+  func testWithNoHapticsAndNoDurationSeekingIsANoOp() {
+    let view = animationView()
+    let controller = HapticLottieController(animationView: view, pulsar: pulsar, durationMs: 0)
+
+    // No pattern and no explicit duration: the 2s composition is still the clock.
+    controller.setTimestamp(1000)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  // MARK: - Transport
+
+  func testPlayRewindsToTheStart() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
+    )
+    controller.setTimestamp(400)
+
+    controller.play()
+    controller.pause() // freeze it before the display link can advance much
+
+    XCTAssertLessThan(view.currentProgress, 0.4)
+  }
+
+  func testRealtimePlaybackAdvancesTheAnimationItself() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 4000
+    )
+
+    controller.play()
+    spinRunLoop()
+    controller.pause()
+    let progressed = view.currentProgress
+
+    XCTAssertGreaterThan(progressed, 0, "the display link drives the timeline in realtime mode")
+    XCTAssertLessThan(progressed, 1)
+
+    // Paused means paused: the playhead stays put.
+    spinRunLoop(0.2)
+    XCTAssertEqual(view.currentProgress, progressed, accuracy: 1e-6)
+  }
+
+  func testResumeContinuesFromWhereItPaused() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 4000
+    )
+    controller.setTimestamp(1000)
+
+    controller.resume()
+    spinRunLoop(0.2)
+    controller.pause()
+
+    XCTAssertGreaterThan(view.currentProgress, 0.25)
+  }
+
+  func testStopAndResetBothRewind() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
+    )
+
+    controller.setTimestamp(600)
+    controller.stop()
+    XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-6)
+    XCTAssertFalse(view.isAnimationPlaying)
+
+    controller.setTimestamp(600)
+    controller.reset()
+    XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-6)
+  }
+
+  func testRealtimePlaybackStopsAtTheEndWithoutLooping() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 100
+    )
+
+    controller.play()
+    spinRunLoop()
+
+    XCTAssertEqual(view.currentProgress, 1, accuracy: 1e-6)
+  }
+
+  func testALoopingRealtimePlaybackWrapsInsteadOfEnding() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 100
+    )
+    controller.setLoop(true)
+
+    controller.play()
+    spinRunLoop()
+    controller.pause()
+
+    XCTAssertLessThan(view.currentProgress, 1, "a looping clock wrapped rather than parking at the end")
+  }
+
+  func testSetLoopMapsOntoTheViewsLoopMode() {
+    let view = animationView()
+    let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
+
+    controller.setLoop(true)
+    XCTAssertEqual(view.loopMode, .loop)
+
+    controller.setLoop(true, count: 3)
+    XCTAssertEqual(view.loopMode, .repeat(3))
+
+    controller.setLoop(true, count: 3, reverse: true)
+    XCTAssertEqual(view.loopMode, .autoReverse, "reverse wins: it is a boomerang, not a count")
+
+    controller.setLoop(false)
+    XCTAssertEqual(view.loopMode, .playOnce)
+  }
+
+  // MARK: - Modes
+
+  func testPatternModeLetsTheViewRunItsOwnAnimation() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view,
+      pulsar: pulsar,
+      haptics: pattern,
+      hapticMode: .pattern,
+      durationMs: 4000
+    )
+
+    controller.play()
+
+    XCTAssertTrue(view.isAnimationPlaying, "pattern mode hands playback back to Lottie")
+
+    controller.pause()
+    XCTAssertFalse(view.isAnimationPlaying)
+  }
+
+  func testAPresetWithAudioDefaultsToPatternModeSoItsAudioPlays() throws {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view, pulsar: pulsar, preset: try preset(withAudio: true)
+    )
+
+    controller.play()
+
+    XCTAssertTrue(view.isAnimationPlaying, "the audio preset needs pattern mode, which Lottie drives")
+
+    controller.stop()
+  }
+
+  func testAnExplicitModeWinsOverTheAudioPresetDefault() throws {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view,
+      pulsar: pulsar,
+      preset: try preset(withAudio: true),
+      hapticMode: .realtime,
+      durationMs: 4000
+    )
+
+    controller.play()
+    spinRunLoop(0.2)
+    controller.pause()
+
+    XCTAssertFalse(view.isAnimationPlaying, "realtime drives the timeline itself")
+    XCTAssertGreaterThan(view.currentProgress, 0)
+  }
+
+  func testWithNoHapticsTheTransportStillSteersTheAnimation() {
+    let view = animationView()
+    let controller = HapticLottieController(animationView: view, pulsar: pulsar)
+
+    controller.play()
+    XCTAssertTrue(view.isAnimationPlaying)
+
+    controller.stop()
+    XCTAssertFalse(view.isAnimationPlaying)
+    XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-6)
+  }
+
+  func testHapticsDisabledStillAnimates() {
+    let view = animationView()
+    let controller = HapticLottieController(
+      animationView: view,
+      pulsar: pulsar,
+      haptics: pattern,
+      hapticsEnabled: false,
+      durationMs: 4000
+    )
+
+    controller.play()
+    spinRunLoop(0.2)
+    controller.pause()
+
+    XCTAssertGreaterThan(view.currentProgress, 0)
+  }
+
+  // MARK: - The bind entry point
+
+  func testBindReturnsAControllerForTheView() throws {
+    let view = animationView()
+
+    let controller = PulsarLottie.bind(
+      view, pulsar: pulsar, preset: try preset(durationMs: 1500)
+    )
+    controller.setTimestamp(750)
+
+    XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
+  }
+
+  // MARK: - The SwiftUI view
+
+  func testTheSwiftUIViewBuildsFromANameOrAPreset() throws {
+    let named = HapticLottieView("anim", haptics: pattern, autoPlay: false)
+    let fromPreset = HapticLottieView(preset: try preset(), autoPlay: false)
+
+    // Each view owns a coordinator holding its Pulsar instance and, later, its controller.
+    XCTAssertNil(named.makeCoordinator().controller)
+    XCTAssertNil(fromPreset.makeCoordinator().controller)
+  }
+}

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/HapticLottieControllerTests.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/HapticLottieControllerTests.swift
@@ -3,16 +3,6 @@ import Lottie
 import Pulsar
 @testable import PulsarLottie
 
-/// Public-API coverage for ``HapticLottieController``, ``PulsarLottie/bind`` and
-/// ``HapticLottieView``.
-///
-/// The controller's own state is private, so the assertions read what it did to the
-/// `LottieAnimationView` it drives: `currentProgress` for the clock (which makes the
-/// duration-resolution order observable through `setTimestamp`), and `loopMode` /
-/// `isAnimationPlaying` for transport.
-///
-/// Runs on an iOS Simulator, where `CHHapticEngine` reports haptics unsupported — so the
-/// engine never actually vibrates and what is verified is the SDK's own behaviour.
 @MainActor
 final class HapticLottieControllerTests: XCTestCase {
 
@@ -34,18 +24,12 @@ final class HapticLottieControllerTests: XCTestCase {
     pulsar = Pulsar()
   }
 
-  // MARK: - Helpers
-
-  /// A view rendering the 2s test composition. `currentProgress` only sticks on a view
-  /// that has an animation, so every seek assertion needs one.
-  private func animationView() -> LottieAnimationView {
+  private func twoSecondAnimationView() -> LottieAnimationView {
     let animation = try? LottieAnimation.from(data: Data(TestBundle.lottieJSON.utf8))
     XCTAssertNotNil(animation, "the test Lottie document must parse")
     return LottieAnimationView(animation: animation)
   }
 
-  /// A view whose composition has no length, so the controller falls through to the
-  /// next duration source while `currentProgress` remains observable.
   private func zeroLengthAnimationView() -> LottieAnimationView {
     let json = TestBundle.lottieJSON.replacingOccurrences(of: #""op":60"#, with: #""op":0"#)
     return LottieAnimationView(animation: try? LottieAnimation.from(data: Data(json.utf8)))
@@ -62,17 +46,14 @@ final class HapticLottieControllerTests: XCTestCase {
     return try XCTUnwrap(bundle.handle("celebration"))
   }
 
-  /// Lets the main run loop turn, so a display-link-driven controller can step.
   private func spinRunLoop(_ seconds: TimeInterval = 0.3) {
     let done = expectation(description: "run loop")
     DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { done.fulfill() }
     wait(for: [done], timeout: seconds + 2)
   }
 
-  // MARK: - Duration resolution, observed through setTimestamp
-
   func testAnExplicitDurationWinsOverEverything() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view,
       pulsar: pulsar,
@@ -87,7 +68,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testThePresetsAuthoredDurationComesNext() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, preset: try preset(durationMs: 1500)
     )
@@ -98,7 +79,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testThenTheLottieCompositionLength() {
-    let view = animationView() // 60 frames @ 30fps = 2s
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
 
     controller.setTimestamp(1000)
@@ -106,10 +87,6 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
   }
 
-  /// After the composition comes the pattern's own length — but that fallback only applies
-  /// when the view has no usable composition, and such a view ignores `currentProgress`
-  /// altogether, so there is nothing to observe. `patternDurationMs`, the value it falls back
-  /// to, is covered in `SamplerTests`.
   func testAViewWithoutAUsableCompositionCannotBeSeeked() {
     let view = zeroLengthAnimationView()
     let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
@@ -120,7 +97,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testAZeroDurationFallsThroughInsteadOfStoppingTheClock() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, preset: try preset(durationMs: 1500), durationMs: 0
     )
@@ -131,7 +108,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testSetTimestampClampsToBothEndsOfTheClock() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
     )
@@ -143,33 +120,30 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertEqual(view.currentProgress, 0, accuracy: 1e-3)
   }
 
-  func testWithNoHapticsAndNoDurationSeekingIsANoOp() {
-    let view = animationView()
+  func testWithNoHapticsTheCompositionIsStillTheClock() {
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(animationView: view, pulsar: pulsar, durationMs: 0)
 
-    // No pattern and no explicit duration: the 2s composition is still the clock.
     controller.setTimestamp(1000)
 
     XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
   }
 
-  // MARK: - Transport
-
   func testPlayRewindsToTheStart() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
     )
     controller.setTimestamp(400)
 
     controller.play()
-    controller.pause() // freeze it before the display link can advance much
+    controller.pause()
 
     XCTAssertLessThan(view.currentProgress, 0.4)
   }
 
   func testRealtimePlaybackAdvancesTheAnimationItself() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 4000
     )
@@ -182,13 +156,12 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertGreaterThan(progressed, 0, "the display link drives the timeline in realtime mode")
     XCTAssertLessThan(progressed, 1)
 
-    // Paused means paused: the playhead stays put.
     spinRunLoop(0.2)
     XCTAssertEqual(view.currentProgress, progressed, accuracy: 1e-6)
   }
 
   func testResumeContinuesFromWhereItPaused() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 4000
     )
@@ -202,7 +175,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testStopAndResetBothRewind() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 800
     )
@@ -218,7 +191,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testRealtimePlaybackStopsAtTheEndWithoutLooping() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 100
     )
@@ -230,7 +203,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testALoopingRealtimePlaybackWrapsInsteadOfEnding() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, haptics: pattern, durationMs: 100
     )
@@ -244,7 +217,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testSetLoopMapsOntoTheViewsLoopMode() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(animationView: view, pulsar: pulsar, haptics: pattern)
 
     controller.setLoop(true)
@@ -260,10 +233,8 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertEqual(view.loopMode, .playOnce)
   }
 
-  // MARK: - Modes
-
   func testPatternModeLetsTheViewRunItsOwnAnimation() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view,
       pulsar: pulsar,
@@ -281,7 +252,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testAPresetWithAudioDefaultsToPatternModeSoItsAudioPlays() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view, pulsar: pulsar, preset: try preset(withAudio: true)
     )
@@ -294,7 +265,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testAnExplicitModeWinsOverTheAudioPresetDefault() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view,
       pulsar: pulsar,
@@ -312,7 +283,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testWithNoHapticsTheTransportStillSteersTheAnimation() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(animationView: view, pulsar: pulsar)
 
     controller.play()
@@ -324,7 +295,7 @@ final class HapticLottieControllerTests: XCTestCase {
   }
 
   func testHapticsDisabledStillAnimates() {
-    let view = animationView()
+    let view = twoSecondAnimationView()
     let controller = HapticLottieController(
       animationView: view,
       pulsar: pulsar,
@@ -340,10 +311,8 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertGreaterThan(view.currentProgress, 0)
   }
 
-  // MARK: - The bind entry point
-
   func testBindReturnsAControllerForTheView() throws {
-    let view = animationView()
+    let view = twoSecondAnimationView()
 
     let controller = PulsarLottie.bind(
       view, pulsar: pulsar, preset: try preset(durationMs: 1500)
@@ -353,13 +322,10 @@ final class HapticLottieControllerTests: XCTestCase {
     XCTAssertEqual(view.currentProgress, 0.5, accuracy: 1e-3)
   }
 
-  // MARK: - The SwiftUI view
-
   func testTheSwiftUIViewBuildsFromANameOrAPreset() throws {
     let named = HapticLottieView("anim", haptics: pattern, autoPlay: false)
     let fromPreset = HapticLottieView(preset: try preset(), autoPlay: false)
 
-    // Each view owns a coordinator holding its Pulsar instance and, later, its controller.
     XCTAssertNil(named.makeCoordinator().controller)
     XCTAssertNil(fromPreset.makeCoordinator().controller)
   }

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/SamplerTests.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/SamplerTests.swift
@@ -56,4 +56,59 @@ final class SamplerTests: XCTestCase {
         XCTAssertEqual(clamp01(5), 1, accuracy: 1e-6)
         XCTAssertEqual(clamp01(0.4), 0.4, accuracy: 1e-6)
     }
+
+    func testSinglePointHoldsItsValue() {
+        let flat = [EnvPoint(time: 500, value: 0.7)]
+        XCTAssertEqual(sampleEnvelope(flat, 0), 0.7, accuracy: 1e-6)
+        XCTAssertEqual(sampleEnvelope(flat, 500), 0.7, accuracy: 1e-6)
+        XCTAssertEqual(sampleEnvelope(flat, 10_000), 0.7, accuracy: 1e-6)
+    }
+
+    func testZeroWidthSpanTakesTheLaterValue() {
+        let step = [
+            EnvPoint(time: 0, value: 0),
+            EnvPoint(time: 400, value: 0.2),
+            EnvPoint(time: 400, value: 0.9),
+            EnvPoint(time: 800, value: 1),
+        ]
+        XCTAssertEqual(sampleEnvelope(step, 400), 0.2, accuracy: 1e-6)
+        XCTAssertEqual(sampleEnvelope(step, 600), 0.95, accuracy: 1e-6)
+    }
+
+    func testAnEmptyPatternHasNoLengthAndNoContinuousChannel() {
+        let empty = sampledPattern(
+            from: PatternData(
+                continuousPattern: ContinuousPattern(amplitude: [], frequency: []),
+                discretePattern: []
+            )
+        )
+        XCTAssertEqual(patternDurationMs(empty), 0, accuracy: 1e-6)
+        XCTAssertFalse(empty.hasContinuous)
+    }
+
+    func testOneSidedContinuousChannelsDoNotCount() {
+        let amplitudeOnly = sampledPattern(
+            from: PatternData(
+                continuousPattern: ContinuousPattern(
+                    amplitude: [ValuePoint(time: 0, value: 1)],
+                    frequency: []
+                ),
+                discretePattern: []
+            )
+        )
+        XCTAssertFalse(amplitudeOnly.hasContinuous, "both channels are needed to drive one")
+    }
+
+    func testALateTransientCanBeTheLongestChannel() {
+        let pattern = sampledPattern(
+            from: PatternData(
+                continuousPattern: ContinuousPattern(
+                    amplitude: [ValuePoint(time: 0, value: 0), ValuePoint(time: 300, value: 1)],
+                    frequency: [ValuePoint(time: 0, value: 0.3)]
+                ),
+                discretePattern: [DiscretePoint(time: 1200, amplitude: 1, frequency: 0.5)]
+            )
+        )
+        XCTAssertEqual(patternDurationMs(pattern), 1200, accuracy: 1e-6)
+    }
 }

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/TestBundle.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/TestBundle.swift
@@ -1,16 +1,11 @@
 import Foundation
 
-/// Builds `.pulsar` archives in memory so the tests can obtain real `PresetHandle`s
-/// through the public `Pulsar.loadBundle(data:)` path — the handle's own initializer
-/// is internal to the core module.
 enum TestBundle {
 
-  /// A 2s animation (60 frames @ 30fps) with nothing in it, but parseable by Lottie.
   static let lottieJSON = """
     {"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,"assets":[],"layers":[]}
     """
 
-  /// Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients.
   private static let hapticsJSON = """
     {"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],\
     "frequency":[{"time":0,"value":0.3}]},\
@@ -18,7 +13,6 @@ enum TestBundle {
     {"time":600,"amplitude":0.4,"frequency":0.2}]}
     """
 
-  /// A single-preset bundle, optionally carrying synced audio and/or its Lottie animation.
   static func data(
     durationMs: Double = 1500,
     withAudio: Bool = false,
@@ -42,8 +36,6 @@ enum TestBundle {
     if withAnimation { entries.append(("anim/celebration.json", lottieJSON)) }
     return storedZip(entries)
   }
-
-  // MARK: - A minimal STORE-only zip writer
 
   private static func crc32(_ bytes: [UInt8]) -> UInt32 {
     var table = [UInt32](repeating: 0, count: 256)

--- a/iOS/PulsarLottie/Tests/PulsarLottieTests/TestBundle.swift
+++ b/iOS/PulsarLottie/Tests/PulsarLottieTests/TestBundle.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Builds `.pulsar` archives in memory so the tests can obtain real `PresetHandle`s
+/// through the public `Pulsar.loadBundle(data:)` path — the handle's own initializer
+/// is internal to the core module.
+enum TestBundle {
+
+  /// A 2s animation (60 frames @ 30fps) with nothing in it, but parseable by Lottie.
+  static let lottieJSON = """
+    {"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,"assets":[],"layers":[]}
+    """
+
+  /// Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients.
+  private static let hapticsJSON = """
+    {"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],\
+    "frequency":[{"time":0,"value":0.3}]},\
+    "discretePattern":[{"time":250,"amplitude":1.0,"frequency":0.5},\
+    {"time":600,"amplitude":0.4,"frequency":0.2}]}
+    """
+
+  /// A single-preset bundle, optionally carrying synced audio and/or its Lottie animation.
+  static func data(
+    durationMs: Double = 1500,
+    withAudio: Bool = false,
+    withAnimation: Bool = true
+  ) -> Data {
+    let audio = withAudio ? #","audio":{"src":"audio/boom.ogg","volume":1.0,"offset":0}"# : ""
+    let animation = withAnimation
+      ? #","animation":{"src":"anim/celebration.json","frameRate":30,"totalFrames":60}"#
+      : ""
+    let manifest = """
+      {"schema":"pulsar.bundle/1","id":"com.acme.haptics","name":"Acme Pack","revision":7,\
+      "hash":"sha256-test","presets":[{"id":"celebration","name":"Celebration",\
+      "duration":\(durationMs),"haptics":"haptics/celebration.json"\(audio)\(animation)}]}
+      """
+
+    var entries: [(String, String)] = [
+      ("manifest.json", manifest),
+      ("haptics/celebration.json", hapticsJSON),
+    ]
+    if withAudio { entries.append(("audio/boom.ogg", "not-really-audio")) }
+    if withAnimation { entries.append(("anim/celebration.json", lottieJSON)) }
+    return storedZip(entries)
+  }
+
+  // MARK: - A minimal STORE-only zip writer
+
+  private static func crc32(_ bytes: [UInt8]) -> UInt32 {
+    var table = [UInt32](repeating: 0, count: 256)
+    for i in 0..<256 {
+      var c = UInt32(i)
+      for _ in 0..<8 { c = (c & 1) != 0 ? (0xEDB8_8320 ^ (c >> 1)) : (c >> 1) }
+      table[i] = c
+    }
+    var c: UInt32 = 0xFFFF_FFFF
+    for b in bytes { c = table[Int((c ^ UInt32(b)) & 0xFF)] ^ (c >> 8) }
+    return c ^ 0xFFFF_FFFF
+  }
+
+  private static func le16(_ v: Int) -> [UInt8] { [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF)] }
+
+  private static func le32(_ v: UInt32) -> [UInt8] {
+    [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)]
+  }
+
+  private static func storedZip(_ entries: [(String, String)]) -> Data {
+    var local: [UInt8] = []
+    var central: [UInt8] = []
+    var offset = 0
+
+    for (name, content) in entries {
+      let nameBytes = Array(name.utf8)
+      let payload = Array(content.utf8)
+      let crc = crc32(payload)
+      let size = UInt32(payload.count)
+
+      var header = le32(0x0403_4B50) + le16(20) + le16(0) + le16(0) + le16(0) + le16(0)
+      header += le32(crc) + le32(size) + le32(size) + le16(nameBytes.count) + le16(0)
+      local += header + nameBytes + payload
+
+      var entry = le32(0x0201_4B50) + le16(20) + le16(20) + le16(0) + le16(0) + le16(0) + le16(0)
+      entry += le32(crc) + le32(size) + le32(size)
+      entry += le16(nameBytes.count) + le16(0) + le16(0) + le16(0) + le16(0)
+      entry += le32(0) + le32(UInt32(offset))
+      central += entry + nameBytes
+
+      offset += header.count + nameBytes.count + payload.count
+    }
+
+    let eocd = le32(0x0605_4B50) + le16(0) + le16(0) + le16(entries.count) + le16(entries.count)
+      + le32(UInt32(central.count)) + le32(UInt32(local.count)) + le16(0)
+    return Data(local + central + eocd)
+  }
+}

--- a/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngineTest.kt
+++ b/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngineTest.kt
@@ -1,0 +1,332 @@
+package com.swmansion.pulsar.lottie
+
+import com.swmansion.pulsar.kmp.ConfigPoint
+import com.swmansion.pulsar.kmp.ContinuousPattern
+import com.swmansion.pulsar.kmp.PatternData
+import com.swmansion.pulsar.kmp.Pulsar
+import com.swmansion.pulsar.kmp.ValuePoint
+import com.swmansion.pulsar.kmp.bundle.PresetHandle
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Public-API coverage for [HapticLottieEngine] and [animationJson] — the whole
+ * non-Compose surface of the KMP Lottie SDK. The `@Composable` wrappers
+ * ([HapticLottie], [HapticLottieSync]) are thin adapters that feed this engine
+ * a Compose progress value.
+ */
+class HapticLottieEngineTest {
+
+    private lateinit var pulsar: Pulsar
+    private lateinit var device: RecordingHandle
+
+    private val pattern = PatternData(
+        continuousPattern = ContinuousPattern(
+            amplitude = listOf(ValuePoint(0L, 0f), ValuePoint(800L, 1f)),
+            frequency = listOf(ValuePoint(0L, 0.3f)),
+        ),
+        discretePattern = listOf(
+            ConfigPoint(250L, 1f, 0.5f),
+            ConfigPoint(600L, 0.4f, 0.2f),
+        ),
+    )
+
+    @BeforeTest
+    fun setUp() {
+        val (p, handle) = installTestPulsar()
+        pulsar = p
+        device = handle
+    }
+
+    private fun preset(durationMs: Double = 1500.0, withAnimation: Boolean = true): PresetHandle =
+        pulsar.loadBundle(TestBundle.bytes(durationMs, withAnimation)).handle("celebration")!!
+
+    private fun engine(
+        preset: PresetHandle? = null,
+        haptics: PatternData? = null,
+        hapticMode: HapticMode? = null,
+        hapticOffset: Long = 0,
+        hapticsEnabled: Boolean = true,
+        durationMs: Long? = null,
+    ) = HapticLottieEngine(
+        pulsar = pulsar,
+        preset = preset,
+        haptics = haptics,
+        hapticMode = hapticMode,
+        hapticOffset = hapticOffset,
+        hapticsEnabled = hapticsEnabled,
+        durationMs = durationMs,
+    )
+
+    // region duration resolution
+
+    @Test
+    fun anExplicitDurationWinsOverEverything() {
+        assertEquals(700L, engine(preset = preset(), haptics = pattern, durationMs = 700L).resolvedDurationMs)
+    }
+
+    @Test
+    fun thePresetsAuthoredDurationComesNext() {
+        assertEquals(1500L, engine(preset = preset(durationMs = 1500.0)).resolvedDurationMs)
+    }
+
+    @Test
+    fun withoutAHintTheClockIsThePatternsOwnLength() {
+        assertEquals(800L, engine(haptics = pattern).resolvedDurationMs)
+    }
+
+    @Test
+    fun aZeroDurationFallsThroughInsteadOfStoppingTheClock() {
+        assertEquals(1500L, engine(preset = preset(durationMs = 1500.0), durationMs = 0L).resolvedDurationMs)
+        assertEquals(800L, engine(haptics = pattern, durationMs = 0L).resolvedDurationMs)
+    }
+
+    @Test
+    fun withNothingToDeriveFromTheClockIsZero() {
+        assertEquals(0L, engine().resolvedDurationMs)
+    }
+
+    // endregion
+
+    // region the progress-driven clock
+
+    @Test
+    fun progressSamplesTheEnvelopesAndFiresThePassedTransients() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+        e.setPlaying(true)
+
+        e.onProgress(0.5f) // t = 400ms
+
+        assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
+        assertEquals(0.3f, device.realtime.sets.last().second, 1e-6f)
+        assertEquals(1, device.realtime.discretes.size)
+        assertEquals(1f, device.realtime.discretes.last().first, 1e-6f)
+
+        e.onProgress(0.9f) // t = 720ms
+
+        assertEquals(2, device.realtime.discretes.size)
+        assertEquals(0.4f, device.realtime.discretes.last().first, 1e-6f)
+        assertEquals(0.2f, device.realtime.discretes.last().second, 1e-6f)
+    }
+
+    @Test
+    fun nothingIsEmittedBeforePlayingStarts() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+
+        e.onProgress(0.5f)
+
+        assertTrue(device.realtime.sets.isEmpty())
+        assertTrue(device.realtime.discretes.isEmpty())
+    }
+
+    @Test
+    fun aTransientNeverFiresTwiceInOnePass() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+        e.setPlaying(true)
+
+        e.onProgress(0.4f)
+        e.onProgress(0.45f)
+        e.onProgress(0.5f)
+
+        assertEquals(1, device.realtime.discretes.size)
+    }
+
+    @Test
+    fun wrappingBackToTheStartReArmsTheTransients() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+        e.setPlaying(true)
+
+        e.onProgress(0.5f)
+        e.onProgress(0.1f) // looped
+        e.onProgress(0.5f)
+
+        assertEquals(2, device.realtime.discretes.size)
+    }
+
+    @Test
+    fun aCallerCanSupplyItsOwnAnimationLength() {
+        val e = engine(haptics = pattern) // no fixed duration
+        e.setPlaying(true)
+
+        e.onProgress(0.25f, durationMs = 1600L) // t = 400ms
+
+        assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
+        assertEquals(1, device.realtime.discretes.size)
+    }
+
+    @Test
+    fun anExplicitDurationOutranksTheOneFedPerFrame() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+        e.setPlaying(true)
+
+        e.onProgress(0.5f, durationMs = 4000L) // still t = 400ms
+
+        assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
+    }
+
+    @Test
+    fun hapticOffsetShiftsWhereThePatternIsSampled() {
+        val e = engine(haptics = pattern, durationMs = 800L, hapticOffset = 400L)
+        e.setPlaying(true)
+
+        e.onProgress(0.25f) // t = 200ms, sampled at 600ms
+
+        assertEquals(0.75f, device.realtime.sets.last().first, 1e-3f)
+    }
+
+    @Test
+    fun aDiscreteOnlyPatternDrivesNoContinuousChannel() {
+        val discreteOnly = PatternData(
+            continuousPattern = ContinuousPattern(amplitude = emptyList(), frequency = emptyList()),
+            discretePattern = listOf(ConfigPoint(100L, 1f, 0.5f)),
+        )
+        val e = engine(haptics = discreteOnly, durationMs = 800L)
+        e.setPlaying(true)
+
+        e.onProgress(0.5f)
+        e.stop()
+
+        assertTrue(device.realtime.sets.isEmpty())
+        assertEquals(1, device.realtime.discretes.size)
+        assertEquals(0, device.realtime.stops, "nothing continuous is running, so nothing is stopped")
+    }
+
+    @Test
+    fun hapticsDisabledLeavesTheEngineUntouched() {
+        val e = engine(haptics = pattern, durationMs = 800L, hapticsEnabled = false)
+
+        e.setPlaying(true)
+        e.onProgress(0.5f)
+        e.setPlaying(false)
+
+        assertTrue(device.realtime.sets.isEmpty())
+        assertTrue(device.realtime.discretes.isEmpty())
+        assertEquals(0, device.pattern.plays)
+    }
+
+    // endregion
+
+    // region play/pause and stop
+
+    @Test
+    fun pausingStopsTheContinuousChannelAndRewindsTheWindow() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+        e.setPlaying(true)
+        e.onProgress(0.5f)
+
+        e.setPlaying(false)
+        assertEquals(1, device.realtime.stops)
+
+        e.setPlaying(true)
+        e.onProgress(0.5f)
+        assertEquals(2, device.realtime.discretes.size, "the window restarts, so the transient replays")
+    }
+
+    @Test
+    fun repeatingTheSamePlayStateChangesNothing() {
+        val e = engine(haptics = pattern, durationMs = 800L)
+
+        e.setPlaying(true)
+        e.setPlaying(true)
+        e.setPlaying(false)
+        e.setPlaying(false)
+
+        assertEquals(1, device.realtime.stops)
+    }
+
+    @Test
+    fun stopIsSafeBeforeAnythingPlayed() {
+        engine(haptics = pattern, durationMs = 800L).stop()
+
+        assertEquals(1, device.realtime.stops)
+    }
+
+    // endregion
+
+    // region pattern mode
+
+    @Test
+    fun patternModeBuffersUpFrontAndFiresOnPlay() {
+        val e = engine(haptics = pattern, hapticMode = HapticMode.PATTERN, durationMs = 800L)
+
+        assertEquals(1, device.pattern.parsed.size, "the pattern is pre-parsed so play() is instant")
+        assertEquals(0, device.pattern.plays)
+
+        e.setPlaying(true)
+        assertEquals(1, device.pattern.plays)
+
+        e.onProgress(0.5f)
+        assertTrue(device.realtime.sets.isEmpty(), "the timeline is not the haptic clock here")
+
+        e.setPlaying(false)
+        assertEquals(1, device.pattern.stops)
+    }
+
+    @Test
+    fun aPresetCanBePlayedInPatternModeToo() {
+        val e = engine(preset = preset(), hapticMode = HapticMode.PATTERN)
+
+        e.setPlaying(true)
+
+        assertEquals(1, device.pattern.plays)
+    }
+
+    @Test
+    fun realtimeIsTheDefaultAndNeedsNoPatternComposer() {
+        engine(haptics = pattern, durationMs = 800L).setPlaying(true)
+
+        assertTrue(device.pattern.parsed.isEmpty())
+        assertEquals(0, device.pattern.plays)
+    }
+
+    @Test
+    fun withNoPatternAtAllNothingIsWiredUp() {
+        val e = engine()
+
+        e.setPlaying(true)
+        e.onProgress(0.5f)
+        e.stop()
+
+        assertTrue(device.pattern.parsed.isEmpty())
+        assertEquals(0, device.pattern.plays)
+        assertTrue(device.realtime.sets.isEmpty())
+    }
+
+    @Test
+    fun explicitHapticsOverrideThePresetsOwnPattern() {
+        val ownPattern = PatternData(
+            continuousPattern = ContinuousPattern(
+                amplitude = listOf(ValuePoint(0L, 1f), ValuePoint(400L, 1f)),
+                frequency = listOf(ValuePoint(0L, 0.9f)),
+            ),
+            discretePattern = emptyList(),
+        )
+        val e = engine(preset = preset(), haptics = ownPattern, durationMs = 400L)
+        e.setPlaying(true)
+
+        e.onProgress(0.5f)
+
+        assertEquals(1f, device.realtime.sets.last().first, 1e-6f)
+        assertEquals(0.9f, device.realtime.sets.last().second, 1e-6f)
+        assertTrue(device.realtime.discretes.isEmpty(), "the preset's transients are not used")
+    }
+
+    // endregion
+
+    // region the preset's animation
+
+    @Test
+    fun animationJsonDecodesTheLottieThePresetWasAuthoredAgainst() {
+        assertEquals(TestBundle.LOTTIE_JSON, preset().animationJson())
+    }
+
+    @Test
+    fun animationJsonIsNullForAPresetWithoutOne() {
+        assertNull(preset(withAnimation = false).animationJson())
+    }
+
+    // endregion
+}

--- a/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngineTest.kt
+++ b/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/HapticLottieEngineTest.kt
@@ -12,12 +12,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-/**
- * Public-API coverage for [HapticLottieEngine] and [animationJson] — the whole
- * non-Compose surface of the KMP Lottie SDK. The `@Composable` wrappers
- * ([HapticLottie], [HapticLottieSync]) are thin adapters that feed this engine
- * a Compose progress value.
- */
 class HapticLottieEngineTest {
 
     private lateinit var pulsar: Pulsar
@@ -36,13 +30,18 @@ class HapticLottieEngineTest {
 
     @BeforeTest
     fun setUp() {
-        val (p, handle) = installTestPulsar()
+        val (p, handle) = installRecordingPulsar()
         pulsar = p
         device = handle
     }
 
     private fun preset(durationMs: Double = 1500.0, withAnimation: Boolean = true): PresetHandle =
         pulsar.loadBundle(TestBundle.bytes(durationMs, withAnimation)).handle("celebration")!!
+
+    private fun HapticLottieEngine.tickAt(ms: Long, animationMs: Long = 0L) {
+        val clock = if (animationMs > 0L) animationMs else PATTERN_CLOCK_MS
+        onProgress(ms.toFloat() / clock, animationMs)
+    }
 
     private fun engine(
         preset: PresetHandle? = null,
@@ -60,8 +59,6 @@ class HapticLottieEngineTest {
         hapticsEnabled = hapticsEnabled,
         durationMs = durationMs,
     )
-
-    // region duration resolution
 
     @Test
     fun anExplicitDurationWinsOverEverything() {
@@ -89,23 +86,19 @@ class HapticLottieEngineTest {
         assertEquals(0L, engine().resolvedDurationMs)
     }
 
-    // endregion
-
-    // region the progress-driven clock
-
     @Test
     fun progressSamplesTheEnvelopesAndFiresThePassedTransients() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
 
-        e.onProgress(0.5f) // t = 400ms
+        e.tickAt(400)
 
         assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
         assertEquals(0.3f, device.realtime.sets.last().second, 1e-6f)
         assertEquals(1, device.realtime.discretes.size)
         assertEquals(1f, device.realtime.discretes.last().first, 1e-6f)
 
-        e.onProgress(0.9f) // t = 720ms
+        e.tickAt(720)
 
         assertEquals(2, device.realtime.discretes.size)
         assertEquals(0.4f, device.realtime.discretes.last().first, 1e-6f)
@@ -114,9 +107,9 @@ class HapticLottieEngineTest {
 
     @Test
     fun nothingIsEmittedBeforePlayingStarts() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
-        e.onProgress(0.5f)
+        e.tickAt(400)
 
         assertTrue(device.realtime.sets.isEmpty())
         assertTrue(device.realtime.discretes.isEmpty())
@@ -124,34 +117,34 @@ class HapticLottieEngineTest {
 
     @Test
     fun aTransientNeverFiresTwiceInOnePass() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
 
-        e.onProgress(0.4f)
-        e.onProgress(0.45f)
-        e.onProgress(0.5f)
+        e.tickAt(320)
+        e.tickAt(360)
+        e.tickAt(400)
 
         assertEquals(1, device.realtime.discretes.size)
     }
 
     @Test
     fun wrappingBackToTheStartReArmsTheTransients() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
 
-        e.onProgress(0.5f)
-        e.onProgress(0.1f) // looped
-        e.onProgress(0.5f)
+        e.tickAt(400)
+        e.tickAt(80)
+        e.tickAt(400)
 
         assertEquals(2, device.realtime.discretes.size)
     }
 
     @Test
     fun aCallerCanSupplyItsOwnAnimationLength() {
-        val e = engine(haptics = pattern) // no fixed duration
+        val e = engine(haptics = pattern)
         e.setPlaying(true)
 
-        e.onProgress(0.25f, durationMs = 1600L) // t = 400ms
+        e.tickAt(400, animationMs = 1600L)
 
         assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
         assertEquals(1, device.realtime.discretes.size)
@@ -159,20 +152,20 @@ class HapticLottieEngineTest {
 
     @Test
     fun anExplicitDurationOutranksTheOneFedPerFrame() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
 
-        e.onProgress(0.5f, durationMs = 4000L) // still t = 400ms
+        e.onProgress(progress = 0.5f, durationMs = 4000L)
 
         assertEquals(0.5f, device.realtime.sets.last().first, 1e-3f)
     }
 
     @Test
     fun hapticOffsetShiftsWhereThePatternIsSampled() {
-        val e = engine(haptics = pattern, durationMs = 800L, hapticOffset = 400L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS, hapticOffset = 400L)
         e.setPlaying(true)
 
-        e.onProgress(0.25f) // t = 200ms, sampled at 600ms
+        e.tickAt(200)
 
         assertEquals(0.75f, device.realtime.sets.last().first, 1e-3f)
     }
@@ -183,10 +176,10 @@ class HapticLottieEngineTest {
             continuousPattern = ContinuousPattern(amplitude = emptyList(), frequency = emptyList()),
             discretePattern = listOf(ConfigPoint(100L, 1f, 0.5f)),
         )
-        val e = engine(haptics = discreteOnly, durationMs = 800L)
+        val e = engine(haptics = discreteOnly, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
 
-        e.onProgress(0.5f)
+        e.tickAt(400)
         e.stop()
 
         assertTrue(device.realtime.sets.isEmpty())
@@ -196,10 +189,10 @@ class HapticLottieEngineTest {
 
     @Test
     fun hapticsDisabledLeavesTheEngineUntouched() {
-        val e = engine(haptics = pattern, durationMs = 800L, hapticsEnabled = false)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS, hapticsEnabled = false)
 
         e.setPlaying(true)
-        e.onProgress(0.5f)
+        e.tickAt(400)
         e.setPlaying(false)
 
         assertTrue(device.realtime.sets.isEmpty())
@@ -207,27 +200,23 @@ class HapticLottieEngineTest {
         assertEquals(0, device.pattern.plays)
     }
 
-    // endregion
-
-    // region play/pause and stop
-
     @Test
     fun pausingStopsTheContinuousChannelAndRewindsTheWindow() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
         e.setPlaying(true)
-        e.onProgress(0.5f)
+        e.tickAt(400)
 
         e.setPlaying(false)
         assertEquals(1, device.realtime.stops)
 
         e.setPlaying(true)
-        e.onProgress(0.5f)
+        e.tickAt(400)
         assertEquals(2, device.realtime.discretes.size, "the window restarts, so the transient replays")
     }
 
     @Test
     fun repeatingTheSamePlayStateChangesNothing() {
-        val e = engine(haptics = pattern, durationMs = 800L)
+        val e = engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS)
 
         e.setPlaying(true)
         e.setPlaying(true)
@@ -239,18 +228,14 @@ class HapticLottieEngineTest {
 
     @Test
     fun stopIsSafeBeforeAnythingPlayed() {
-        engine(haptics = pattern, durationMs = 800L).stop()
+        engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS).stop()
 
         assertEquals(1, device.realtime.stops)
     }
 
-    // endregion
-
-    // region pattern mode
-
     @Test
     fun patternModeBuffersUpFrontAndFiresOnPlay() {
-        val e = engine(haptics = pattern, hapticMode = HapticMode.PATTERN, durationMs = 800L)
+        val e = engine(haptics = pattern, hapticMode = HapticMode.PATTERN, durationMs = PATTERN_CLOCK_MS)
 
         assertEquals(1, device.pattern.parsed.size, "the pattern is pre-parsed so play() is instant")
         assertEquals(0, device.pattern.plays)
@@ -258,7 +243,7 @@ class HapticLottieEngineTest {
         e.setPlaying(true)
         assertEquals(1, device.pattern.plays)
 
-        e.onProgress(0.5f)
+        e.tickAt(400)
         assertTrue(device.realtime.sets.isEmpty(), "the timeline is not the haptic clock here")
 
         e.setPlaying(false)
@@ -276,7 +261,7 @@ class HapticLottieEngineTest {
 
     @Test
     fun realtimeIsTheDefaultAndNeedsNoPatternComposer() {
-        engine(haptics = pattern, durationMs = 800L).setPlaying(true)
+        engine(haptics = pattern, durationMs = PATTERN_CLOCK_MS).setPlaying(true)
 
         assertTrue(device.pattern.parsed.isEmpty())
         assertEquals(0, device.pattern.plays)
@@ -287,7 +272,7 @@ class HapticLottieEngineTest {
         val e = engine()
 
         e.setPlaying(true)
-        e.onProgress(0.5f)
+        e.tickAt(400)
         e.stop()
 
         assertTrue(device.pattern.parsed.isEmpty())
@@ -307,16 +292,12 @@ class HapticLottieEngineTest {
         val e = engine(preset = preset(), haptics = ownPattern, durationMs = 400L)
         e.setPlaying(true)
 
-        e.onProgress(0.5f)
+        e.tickAt(400)
 
         assertEquals(1f, device.realtime.sets.last().first, 1e-6f)
         assertEquals(0.9f, device.realtime.sets.last().second, 1e-6f)
         assertTrue(device.realtime.discretes.isEmpty(), "the preset's transients are not used")
     }
-
-    // endregion
-
-    // region the preset's animation
 
     @Test
     fun animationJsonDecodesTheLottieThePresetWasAuthoredAgainst() {
@@ -328,5 +309,7 @@ class HapticLottieEngineTest {
         assertNull(preset(withAnimation = false).animationJson())
     }
 
-    // endregion
+    private companion object {
+        const val PATTERN_CLOCK_MS = 800L
+    }
 }

--- a/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/SamplerTest.kt
+++ b/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/SamplerTest.kt
@@ -54,4 +54,49 @@ class SamplerTest {
         assertEquals(1f, clamp01(5f), 1e-6f)
         assertEquals(0.4f, clamp01(0.4f), 1e-6f)
     }
+
+    @Test
+    fun singlePointHoldsItsValue() {
+        val flat = listOf(ValuePoint(500L, 0.7f))
+        assertEquals(0.7f, sampleEnvelope(flat, 0L), 1e-6f)
+        assertEquals(0.7f, sampleEnvelope(flat, 500L), 1e-6f)
+        assertEquals(0.7f, sampleEnvelope(flat, 10_000L), 1e-6f)
+    }
+
+    @Test
+    fun zeroWidthSpanTakesTheLaterValue() {
+        val step = listOf(
+            ValuePoint(0L, 0f),
+            ValuePoint(400L, 0.2f),
+            ValuePoint(400L, 0.9f),
+            ValuePoint(800L, 1f),
+        )
+        assertEquals(0.2f, sampleEnvelope(step, 400L), 1e-6f)
+        assertEquals(0.95f, sampleEnvelope(step, 600L), 1e-6f)
+    }
+
+    @Test
+    fun emptyPatternHasNoLength() {
+        assertEquals(
+            0L,
+            patternDurationMs(
+                PatternData(
+                    continuousPattern = ContinuousPattern(emptyList(), emptyList()),
+                    discretePattern = emptyList(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun aLateTransientCanBeTheLongestChannel() {
+        val p = PatternData(
+            continuousPattern = ContinuousPattern(
+                amplitude = listOf(ValuePoint(0L, 0f), ValuePoint(300L, 1f)),
+                frequency = listOf(ValuePoint(0L, 0.3f)),
+            ),
+            discretePattern = listOf(ConfigPoint(1200L, 1f, 0.5f)),
+        )
+        assertEquals(1200L, patternDurationMs(p))
+    }
 }

--- a/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/TestPulsar.kt
+++ b/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/TestPulsar.kt
@@ -11,12 +11,6 @@ import com.swmansion.pulsar.kmp.RealtimeComposerHandle
 import com.swmansion.pulsar.kmp.SoundData
 import com.swmansion.pulsar.kmp.registerPulsarFactory
 
-/**
- * A platform handle that records what the Lottie engine asks the device to do, so the
- * tests can assert the emitted haptics rather than only that nothing threw.
- *
- * Register it with [installTestPulsar] before building a [Pulsar].
- */
 class RecordingHandle : PulsarPlatformHandle {
     val realtime = RecordingRealtime()
     val pattern = RecordingPattern()
@@ -96,8 +90,7 @@ class RecordingPattern : PatternComposerHandle {
     }
 }
 
-/** Installs a fresh recorder as the platform and returns the [Pulsar] built on it. */
-fun installTestPulsar(): Pair<Pulsar, RecordingHandle> {
+fun installRecordingPulsar(): Pair<Pulsar, RecordingHandle> {
     val handle = RecordingHandle()
     registerPulsarFactory(object : PulsarPlatformFactory {
         override fun createPulsar(): PulsarPlatformHandle = handle
@@ -105,18 +98,12 @@ fun installTestPulsar(): Pair<Pulsar, RecordingHandle> {
     return Pulsar.create() to handle
 }
 
-/**
- * Builds `.pulsar` archives in memory so tests can get real `PresetHandle`s through the
- * public `Pulsar.loadBundle` path — the handle's own constructor is internal to the core.
- */
 object TestBundle {
 
-    /** A 2s animation (60 frames @ 30fps) with nothing in it. */
     const val LOTTIE_JSON =
         """{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,""" +
             """"assets":[],"layers":[]}"""
 
-    /** Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients. */
     private const val HAPTICS_JSON =
         """{"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],""" +
             """"frequency":[{"time":0,"value":0.3}]},""" +
@@ -143,7 +130,6 @@ object TestBundle {
         return storedZip(entries)
     }
 
-    /** Minimal STORE-only zip writer, so no platform zip API is needed in common code. */
     private fun storedZip(entries: Map<String, String>): ByteArray {
         fun crc32(bytes: ByteArray): Int {
             val table = IntArray(256) { n ->

--- a/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/TestPulsar.kt
+++ b/kmp/PulsarLottie/src/commonTest/kotlin/com/swmansion/pulsar/lottie/TestPulsar.kt
@@ -1,0 +1,183 @@
+package com.swmansion.pulsar.lottie
+
+import com.swmansion.pulsar.kmp.CompatibilityMode
+import com.swmansion.pulsar.kmp.PatternComposerHandle
+import com.swmansion.pulsar.kmp.PatternData
+import com.swmansion.pulsar.kmp.Pulsar
+import com.swmansion.pulsar.kmp.PulsarPlatformFactory
+import com.swmansion.pulsar.kmp.PulsarPlatformHandle
+import com.swmansion.pulsar.kmp.PulsarPresetsHandle
+import com.swmansion.pulsar.kmp.RealtimeComposerHandle
+import com.swmansion.pulsar.kmp.SoundData
+import com.swmansion.pulsar.kmp.registerPulsarFactory
+
+/**
+ * A platform handle that records what the Lottie engine asks the device to do, so the
+ * tests can assert the emitted haptics rather than only that nothing threw.
+ *
+ * Register it with [installTestPulsar] before building a [Pulsar].
+ */
+class RecordingHandle : PulsarPlatformHandle {
+    val realtime = RecordingRealtime()
+    val pattern = RecordingPattern()
+
+    override fun presets(): PulsarPresetsHandle =
+        throw UnsupportedOperationException("the Lottie SDK never reaches for the preset library")
+
+    override fun patternComposer(): PatternComposerHandle = pattern
+    override fun realtimeComposer(): RealtimeComposerHandle = realtime
+
+    override fun preloadPreset(name: String) = Unit
+    override fun enableHaptics(state: Boolean) = Unit
+    override fun enableSound(state: Boolean) = Unit
+    override fun enableCache(state: Boolean) = Unit
+    override fun isCacheEnabled(): Boolean = true
+    override fun clearCache() = Unit
+    override fun stopHaptics() = Unit
+    override fun shutDownEngine() = Unit
+    override fun isHapticsEnabled(): Boolean = true
+    override fun isHapticsSupported(): Boolean = true
+    override fun canPlayHaptics(): Boolean = true
+    override fun hapticSupport(): CompatibilityMode = CompatibilityMode.ADVANCED_SUPPORT
+}
+
+class RecordingRealtime : RealtimeComposerHandle {
+    val sets = mutableListOf<Pair<Float, Float>>()
+    val discretes = mutableListOf<Pair<Float, Float>>()
+    var stops = 0
+
+    override fun set(amplitude: Float, frequency: Float) {
+        sets += amplitude to frequency
+    }
+
+    override fun playDiscrete(amplitude: Float, frequency: Float) {
+        discretes += amplitude to frequency
+    }
+
+    override fun stop() {
+        stops++
+    }
+
+    override fun isActive(): Boolean = false
+
+    fun clear() {
+        sets.clear()
+        discretes.clear()
+        stops = 0
+    }
+}
+
+class RecordingPattern : PatternComposerHandle {
+    val parsed = mutableListOf<PatternData>()
+    var plays = 0
+    var stops = 0
+
+    override fun parsePattern(pattern: PatternData) {
+        parsed += pattern
+    }
+
+    override fun parsePatternWithSound(pattern: PatternData, sound: SoundData) {
+        parsed += pattern
+    }
+
+    override fun playPattern(pattern: PatternData) {
+        parsed += pattern
+        plays++
+    }
+
+    override fun play() {
+        plays++
+    }
+
+    override fun playAudioOnly() = Unit
+
+    override fun stop() {
+        stops++
+    }
+}
+
+/** Installs a fresh recorder as the platform and returns the [Pulsar] built on it. */
+fun installTestPulsar(): Pair<Pulsar, RecordingHandle> {
+    val handle = RecordingHandle()
+    registerPulsarFactory(object : PulsarPlatformFactory {
+        override fun createPulsar(): PulsarPlatformHandle = handle
+    })
+    return Pulsar.create() to handle
+}
+
+/**
+ * Builds `.pulsar` archives in memory so tests can get real `PresetHandle`s through the
+ * public `Pulsar.loadBundle` path — the handle's own constructor is internal to the core.
+ */
+object TestBundle {
+
+    /** A 2s animation (60 frames @ 30fps) with nothing in it. */
+    const val LOTTIE_JSON =
+        """{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":100,"h":100,"nm":"empty","ddd":0,""" +
+            """"assets":[],"layers":[]}"""
+
+    /** Amplitude ramps 0→1 across 800ms; one flat frequency point; two transients. */
+    private const val HAPTICS_JSON =
+        """{"continuousPattern":{"amplitude":[{"time":0,"value":0.0},{"time":800,"value":1.0}],""" +
+            """"frequency":[{"time":0,"value":0.3}]},""" +
+            """"discretePattern":[{"time":250,"amplitude":1.0,"frequency":0.5},""" +
+            """{"time":600,"amplitude":0.4,"frequency":0.2}]}"""
+
+    fun bytes(durationMs: Double = 1500.0, withAnimation: Boolean = true): ByteArray {
+        val animation =
+            if (withAnimation) {
+                ""","animation":{"src":"anim/celebration.json","frameRate":30,"totalFrames":60}"""
+            } else {
+                ""
+            }
+        val manifest =
+            """{"schema":"pulsar.bundle/1","id":"com.acme.haptics","name":"Acme Pack","revision":7,""" +
+                """"hash":"sha256-test","presets":[{"id":"celebration","name":"Celebration",""" +
+                """"duration":$durationMs,"haptics":"haptics/celebration.json"$animation}]}"""
+
+        val entries = buildMap {
+            put("manifest.json", manifest)
+            put("haptics/celebration.json", HAPTICS_JSON)
+            if (withAnimation) put("anim/celebration.json", LOTTIE_JSON)
+        }
+        return storedZip(entries)
+    }
+
+    /** Minimal STORE-only zip writer, so no platform zip API is needed in common code. */
+    private fun storedZip(entries: Map<String, String>): ByteArray {
+        fun crc32(bytes: ByteArray): Int {
+            val table = IntArray(256) { n ->
+                var c = n
+                repeat(8) { c = if (c and 1 != 0) (0xEDB88320.toInt() xor (c ushr 1)) else (c ushr 1) }
+                c
+            }
+            var c = -1
+            for (b in bytes) c = table[(c xor b.toInt()) and 0xFF] xor (c ushr 8)
+            return c.inv()
+        }
+        fun le16(v: Int) = byteArrayOf((v and 0xFF).toByte(), ((v ushr 8) and 0xFF).toByte())
+        fun le32(v: Int) = byteArrayOf(
+            (v and 0xFF).toByte(), ((v ushr 8) and 0xFF).toByte(),
+            ((v ushr 16) and 0xFF).toByte(), ((v ushr 24) and 0xFF).toByte(),
+        )
+        val local = ArrayList<Byte>()
+        val central = ArrayList<Byte>()
+        var offset = 0
+        for ((name, content) in entries) {
+            val nameB = name.encodeToByteArray()
+            val data = content.encodeToByteArray()
+            val crc = crc32(data)
+            val lh = le32(0x04034b50) + le16(20) + le16(0) + le16(0) + le16(0) + le16(0) +
+                le32(crc) + le32(data.size) + le32(data.size) + le16(nameB.size) + le16(0)
+            local += lh.toList(); local += nameB.toList(); local += data.toList()
+            val ch = le32(0x02014b50) + le16(20) + le16(20) + le16(0) + le16(0) + le16(0) + le16(0) +
+                le32(crc) + le32(data.size) + le32(data.size) +
+                le16(nameB.size) + le16(0) + le16(0) + le16(0) + le16(0) + le32(0) + le32(offset)
+            central += ch.toList(); central += nameB.toList()
+            offset += lh.size + nameB.size + data.size
+        }
+        val eocd = le32(0x06054b50) + le16(0) + le16(0) + le16(entries.size) + le16(entries.size) +
+            le32(central.size) + le32(local.size) + le16(0)
+        return (local + central.toList() + eocd.toList()).toByteArray()
+    }
+}

--- a/react-native/react-native-pulsar-lottie/package-lock.json
+++ b/react-native/react-native-pulsar-lottie/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^19.2.0",
+        "@types/react-test-renderer": "^19.1.0",
         "del-cli": "^6.0.0",
         "lottie-react-native": "~7.3.8",
         "prettier": "^3.6.2",
@@ -19,6 +20,7 @@
         "react-native-pulsar": "^1.6.1",
         "react-native-reanimated": "4.5.1",
         "react-native-worklets": "0.10.1",
+        "react-test-renderer": "^19.2.3",
         "typescript": "^5.9.2"
       },
       "peerDependencies": {
@@ -2332,6 +2334,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -5348,6 +5360,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.3",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",

--- a/react-native/react-native-pulsar-lottie/package.json
+++ b/react-native/react-native-pulsar-lottie/package.json
@@ -22,7 +22,7 @@
     "!**/.*"
   ],
   "scripts": {
-    "test": "node --test \"src/__tests__/*.test.ts\"",
+    "test": "node --test --experimental-test-module-mocks \"src/__tests__/*.test.ts\"",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "build": "bob build",
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.0",
+    "@types/react-test-renderer": "^19.1.0",
     "del-cli": "^6.0.0",
     "lottie-react-native": "~7.3.8",
     "prettier": "^3.6.2",
@@ -62,6 +63,7 @@
     "react-native-pulsar": "^1.6.1",
     "react-native-reanimated": "4.5.1",
     "react-native-worklets": "0.10.1",
+    "react-test-renderer": "^19.2.3",
     "typescript": "^5.9.2"
   },
   "peerDependencies": {

--- a/react-native/react-native-pulsar-lottie/src/__tests__/sampler.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/sampler.test.ts
@@ -1,0 +1,148 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clamp,
+  lottieDurationMs,
+  patternDurationMs,
+  sampleEnvelope,
+  type EnvelopePoint,
+} from '../internal/sampler.ts';
+import type { Pattern } from 'react-native-pulsar';
+
+const env: EnvelopePoint[] = [
+  { time: 0, value: 0 },
+  { time: 400, value: 1 },
+  { time: 800, value: 0 },
+];
+
+const near = (actual: number, expected: number, eps = 1e-9) =>
+  assert.ok(
+    Math.abs(actual - expected) <= eps,
+    `expected ${actual} to be within ${eps} of ${expected}`
+  );
+
+describe('sampleEnvelope', () => {
+  test('clamps to the first and last point outside the range', () => {
+    assert.equal(sampleEnvelope(env, -50), 0);
+    assert.equal(sampleEnvelope(env, 900), 0);
+  });
+
+  test('returns the value at an exact knot', () => {
+    assert.equal(sampleEnvelope(env, 0), 0);
+    assert.equal(sampleEnvelope(env, 400), 1);
+    assert.equal(sampleEnvelope(env, 800), 0);
+  });
+
+  test('interpolates linearly between knots', () => {
+    near(sampleEnvelope(env, 200), 0.5);
+    near(sampleEnvelope(env, 600), 0.5);
+    near(sampleEnvelope(env, 100), 0.25);
+  });
+
+  test('an empty curve is silent', () => {
+    assert.equal(sampleEnvelope([], 123), 0);
+  });
+
+  test('a single point holds its value everywhere', () => {
+    const flat = [{ time: 500, value: 0.7 }];
+    assert.equal(sampleEnvelope(flat, 0), 0.7);
+    assert.equal(sampleEnvelope(flat, 500), 0.7);
+    assert.equal(sampleEnvelope(flat, 10_000), 0.7);
+  });
+
+  test('a zero-width span takes the later value instead of dividing by zero', () => {
+    const step: EnvelopePoint[] = [
+      { time: 0, value: 0 },
+      { time: 400, value: 0.2 },
+      { time: 400, value: 0.9 },
+      { time: 800, value: 1 },
+    ];
+    assert.equal(sampleEnvelope(step, 400), 0.2);
+    near(sampleEnvelope(step, 600), 0.95);
+  });
+});
+
+describe('clamp', () => {
+  test('bounds a value into the range', () => {
+    assert.equal(clamp(-1, 0, 1), 0);
+    assert.equal(clamp(5, 0, 1), 1);
+    assert.equal(clamp(0.4, 0, 1), 0.4);
+  });
+
+  test('the bounds themselves pass through', () => {
+    assert.equal(clamp(0, 0, 1), 0);
+    assert.equal(clamp(1, 0, 1), 1);
+  });
+});
+
+describe('patternDurationMs', () => {
+  const pattern = (over: Partial<Pattern> = {}): Pattern =>
+    ({
+      continuousPattern: {
+        amplitude: [
+          { time: 0, value: 0 },
+          { time: 800, value: 1 },
+        ],
+        frequency: [
+          { time: 0, value: 0.3 },
+          { time: 600, value: 0.8 },
+        ],
+      },
+      discretePattern: [{ time: 250, amplitude: 1, frequency: 0.5 }],
+      ...over,
+    }) as Pattern;
+
+  test('is the largest timestamp across every channel', () => {
+    assert.equal(patternDurationMs(pattern()), 800);
+  });
+
+  test('a late transient can be the longest channel', () => {
+    assert.equal(
+      patternDurationMs(
+        pattern({ discretePattern: [{ time: 1200, amplitude: 1, frequency: 0.5 }] })
+      ),
+      1200
+    );
+  });
+
+  test('an empty pattern has no length', () => {
+    assert.equal(
+      patternDurationMs({
+        continuousPattern: { amplitude: [], frequency: [] },
+        discretePattern: [],
+      } as unknown as Pattern),
+      0
+    );
+  });
+});
+
+describe('lottieDurationMs', () => {
+  test('reads fr/ip/op out of an inline Lottie document', () => {
+    assert.equal(lottieDurationMs({ v: '5.7.4', fr: 30, ip: 0, op: 60 }), 2000);
+  });
+
+  test('honours a non-zero in-point', () => {
+    assert.equal(lottieDurationMs({ fr: 30, ip: 30, op: 60 }), 1000);
+  });
+
+  test('a missing in-point counts from zero', () => {
+    assert.equal(lottieDurationMs({ fr: 60, op: 60 }), 1000);
+  });
+
+  test('gives up on a source it cannot read', () => {
+    assert.equal(lottieDurationMs(undefined), undefined);
+    assert.equal(lottieDurationMs(42), undefined);
+    // A `require()`d asset — a number to the bundler, nothing to read here.
+    assert.equal(lottieDurationMs({ uri: 'https://example.com/a.json' }), undefined);
+    assert.equal(lottieDurationMs({ fr: 30 }), undefined);
+  });
+
+  test('treats a zero frame rate as the 30fps default', () => {
+    assert.equal(lottieDurationMs({ fr: 0, op: 60 }), 2000);
+  });
+
+  test('rejects a document whose timeline makes no sense', () => {
+    assert.equal(lottieDurationMs({ fr: 30, ip: 60, op: 60 }), undefined);
+    assert.equal(lottieDurationMs({ fr: 30, ip: 90, op: 60 }), undefined);
+  });
+});

--- a/react-native/react-native-pulsar-lottie/src/__tests__/sampler.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/sampler.test.ts
@@ -132,7 +132,6 @@ describe('lottieDurationMs', () => {
   test('gives up on a source it cannot read', () => {
     assert.equal(lottieDurationMs(undefined), undefined);
     assert.equal(lottieDurationMs(42), undefined);
-    // A `require()`d asset — a number to the bundler, nothing to read here.
     assert.equal(lottieDurationMs({ uri: 'https://example.com/a.json' }), undefined);
     assert.equal(lottieDurationMs({ fr: 30 }), undefined);
   });

--- a/react-native/react-native-pulsar-lottie/src/__tests__/useHapticLottie.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/useHapticLottie.test.ts
@@ -1,0 +1,186 @@
+import { test, describe, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+
+/**
+ * Records what the hook asks of `react-native-pulsar`, standing in for the native
+ * pattern composer. Registered as a module mock before the hook is imported.
+ */
+const composer = {
+  parsed: [] as unknown[],
+  plays: 0,
+  stops: 0,
+  ready: true,
+  isParsed() {
+    return this.ready;
+  },
+  play() {
+    this.plays += 1;
+  },
+  stop() {
+    this.stops += 1;
+  },
+  reset(ready = true) {
+    this.parsed = [];
+    this.plays = 0;
+    this.stops = 0;
+    this.ready = ready;
+  },
+};
+
+// React needs to know it is inside an act() scope before anything renders.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+mock.module('react-native-pulsar', {
+  exports: {
+    usePatternComposer(pattern: unknown) {
+      composer.parsed.push(pattern);
+      return composer;
+    },
+  },
+});
+
+const { useHapticLottie } = await import('../useHapticLottie.ts');
+const TestRenderer = (await import('react-test-renderer')).default;
+
+type Options = Parameters<typeof useHapticLottie>[0];
+type Handle = ReturnType<typeof useHapticLottie>;
+type Preset = NonNullable<Options['preset']>;
+
+/** Renders the hook once and hands back its result. */
+function renderHook(options: Options): Handle {
+  let handle: Handle | undefined;
+  function Probe() {
+    handle = useHapticLottie(options);
+    return null;
+  }
+  TestRenderer.act(() => {
+    TestRenderer.create(createElement(Probe));
+  });
+  return handle!;
+}
+
+const pattern = {
+  continuousPattern: {
+    amplitude: [{ time: 0, value: 1 }],
+    frequency: [{ time: 0, value: 0.5 }],
+  },
+  discretePattern: [{ time: 0, amplitude: 1, frequency: 0.5 }],
+};
+
+/** The hook's `Pattern` type lives in the native package; the shape above is enough. */
+const asHaptics = (p: object) => p as NonNullable<Options['haptics']>;
+
+/** A generated bundle preset, as the hook sees it. */
+function preset(over: Record<string, unknown> = {}) {
+  const played: string[] = [];
+  return Object.assign(
+    {
+      id: 'celebration',
+      name: 'Celebration',
+      duration: 1500,
+      pattern,
+      hasAudio: false,
+      hasAnimation: true,
+      play: () => played.push('play'),
+      stop: () => played.push('stop'),
+      calls: played,
+      ...over,
+    },
+    {}
+  ) as unknown as Preset & { calls: string[] };
+}
+
+describe('useHapticLottie', () => {
+  beforeEach(() => composer.reset());
+
+  test("plays the preset's pattern through the composer", () => {
+    const handle = renderHook({ preset: preset() });
+
+    assert.equal(composer.parsed[0], pattern, 'the pattern is pre-parsed, warming the engine');
+    assert.equal(handle.isReady, true);
+
+    handle.play();
+    handle.stop();
+
+    assert.equal(composer.plays, 1);
+    assert.equal(composer.stops, 1);
+  });
+
+  test('explicit haptics win over the preset', () => {
+    const own = asHaptics({ ...pattern });
+    renderHook({ preset: preset(), haptics: own });
+
+    assert.equal(composer.parsed[0], own);
+  });
+
+  test('a preset with audio plays itself, so its audio plays too', () => {
+    const p = preset({ hasAudio: true });
+    const handle = renderHook({ preset: p });
+
+    handle.play();
+    handle.stop();
+
+    assert.deepEqual(p.calls, ['play', 'stop']);
+    assert.equal(composer.plays, 0, 'the preset owns the pattern natively');
+    assert.equal(composer.parsed[0], undefined, 'nothing is re-parsed in JS');
+    assert.equal(handle.isReady, true, 'a preset source is always ready');
+  });
+
+  test('explicit haptics keep an audio preset from playing itself', () => {
+    const p = preset({ hasAudio: true });
+    const handle = renderHook({ preset: p, haptics: asHaptics(pattern) });
+
+    handle.play();
+    handle.stop();
+
+    assert.deepEqual(p.calls, []);
+    assert.equal(composer.plays, 1);
+    assert.equal(composer.stops, 1);
+  });
+
+  test('a preset trigger function is simply called', () => {
+    let fired = 0;
+    const handle = renderHook({ haptics: () => (fired += 1) });
+
+    assert.equal(handle.isReady, true);
+
+    handle.play();
+    handle.stop();
+
+    assert.equal(fired, 1);
+    assert.equal(composer.plays, 0, 'a trigger has no buffered pattern to stop');
+  });
+
+  test('a pattern that is not parsed yet does not fire', () => {
+    composer.reset(false);
+    const handle = renderHook({ haptics: asHaptics(pattern) });
+
+    assert.equal(handle.isReady, false);
+
+    handle.play();
+
+    assert.equal(composer.plays, 0);
+  });
+
+  test('hapticsEnabled: false silences play but still allows stop', () => {
+    const handle = renderHook({ haptics: asHaptics(pattern), hapticsEnabled: false });
+
+    handle.play();
+    assert.equal(composer.plays, 0);
+
+    handle.stop();
+    assert.equal(composer.stops, 1, 'stopping is always safe');
+  });
+
+  test('with nothing to play at all the handle is inert', () => {
+    const handle = renderHook({});
+
+    handle.play();
+    handle.stop();
+
+    assert.equal(composer.plays, 0);
+    assert.equal(composer.stops, 0);
+    assert.equal(handle.isReady, true);
+  });
+});

--- a/react-native/react-native-pulsar-lottie/src/__tests__/useHapticLottie.test.ts
+++ b/react-native/react-native-pulsar-lottie/src/__tests__/useHapticLottie.test.ts
@@ -2,10 +2,6 @@ import { test, describe, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { createElement } from 'react';
 
-/**
- * Records what the hook asks of `react-native-pulsar`, standing in for the native
- * pattern composer. Registered as a module mock before the hook is imported.
- */
 const composer = {
   parsed: [] as unknown[],
   plays: 0,
@@ -28,7 +24,6 @@ const composer = {
   },
 };
 
-// React needs to know it is inside an act() scope before anything renders.
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 mock.module('react-native-pulsar', {
@@ -47,7 +42,6 @@ type Options = Parameters<typeof useHapticLottie>[0];
 type Handle = ReturnType<typeof useHapticLottie>;
 type Preset = NonNullable<Options['preset']>;
 
-/** Renders the hook once and hands back its result. */
 function renderHook(options: Options): Handle {
   let handle: Handle | undefined;
   function Probe() {
@@ -68,10 +62,8 @@ const pattern = {
   discretePattern: [{ time: 0, amplitude: 1, frequency: 0.5 }],
 };
 
-/** The hook's `Pattern` type lives in the native package; the shape above is enough. */
 const asHaptics = (p: object) => p as NonNullable<Options['haptics']>;
 
-/** A generated bundle preset, as the hook sees it. */
 function preset(over: Record<string, unknown> = {}) {
   const played: string[] = [];
   return Object.assign(


### PR DESCRIPTION
## What

Every PulsarLottie SDK only had unit tests for its pure sampler helpers, so the whole public surface — controller/engine construction, mode selection, duration resolution, transport, and the per-frame haptic clock — was unverified on all five frameworks. This adds suites that cover it, contract for contract, on iOS, Android, KMP, Flutter and React Native.

| SDK | Tests | Run |
|---|---|---|
| Flutter | 54 (35 controller + 13 widget + 6 sampler) | `cd flutter/PulsarLottie && flutter test` |
| Android | 37 (27 controller/view + 10 sampler) | from `Android/PulsarApp`: `./gradlew :PulsarLottie:testDebugUnitTest` |
| KMP | 34 (24 engine + 10 sampler), on the Android-host **and** iOS-sim targets | from `kmp/Pulsar`: `USE_LOCAL_PULSAR_ANDROID=1 ./gradlew :PulsarLottie:testAndroidHostTest :PulsarLottie:iosSimulatorArm64Test` |
| iOS | 32 (21 controller/view + 11 sampler) | from `iOS/PulsarLottie`: `xcodebuild test -scheme PulsarLottie -destination "platform=iOS Simulator,id=<UDID>" -skipPackagePluginValidation` |
| React Native | 34 (8 hook + 17 sampler + 9 pre-existing) | `cd react-native/react-native-pulsar-lottie && npm test` |

All five suites pass locally.

Each suite covers the same contract:

- mode selection — realtime vs pattern, the audio-preset default, and both ways of overriding it
- the full duration order: explicit `durationMs` > preset's authored duration > Lottie composition > pattern length (plus the zero-value fall-throughs)
- transport: `play` / `pause` / `resume` / `stop` / `reset` / `setTimestamp` (including clamping) / `setLoop` / `release`
- the sampling clock: envelope interpolation, transients firing once per pass and re-arming on a loop wrap, `hapticOffset`, discrete-only patterns driving no continuous channel
- `hapticsEnabled: false`, preset binding, and presets carrying no animation

## How the haptics are observed

To assert what actually reaches the engine rather than only that nothing threw, each SDK gets a recording seam — there is no shared mock layer:

- **Flutter** — a `PulsarPlatform` subclass installed as `PulsarPlatform.instance`, recording every native call.
- **Android** — `RealtimeComposer.delegate` is a public `var` over the `RealtimeComposable` interface, so a recorder swaps in under Robolectric. (The Robolectric vibrator records nothing unless `VIBRATE` is granted, so the delegate is the reliable seam; the pattern-mode path does use the vibrator shadow.)
- **KMP** — `registerPulsarFactory()` with a fake `PulsarPlatformHandle` whose `presets()` just throws; the Lottie SDK never reaches for the preset library.
- **iOS** — no seam, so assertions read `LottieAnimationView.currentProgress` / `loopMode` / `isAnimationPlaying`. `setTimestamp` is what makes the duration order observable.

`PresetHandle` constructors are internal on Android/KMP/iOS, so the tests build real `.pulsar` archives in memory (a small STORE-only zip writer per language) and load them through the public `loadBundle`.

## Supporting changes

- **Android** — Robolectric 4.14.1 + `isIncludeAndroidResources` for `:PulsarLottie` unit tests, pinned in the module rather than the example app's shared catalog (matching `:Pulsar`).
- **Flutter** — added `pubspec_overrides.yaml` resolving `pulsar_haptics` from `../pulsar`. The published `0.1.1` has no `PresetHandle`, so the **existing** suite did not compile in that directory before this PR. `pub publish --dry-run` emits a hint about the override, not a warning; publishing is unaffected.
- **React Native** — `react-test-renderer` (+ its types) as devDependencies for the `useHapticLottie` hook test, and `--experimental-test-module-mocks` on the `test` script (the hook test mocks `react-native-pulsar`).

## Notes for the reviewer

- **A real divergence, documented rather than locked in:** Flutter's `setTimestamp` fires every transient it seeks past, because writing `AnimationController.value` notifies listeners synchronously. iOS and Android move the playhead silently. The test says so in a comment instead of asserting it as desired behaviour — the fix would be to set `_lastT = ms` before writing `value`. Happy to do that here if you agree it's a bug.
- **RN `HapticLottieView` is not covered.** Node's type-stripping cannot handle JSX, and the realtime engine additionally needs reanimated worklets and the native `LottieView`. Covering it means adding jest + `@react-native/jest-preset` to that package.
- **Pre-existing, untouched:** `npm run typecheck` in the RN Lottie package reports 3 errors because the published `react-native-pulsar@1.7.0` typings don't export `PresetHandle`; the new test files typecheck clean. That package's `.nvmrc` also still pins v20.19.0, which cannot run its TS tests at all (CI uses node 24).
- **No CI workflows added** — there are none for any Lottie SDK today. Per-framework workflows mirroring `test-android-sdk.yml` / `test-ios-sdk.yml` can follow.