### PR TITLE
ci(pulsar-gen): add npm publish workflow and track its version

### DIFF
--- a/.github/workflows/publish-pulsar-gen.yml
+++ b/.github/workflows/publish-pulsar-gen.yml
@@ -1,0 +1,99 @@
+name: Publish pulsar-gen to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'npm tag to publish under'
+        required: false
+        type: choice
+        options:
+          - latest
+          - rc
+          - beta
+        default: 'latest'
+      dry-run:
+        description: 'Dry run'
+        required: false
+        type: boolean
+        default: 'true'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        working-directory: tools/pulsar-gen
+        run: npm ci
+
+      - name: Run tests
+        working-directory: tools/pulsar-gen
+        run: npm test
+
+      - name: Typecheck
+        working-directory: tools/pulsar-gen
+        run: npm run typecheck
+
+      # `prepack` builds dist/ during `npm pack`, but a broken build there would
+      # surface as a confusing pack failure — fail here instead, with tsc's own output.
+      - name: Build
+        working-directory: tools/pulsar-gen
+        run: npm run build
+
+      # The published `bin` must be runnable from node_modules: Node refuses to
+      # type-strip files under node_modules, so a package pointing at a .ts entry
+      # installs fine and then fails for every consumer. Catch that here, not on npm.
+      - name: Verify the packed CLI runs as an installed dependency
+        working-directory: tools/pulsar-gen
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARBALL="$(npm pack --silent --pack-destination "$RUNNER_TEMP")"
+          CONSUMER="$RUNNER_TEMP/consumer"
+          mkdir -p "$CONSUMER"
+          cd "$CONSUMER"
+          echo '{"name":"consumer","version":"1.0.0","private":true}' > package.json
+          npm install --no-audit --no-fund "$RUNNER_TEMP/$TARBALL"
+          npx pulsar-gen "$GITHUB_WORKSPACE/tools/pulsar-gen/fixtures/acme-pack.pulsar" \
+            --target swift,kotlin,dart,rn --out ./gen
+          for f in AcmePack.swift AcmePack.kt acme_pack.bundle.dart acme-pack.bundle.ts; do
+            diff "gen/$f" "$GITHUB_WORKSPACE/tools/pulsar-gen/fixtures/golden/$f"
+          done
+          echo "Packed CLI runs from node_modules and matches the goldens."
+
+      - name: Resolve release version
+        id: release
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./sdk-versions.json').pulsarGen.version")"
+
+          if [[ -z "$VERSION" ]]; then
+            echo "Release version could not be determined from sdk-versions.json." >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION (from sdk-versions.json)"
+
+      - name: Publish stable
+        uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
+        with:
+          package-name: pulsar-gen
+          package-json-path: tools/pulsar-gen/package.json
+          release-type: stable
+          version: ${{ steps.release.outputs.version }}
+          tag: ${{ github.event.inputs.tag || 'latest' }}
+          dry-run: ${{ github.event.inputs.dry-run || 'true' }}
+          install-dependencies-command: npm ci

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -57,6 +57,10 @@
     "version": "0.2.0",
     "packageName": "pulsar-haptics"
   },
+  "pulsarGen": {
+    "version": "0.1.1",
+    "packageName": "pulsar-gen"
+  },
   "pulsarGenGradle": {
     "version": "0.1.0",
     "mavenCoordinate": "com.swmansion.pulsar:pulsar-gen-gradle",

--- a/tools/scripts/sync-sdk-versions.mjs
+++ b/tools/scripts/sync-sdk-versions.mjs
@@ -55,6 +55,7 @@ const markedVersions = [
 const jsonVersions = [
   { file: 'react-native/react-native-pulsar/package.json', version: versions.reactNative.version },
   { file: 'web/Pulsar/package.json', version: versions.web.version },
+  { file: 'tools/pulsar-gen/package.json', version: versions.pulsarGen.version },
 ];
 
 function replaceGeneratedSection(content, key, replacement) {


### PR DESCRIPTION
Follow-up to #282, which fixed the `pulsar-gen` package itself. This adds the CI that should have released it.

## Why

`pulsar-gen` was the one publishable artifact in the repo with no publish workflow — every other package has one. It was released by hand, and that is how the unrunnable `0.1.0` reached npm.

## What changed

**`.github/workflows/publish-pulsar-gen.yml`** — modelled on `publish-web-haptics.yml`, so it matches the existing house pattern: `workflow_dispatch` with `tag` / `dry-run` inputs, `dry-run` defaulting to `true`, version resolved from `sdk-versions.json`, and publishing through the same pinned `software-mansion/npm-package-publish` action with `install-dependencies-command: npm ci`.

On top of the usual test / typecheck / build steps it adds one guard: pack the tarball, install it into a throwaway project, run the CLI **from `node_modules`**, and diff all four emitted targets against the goldens.

That guard exists for a specific failure. A package whose `bin` points at a `.ts` entry installs cleanly and then fails for every consumer, because Node refuses to type-strip files under `node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`). Nothing in the previous pipeline could have caught it — in-repo the CLI is not an installed dependency, so it works there and only there. `prepack` now builds `dist/`, but only an install-and-run check proves the published artifact is actually executable.

**`sdk-versions.json` / `tools/scripts/sync-sdk-versions.mjs`** — register `pulsarGen` and add `tools/pulsar-gen/package.json` to the `jsonVersions` list, so the version is covered by `yarn sync:versions` like every other published package.

## Verification

- Ran the guard's bash **verbatim**, with `RUNNER_TEMP` / `GITHUB_WORKSPACE` set as on a runner: passes, all four targets byte-identical to the goldens.
- **Confirmed the guard actually fires.** Pointed `bin` back at `src/cli.ts`, re-packed and re-installed — fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`, exit 1. Then restored it.
- Checked that `npm ci` tolerates the root-version rewrite the shared action performs mid-run (forced a mismatch to be sure) — otherwise the publish would break at the install step.
- `yarn sync:versions` runs clean and idempotent, no file drift; 14/14 tests and typecheck pass on top of `main`.

## Notes for the reviewer

- `dry-run` defaults to `true`, matching the other npm workflows, so the first run is safe by default.
- Once `0.1.1` is out, consider `npm deprecate pulsar-gen@0.1.0 "broken bin — use 0.1.1+"` so nobody pins the dead version.
- Unrelated and still open, flagged while auditing publish coverage: the SPM mirror (`software-mansion-labs/pulsar-ios`) does not carry `Plugins/PulsarGenPlugin` or `Sources/pulsar-gen-swift`, and its `Package.swift` declares only the `Pulsar` library. So the documented iOS zero-manual codegen path (`plugins: [.plugin(name: "PulsarGenPlugin", package: "Pulsar")]`) cannot resolve for published consumers. That needs a change in the mirror repo or in whatever syncs it, not here.