### PR TITLE
fix(pulsar-gen): rename to unscoped `pulsar-gen` and publish compiled JS

### DIFF
--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -704,7 +704,7 @@ flutter:
 ```
 
 ```bash
-npx @swmansion/pulsar-gen assets/pulsar/acme-pack.pulsar --target dart --out lib/bundles/
+npx pulsar-gen assets/pulsar/acme-pack.pulsar --target dart --out lib/bundles/
 ```
 
 ### Load and play

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -657,7 +657,7 @@ plugin so the accessor regenerates on every build:
 ...or run the CLI once and commit the result — the practical option for an Xcode app target:
 
 ```bash
-npx @swmansion/pulsar-gen acme-pack.pulsar --target swift --out Sources/MyApp/
+npx pulsar-gen acme-pack.pulsar --target swift --out Sources/MyApp/
 ```
 
 ### Load and play

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -645,7 +645,7 @@ KMP ships the bundle API under `com.swmansion.pulsar.kmp.bundle`, so point the g
 runtime package:
 
 ```bash
-npx @swmansion/pulsar-gen acme-pack.pulsar --target kotlin \
+npx pulsar-gen acme-pack.pulsar --target kotlin \
   --package com.example.app.bundles \
   --runtime-package com.swmansion.pulsar.kmp.bundle \
   --out composeApp/src/commonMain/kotlin/com/example/app/bundles/

--- a/flutter/pulsar/BUNDLES.md
+++ b/flutter/pulsar/BUNDLES.md
@@ -17,7 +17,7 @@ autocomplete.
 2. Generate the typed accessor (`*.bundle.dart`) with `pulsar-gen`:
 
    ```bash
-   npx @swmansion/pulsar-gen assets/pulsar/acme-pack.pulsar --target dart --out lib/bundles/
+   npx pulsar-gen assets/pulsar/acme-pack.pulsar --target dart --out lib/bundles/
    ```
 
    (A `build_runner` builder wrapping this is a planned convenience; the CLI is the source of truth.)

--- a/iOS/Pulsar/Sources/Pulsar/Bundle/README.md
+++ b/iOS/Pulsar/Sources/Pulsar/Bundle/README.md
@@ -39,7 +39,7 @@ regenerates on every build (like Xcode 15 asset symbols):
 ```
 
 The plugin runs the self-contained `pulsar-gen-swift` host tool — no Node or network in the build.
-CocoaPods consumers (React Native / Flutter) instead run `@swmansion/pulsar-gen` in a script phase.
+CocoaPods consumers (React Native / Flutter) instead run `pulsar-gen` in a script phase.
 
 ## Bridge surface (React Native / Flutter)
 

--- a/iOS/Pulsar/Sources/pulsar-gen-swift/main.swift
+++ b/iOS/Pulsar/Sources/pulsar-gen-swift/main.swift
@@ -74,7 +74,7 @@ struct Manifest: Codable {
   struct Preset: Codable { let id: String; let name: String }
 }
 
-// MARK: - Emit (matches @swmansion/pulsar-gen swift target)
+// MARK: - Emit (matches pulsar-gen swift target)
 
 func pascalCase(_ s: String) -> String {
   let parts = s.split { !$0.isLetter && !$0.isNumber }

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/bundle/README.md
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/bundle/README.md
@@ -9,7 +9,7 @@ KMP ships this API under `com.swmansion.pulsar.kmp.bundle`, not the Android SDK'
 `com.swmansion.pulsar.bundle`, so the generator needs to be told:
 
 ```bash
-npx @swmansion/pulsar-gen acme-pack.pulsar --target kotlin \
+npx pulsar-gen acme-pack.pulsar --target kotlin \
   --package com.example.app.bundles \
   --runtime-package com.swmansion.pulsar.kmp.bundle \
   --out composeApp/src/commonMain/kotlin/com/example/app/bundles/

--- a/tools/pulsar-gen/.gitignore
+++ b/tools/pulsar-gen/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.tsbuildinfo
+dist/

--- a/tools/pulsar-gen/README.md
+++ b/tools/pulsar-gen/README.md
@@ -3,19 +3,19 @@
 Generates the **typed view** of a Pulsar `.pulsar` bundle so `bundle.<id>` autocompletes in
 your IDE. The `.pulsar` format itself is specified internally (pulsar-private, `docs/bundle-format.md`).
 
