### PR TITLE
ci: drop the vestigial `packageManager` field that breaks npm workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,5 @@
     "lint:js": "tools/scripts/lint-js.sh",
     "lint:kotlin": "tools/scripts/lint-kotlin.sh",
     "lint:swift": "tools/scripts/lint-swift.sh"
-  },
-  "packageManager": "yarn@3.6.1+sha512.de524adec81a6c3d7a26d936d439d2832e351cdfc5728f9d91f3fc85dd20b04391c038e9b4ecab11cae2b0dd9f0d55fd355af766bc5c1a7f8d25d96bb2a0b2ca"
+  }
 }


### PR DESCRIPTION
Fixes the failure in [run 34366066216](https://github.com/software-mansion/pulsar/actions/runs/34366066216/job/102514989999).

## What happened

`Publish pulsar-gen to npm` failed inside `actions/setup-node` — before any of the workflow's own steps ran:

```
error This project's package.json defines "packageManager": "yarn@3.6.1".
However the current global version of Yarn is 1.22.22.
```

setup-node v5 enables `package-manager-cache` by default. It reads the top-level `packageManager` field from the root `package.json`, concludes this is a yarn project, and runs `yarn cache dir` with the runner's preinstalled yarn 1.x — which refuses to run against a Corepack-pinned yarn 3.6.1.

## The field is vestigial

Nothing in this repo uses yarn:

- no `yarn.lock` anywhere (the root has no lockfile at all)
- no `.yarnrc.yml`
- no workflow invokes yarn — every install in CI is `npm ci`
- no doc or CONTRIBUTING step tells anyone to use it

It was added in #60, removed in #92 — titled "Remove package manager field", landed the same day `publish-web-haptics` went red twice and then green — and re-added as a stray line by the lockfile update in #257 on 2026-09-04.

So this is the same bug being fixed a second time, and every affected workflow has been broken since 2026-09-04. `publish-pulsar-gen` only surfaced it because it is the first one to run after that date.

## The fix

Delete the line. `package.json` is restored to **exactly its pre-#257 bytes** (the new blob hashes back to `3f85924f`, the blob #257 replaced).

That fixes all seven affected workflows at the source rather than opting each one out of the auto-detection:

- `publish-pulsar-gen.yml` (the observed failure)
- `publish-rn-stable.yml`, `publish-rn-lottie.yml`, `publish-web-haptics.yml`
- `_build-android-rn.yml`, `_build-ios-rn.yml`, `_build-ios-rn-cocoapods.yml` — these have not run since 2026-08-11 and were latently broken too

`deploy-docs.yml` was never affected: it passes an explicit `cache: 'npm'`, which bypasses the detection. It ran green today, after the re-add, which is the in-repo confirmation of the mechanism.

## Note for the reviewer

An earlier revision of this PR instead set `package-manager-cache: false` on all seven setup-node steps. That worked, but it was seven workarounds for one stray line; this is the smaller and more honest change. The trade-off is that the field is now easy to reintroduce a third time — a lint check on the root `package.json`, or a note in CONTRIBUTING, would close that loop if you think it is worth it.

#257 was titled "Package lock update expo doctor", so if `expo doctor` is what wants the field, this will make it complain again. Worth a look from whoever ran it — but declaring yarn in a repo with no yarn.lock is wrong either way, so the fix there would be to give expo doctor whatever it actually needs rather than to keep this line.