-Requires Node ≥ 23.6 (runs TypeScript sources directly via type-stripping — no build step).
+Requires Node ≥ 20.
 
 ## CLI
 
 ```bash
 # Emit a Swift typed accessor next to the bundle
-node src/cli.ts path/to/acme-pack.pulsar --target swift --out ./Generated
+npx pulsar-gen path/to/acme-pack.pulsar --target swift --out ./Generated
 
 # Multiple targets at once
-node src/cli.ts acme-pack.pulsar --target swift,kotlin,dart,rn --out ./gen
+npx pulsar-gen acme-pack.pulsar --target swift,kotlin,dart,rn --out ./gen
 
 # Kotlin package / print to stdout
-node src/cli.ts acme-pack.pulsar --target kotlin --package com.acme.haptics --stdout
+npx pulsar-gen acme-pack.pulsar --target kotlin --package com.acme.haptics --stdout
 ```
 
 Targets: `swift` (`enum` + `BundleDescriptor`), `kotlin` (`object` + `BundleDescriptor`),
@@ -38,9 +38,9 @@ import {
   validateManifest,
   generate,
   buildSidecar,
-} from "@swmansion/pulsar-gen";
+} from "pulsar-gen";
 // Node-only helpers (disk + zip):
-import { readBundleFile, computeContentHash } from "@swmansion/pulsar-gen/read";
+import { readBundleFile, computeContentHash } from "pulsar-gen/read";
 
 const { manifest, entries } = readBundleFile("acme-pack.pulsar");
 generate(manifest, "rn", {
@@ -54,8 +54,24 @@ them directly for in-browser export. `read`/`zip`/`cli` are Node-only.
 
 ## Develop
 
+Working in this repo, run the CLI straight from source — Node type-strips it, no build step
+(needs Node ≥ 23.6, unlike the published package):
+
 ```bash
-node fixtures/build-fixture.ts   # regenerate the fixture bundle + golden outputs
-node --test                      # run the test suite
-npm run typecheck                # tsc --noEmit (needs `npm install` for typescript first)
+node src/cli.ts acme-pack.pulsar --target swift --stdout
 ```
+
+```bash
+npm install                      # typescript + @types/node
+node fixtures/build-fixture.ts   # regenerate the fixture bundle + golden outputs
+node --test                      # run the test suite (runs against src/, not dist/)
+npm run typecheck                # tsc --noEmit
+npm run build                    # tsc -p tsconfig.build.json -> dist/ (what gets published)
+```
+
+## Publishing
+
+`prepack` builds `dist/`, so `npm publish` from this directory ships compiled JS. That is not
+optional: Node refuses to type-strip files under `node_modules`
+(`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`), so a package whose `bin` points at a `.ts` file
+cannot run once installed.

--- a/tools/pulsar-gen/package-lock.json
+++ b/tools/pulsar-gen/package-lock.json
@@ -1,22 +1,22 @@
 {
-  "name": "@swmansion/pulsar-gen",
-  "version": "0.1.0",
+  "name": "pulsar-gen",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@swmansion/pulsar-gen",
-      "version": "0.1.0",
+      "name": "pulsar-gen",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
-        "pulsar-gen": "src/cli.ts"
+        "pulsar-gen": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "typescript": "^5.6.0"
+        "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">=23.6"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@types/node": {

--- a/tools/pulsar-gen/package.json
+++ b/tools/pulsar-gen/package.json
@@ -1,25 +1,45 @@
 {
-  "name": "@swmansion/pulsar-gen",
-  "version": "0.1.0",
+  "name": "pulsar-gen",
+  "version": "0.1.1",
   "description": "Generate typed accessors (Swift/Kotlin/Dart) and RN sidecars for Pulsar .pulsar bundles.",
   "type": "module",
-  "engines": { "node": ">=23.6" },
-  "bin": { "pulsar-gen": "src/cli.ts" },
+  "engines": { "node": ">=20.0.0" },
+  "bin": { "pulsar-gen": "dist/cli.js" },
   "exports": {
-    ".": "./src/index.ts",
-    "./read": "./src/read.ts",
-    "./zip": "./src/zip.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./read": {
+      "types": "./dist/read.d.ts",
+      "default": "./dist/read.js"
+    },
+    "./zip": {
+      "types": "./dist/zip.d.ts",
+      "default": "./dist/zip.js"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "build:fixture": "node fixtures/build-fixture.ts",
     "test": "node --test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepack": "npm run build"
   },
-  "files": ["src", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "keywords": ["pulsar", "haptics", "codegen", "bundle"],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/software-mansion/pulsar.git",
+    "directory": "tools/pulsar-gen"
+  },
+  "homepage": "https://github.com/software-mansion/pulsar/tree/main/tools/pulsar-gen",
+  "bugs": { "url": "https://github.com/software-mansion/pulsar/issues" },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.7.0"
   }
 }

--- a/tools/pulsar-gen/src/emit/rn.ts
+++ b/tools/pulsar-gen/src/emit/rn.ts
@@ -62,7 +62,7 @@ export function emitRn(manifest: BundleManifest, opts: GenerateOptions = {}): Ge
   if (!opts.patterns) {
     throw new Error(
       'rn target requires `patterns` (the inlined haptics). Build them with ' +
-        '`extractPatterns(manifest, entries)` from @swmansion/pulsar-gen.',
+        '`extractPatterns(manifest, entries)` from pulsar-gen.',
     );
   }
   const animations = opts.animations ?? {};

--- a/tools/pulsar-gen/tsconfig.build.json
+++ b/tools/pulsar-gen/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What changed

Two things, both about making `pulsar-gen` usable by people outside this repo.

**1. Rename `@swmansion/pulsar-gen` → `pulsar-gen`.** The package is published unscoped, but nothing in the repo reflected that. All 12 references are updated: the package manifest and lockfile, the programmatic-API examples in the tool README, the iOS/KMP/Flutter docs pages, the per-SDK `BUNDLES.md`/`README.md` files, and the comment in the `pulsar-gen-swift` host tool that pins it to the swift target. `pulsar-gen-rn`, `pulsar-gen-gradle`, `pulsar-gen-swift` and `pulsar-gen-fixture` are untouched — only the exact scoped string was matched.

**2. Publish compiled JS, because the published package could not run.** `bin` pointed at `src/cli.ts`, and Node refuses to type-strip files under `node_modules`:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
unsupported for files under node_modules, for ".../node_modules/pulsar-gen/src/cli.ts"
```

This is not an npx quirk — a plain `npm i -D pulsar-gen` hits the same wall, as would the CocoaPods script phase. It worked in this repo only because here the package isn't installed as a dependency. Since `pulsar-gen` is the *only* codegen path for iOS-CocoaPods, KMP and Flutter, all three were left without a working one.

## How

- New `tools/pulsar-gen/tsconfig.build.json`: emits `dist/` with declarations, `include: ["src"]` so tests and fixtures stay out of the build. The existing `rewriteRelativeImportExtensions` rewrites the `./read.ts` specifiers to `./read.js` on emit; tsc preserves the shebang.
- `bin` → `dist/cli.js`; `exports` for `.`, `./read`, `./zip` map to `dist` with `types`; `prepack` runs the build so a publish can never again ship an unbuilt package.
- `engines` `>=23.6` → `>=20.0.0`. The 23.6 floor existed only for type-stripping; the newest API the sources use is `parseArgs`.
- `typescript` devDep `^5.6.0` → `^5.7.0` — `rewriteRelativeImportExtensions` doesn't exist before 5.7, so the old range could install a tsc that fails the build.
- Version → `0.1.1`; added `repository`/`homepage`/`bugs` (all unset on the published package); `dist/` gitignored; README updated for `npx`, with the in-repo `node src/cli.ts` path kept under Develop.

## Verification

Packed the tarball, installed it as a real dependency in a scratch project, and ran it from `node_modules`:

- `npx pulsar-gen` runs; all four targets (`swift,kotlin,dart,rn`) emit, warnings intact
- Output is **byte-identical to all four goldens** — compiling changed nothing
- `pulsar-gen`, `pulsar-gen/read` and `pulsar-gen/zip` all import at runtime, and a strict `tsc --noEmit` consumer probe resolves the shipped types
- In-repo: 14/14 tests pass (including the test pinning the RN emitter byte-identical to the standalone `pulsar-gen-rn.mjs`), `npm run typecheck` clean, clean-slate `npm run build` clean

## Notes for the reviewer

- `src` stays in `files` with an explicit `./src/*` subpath export, so Studio can still import the emitters as source per the README's portability claim. I deliberately did **not** add a `source` export condition — Metro and some bundlers auto-pick it, which would silently feed TS to React Native consumers. Worth a sanity check from whoever owns the Studio side.
- No golden regeneration was needed: the renamed string in `emit/rn.ts` is only in a thrown error message, not in emitted output.
- After `0.1.1` ships, consider `npm deprecate pulsar-gen@0.1.0 "broken bin — use 0.1.1+"` so nobody pins the dead version.
- Still open, deliberately left out of scope: `pulsar-gen` has no entry in `sdk-versions.json`, so its version isn't covered by `yarn sync:versions`, and there's no publish workflow for it alongside the other `publish-*.yml` files.