### PR TITLE
feat(sdk): expose per-device haptic capabilities on every SDK

### DIFF
--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/Pulsar.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/Pulsar.kt
@@ -13,6 +13,7 @@ import com.swmansion.pulsar.composers.RealtimeComposer
 import com.swmansion.pulsar.haptics.HapticEngineWrapper
 import com.swmansion.pulsar.presets.PresetsWrapper
 import com.swmansion.pulsar.types.CompatibilityMode
+import com.swmansion.pulsar.types.HapticCapabilities
 import com.swmansion.pulsar.types.RealtimeComposerStrategy
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +63,15 @@ open class Pulsar(protected var context: Context) {
     fun hapticSupport(): CompatibilityMode {
         return engine.getRealCompatibilityMode()
     }
+
+    fun hapticCapabilities(): HapticCapabilities =
+        HapticCapabilities(
+            hasAmplitudeControl = engine.isAmplitudeSupported(),
+            hasPrimitiveSupport = engine.hasPrimitiveSupport(),
+            isEnvelopeSupported = engine.isEnvelopeSupported(),
+            isFrequencyProfileSupported = engine.isFrequencyProfileSupported(),
+            minControlPointDurationMillis = engine.getMinControlPointDurationMillis(),
+        )
 
     fun forceHapticsSupportLevel(mode: CompatibilityMode) {
         engine.simulateCompatibilityMode(mode)

--- a/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/Mixed.kt
+++ b/Android/Pulsar/src/main/java/com/swmansion/pulsar/types/Mixed.kt
@@ -12,3 +12,11 @@ enum class CompatibilityMode {
     STANDARD_SUPPORT,
     ADVANCED_SUPPORT,
 }
+
+data class HapticCapabilities(
+    val hasAmplitudeControl: Boolean,
+    val hasPrimitiveSupport: Boolean,
+    val isEnvelopeSupported: Boolean,
+    val isFrequencyProfileSupported: Boolean,
+    val minControlPointDurationMillis: Long,
+)

--- a/docs/src/content/docs/sdk/android.mdx
+++ b/docs/src/content/docs/sdk/android.mdx
@@ -819,6 +819,7 @@ Configuration methods available directly on the `Pulsar` instance.
 | `preloadPresets(presetNames: List<String>)`         | Preload presets by name for faster playback |
 | `stopHaptics()`                                     | Stop all currently playing haptics          |
 | `hapticSupport()`                                   | Returns the device's `CompatibilityMode`    |
+| `hapticCapabilities()`                              | Returns the [`HapticCapabilities`](#hapticcapabilities) behind that level |
 | `forceHapticsSupportLevel(mode: CompatibilityMode)` | Override the detected support level         |
 | `enableImpulseCompositionMode(state: Boolean)`      | Enable or disable `VibrationEffect.Composition` for impulse-only presets (enabled by default) |
 
@@ -925,6 +926,33 @@ enum class CompatibilityMode {
   LIMITED_SUPPORT,   // Timing-based waveform vibration (API 26+)
   STANDARD_SUPPORT,  // Amplitude + timing control
   ADVANCED_SUPPORT,  // Envelope + frequency profile (API 36+)
+}
+```
+
+### HapticCapabilities
+
+The individual vibrator capabilities behind `CompatibilityMode`, returned by
+`pulsar.hapticCapabilities()`.
+
+```kotlin
+data class HapticCapabilities(
+  val hasAmplitudeControl: Boolean,          // Intensity control, not on/off only
+  val hasPrimitiveSupport: Boolean,          // Composition primitives (API 30+)
+  val isEnvelopeSupported: Boolean,          // Envelope effects (API 36+)
+  val isFrequencyProfileSupported: Boolean,  // Vendor frequency profile (API 36+)
+  val minControlPointDurationMillis: Long,   // Shortest envelope control point honored
+)
+```
+
+The support level is decided by amplitude control (and, on Android 16+, the frequency
+profile). **Primitive support is not part of it**, so a `STANDARD_SUPPORT` device can still
+lack composition primitives. If you render your own single-hit patterns, check
+`hasPrimitiveSupport` and fall back to a waveform rather than composing primitives the
+vibrator will silently drop.
+
+```kotlin
+if (!pulsar.hapticCapabilities().hasPrimitiveSupport) {
+  pulsar.enableImpulseCompositionMode(false)
 }
 ```
 

--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -763,6 +763,7 @@ Configuration methods available directly on the `Pulsar` instance. All return a 
 | `isHapticsSupported()`                                        | Returns `true` if the device supports haptics                                                |
 | `canPlayHaptics()`                                            | Returns `true` when haptics can play right now                                               |
 | `hapticSupport()`                                             | Returns the device's [`HapticSupport`](#hapticsupport)                                       |
+| `hapticCapabilities()`                                        | Returns the [`HapticCapabilities`](#hapticcapabilities) behind that level                    |
 | `forceHapticsSupportLevel(HapticSupport level)`               | (Android only) Override the detected support level. Intended for testing fallback behavior.  |
 | `enableImpulseCompositionMode(bool state)`                    | (Android only) Enable or disable impulse composition mode                                    |
 | `setRealtimeComposerStrategy(RealtimeComposerStrategy s)`     | (Android only) Set the default [`RealtimeComposerStrategy`](#realtimecomposerstrategy)       |
@@ -903,6 +904,42 @@ final pulsar = Pulsar();
 
 if ((await pulsar.hapticSupport()).index >= HapticSupport.standardSupport.index) {
   await pulsar.getPresets().dogBark();
+}
+```
+
+### HapticCapabilities
+
+The individual platform capabilities behind [`HapticSupport`](#hapticsupport), returned by
+`pulsar.hapticCapabilities()`.
+
+```dart
+class HapticCapabilities {
+  final bool hasAmplitudeControl;
+  final bool hasPrimitiveSupport;
+  final bool isEnvelopeSupported;
+  final bool isFrequencyProfileSupported;
+  final int minControlPointDurationMillis;
+}
+```
+
+On Android each field maps to the corresponding `Vibrator` query. On iOS, Core Haptics exposes
+a single capability and the Taptic Engine renders the full event set uniformly, so
+`hasAmplitudeControl`, `hasPrimitiveSupport` and `isEnvelopeSupported` all mirror haptic
+support; `isFrequencyProfileSupported` is `false` and `minControlPointDurationMillis` is `0`.
+
+The support level is decided by amplitude control (and, on Android 16+, the frequency
+profile). **Primitive support is not part of it**, so a standard-support device can still lack
+composition primitives. If you render your own single-hit patterns, check `hasPrimitiveSupport`
+and fall back to a waveform rather than composing primitives the vibrator will silently drop.
+
+**Example**
+
+```dart
+final pulsar = Pulsar();
+final capabilities = await pulsar.hapticCapabilities();
+
+if (!capabilities.hasPrimitiveSupport) {
+  await pulsar.enableImpulseCompositionMode(false);
 }
 ```
 

--- a/docs/src/content/docs/sdk/ios.mdx
+++ b/docs/src/content/docs/sdk/ios.mdx
@@ -717,6 +717,7 @@ Configuration methods available directly on the `Pulsar` instance.
 | `shutDownEngine()`                      | Shut down the haptic engine                 |
 | `isHapticsSupported() -> Bool`          | Check if the device supports haptics        |
 | `isHapticsEnabled: Bool`                | Returns whether haptic feedback is currently enabled |
+| `hapticCapabilities() -> HapticCapabilities` | Returns what the device can render, see [`HapticCapabilities`](#hapticcapabilities) |
 
 ### Example
 
@@ -796,6 +797,27 @@ class DiscretePoint: NSObject, Codable {
 ```
 
 Use `discretePattern` for distinct taps and impacts. Use `continuousPattern` envelopes to shape a sustained haptic over time.
+
+### HapticCapabilities
+
+What the device's haptic hardware can render, returned by `pulsar.hapticCapabilities()`.
+
+```swift
+class HapticCapabilities: NSObject {
+  let hasAmplitudeControl: Bool
+  let hasPrimitiveSupport: Bool
+  let isEnvelopeSupported: Bool
+  let isFrequencyProfileSupported: Bool
+  let minControlPointDurationMillis: Double
+}
+```
+
+Core Haptics exposes a single `supportsHaptics` capability and the Taptic Engine renders the
+full event set uniformly, so `hasAmplitudeControl`, `hasPrimitiveSupport` and
+`isEnvelopeSupported` all mirror `isHapticsSupported()`. `isFrequencyProfileSupported` is
+`false` (Core Haptics models sharpness rather than exposing a frequency profile) and
+`minControlPointDurationMillis` is `0`. The type is shared with the Android SDK, where the
+fields carry per-device values.
 
 ### Preset
 

--- a/docs/src/content/docs/sdk/kmp.mdx
+++ b/docs/src/content/docs/sdk/kmp.mdx
@@ -721,6 +721,7 @@ Configuration methods available directly on the `Pulsar` instance.
 | `isHapticsSupported()`                                          | Returns `true` if the device supports haptics                                                |
 | `canPlayHaptics()`                                              | Returns `true` when haptics can play right now                                               |
 | `hapticSupport(): CompatibilityMode`                            | Returns the device's [`CompatibilityMode`](#compatibilitymode)                               |
+| `hapticCapabilities(): HapticCapabilities`                      | Returns the [`HapticCapabilities`](#hapticcapabilities) behind that level                    |
 | `forceHapticsSupportLevel(mode: CompatibilityMode)`             | (Android only) Override the detected support level. Intended for testing fallback behavior.  |
 | `enableImpulseCompositionMode(state: Boolean)`                  | (Android only) Enable or disable impulse composition mode                                    |
 | `realtimeComposerStrategy` (property)                           | (Android only) Get or set the default [`RealtimeComposerStrategy`](#realtimecomposerstrategy) |
@@ -838,6 +839,41 @@ val pulsar = Pulsar.create()
 
 if (pulsar.hapticSupport() >= CompatibilityMode.STANDARD_SUPPORT) {
   pulsar.getPresets().dogBark()
+}
+```
+
+### HapticCapabilities
+
+The individual platform capabilities behind [`CompatibilityMode`](#compatibilitymode),
+returned by `pulsar.hapticCapabilities()`.
+
+```kotlin
+data class HapticCapabilities(
+  val hasAmplitudeControl: Boolean,
+  val hasPrimitiveSupport: Boolean,
+  val isEnvelopeSupported: Boolean,
+  val isFrequencyProfileSupported: Boolean,
+  val minControlPointDurationMillis: Long,
+)
+```
+
+On Android each field maps to the corresponding `Vibrator` query. On iOS, Core Haptics exposes
+a single capability and the Taptic Engine renders the full event set uniformly, so
+`hasAmplitudeControl`, `hasPrimitiveSupport` and `isEnvelopeSupported` all mirror haptic
+support; `isFrequencyProfileSupported` is `false` and `minControlPointDurationMillis` is `0`.
+
+The support level is decided by amplitude control (and, on Android 16+, the frequency
+profile). **Primitive support is not part of it**, so a standard-support device can still lack
+composition primitives. If you render your own single-hit patterns, check `hasPrimitiveSupport`
+and fall back to a waveform rather than composing primitives the vibrator will silently drop.
+
+**Example**
+
+```kotlin
+val pulsar = Pulsar.create()
+
+if (!pulsar.hapticCapabilities().hasPrimitiveSupport) {
+  pulsar.enableImpulseCompositionMode(false)
 }
 ```
 

--- a/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
+++ b/flutter/pulsar/android/src/main/kotlin/com/swmansion/pulsar/flutter/PulsarPlugin.kt
@@ -215,6 +215,19 @@ class PulsarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success(p.hapticSupport().ordinal)
             }
 
+            "Pulsar_hapticCapabilities" -> {
+                val capabilities = p.hapticCapabilities()
+                result.success(
+                    mapOf(
+                        "hasAmplitudeControl" to capabilities.hasAmplitudeControl,
+                        "hasPrimitiveSupport" to capabilities.hasPrimitiveSupport,
+                        "isEnvelopeSupported" to capabilities.isEnvelopeSupported,
+                        "isFrequencyProfileSupported" to capabilities.isFrequencyProfileSupported,
+                        "minControlPointDurationMillis" to capabilities.minControlPointDurationMillis,
+                    )
+                )
+            }
+
             "Pulsar_forceHapticsSupportLevel" -> {
                 val level = call.argument<Int>("level")
                     ?: return result.error("INVALID_ARGS", "level required", null)

--- a/flutter/pulsar/ios/Classes/PulsarPlugin.swift
+++ b/flutter/pulsar/ios/Classes/PulsarPlugin.swift
@@ -181,6 +181,16 @@ public class PulsarPlugin: NSObject, FlutterPlugin {
       let supported = pulsar.isHapticsSupported()
       result(supported ? 2 : 0)
 
+    case "Pulsar_hapticCapabilities":
+      let capabilities = pulsar.hapticCapabilities()
+      result([
+        "hasAmplitudeControl": capabilities.hasAmplitudeControl,
+        "hasPrimitiveSupport": capabilities.hasPrimitiveSupport,
+        "isEnvelopeSupported": capabilities.isEnvelopeSupported,
+        "isFrequencyProfileSupported": capabilities.isFrequencyProfileSupported,
+        "minControlPointDurationMillis": Int(capabilities.minControlPointDurationMillis),
+      ])
+
     case "Pulsar_forceHapticsSupportLevel":
       // No-op on iOS — CoreHaptics support level is hardware-determined.
       result(nil)

--- a/flutter/pulsar/lib/pulsar_method_channel.dart
+++ b/flutter/pulsar/lib/pulsar_method_channel.dart
@@ -136,6 +136,14 @@ class MethodChannelPulsar extends PulsarPlatform {
   }
 
   @override
+  Future<HapticCapabilities> hapticCapabilities() async {
+    final raw = await methodChannel.invokeMapMethod<String, dynamic>(
+      'Pulsar_hapticCapabilities',
+    );
+    return HapticCapabilities.fromMap(raw ?? const {});
+  }
+
+  @override
   Future<void> forceHapticsSupportLevel(HapticSupport level) => methodChannel
       .invokeMethod('Pulsar_forceHapticsSupportLevel', {'level': level.index});
 

--- a/flutter/pulsar/lib/pulsar_platform_interface.dart
+++ b/flutter/pulsar/lib/pulsar_platform_interface.dart
@@ -90,6 +90,9 @@ abstract class PulsarPlatform extends PlatformInterface {
   Future<HapticSupport> hapticSupport() =>
       throw UnimplementedError('hapticSupport() not implemented');
 
+  Future<HapticCapabilities> hapticCapabilities() =>
+      throw UnimplementedError('hapticCapabilities() not implemented');
+
   Future<void> forceHapticsSupportLevel(HapticSupport level) =>
       throw UnimplementedError('forceHapticsSupportLevel() not implemented');
 

--- a/flutter/pulsar/lib/pulsar_types.dart
+++ b/flutter/pulsar/lib/pulsar_types.dart
@@ -54,6 +54,33 @@ enum HapticSupport {
   advancedSupport,
 }
 
+class HapticCapabilities {
+  const HapticCapabilities({
+    required this.hasAmplitudeControl,
+    required this.hasPrimitiveSupport,
+    required this.isEnvelopeSupported,
+    required this.isFrequencyProfileSupported,
+    required this.minControlPointDurationMillis,
+  });
+
+  factory HapticCapabilities.fromMap(Map<dynamic, dynamic> map) =>
+      HapticCapabilities(
+        hasAmplitudeControl: map['hasAmplitudeControl'] as bool? ?? false,
+        hasPrimitiveSupport: map['hasPrimitiveSupport'] as bool? ?? false,
+        isEnvelopeSupported: map['isEnvelopeSupported'] as bool? ?? false,
+        isFrequencyProfileSupported:
+            map['isFrequencyProfileSupported'] as bool? ?? false,
+        minControlPointDurationMillis:
+            (map['minControlPointDurationMillis'] as num?)?.toInt() ?? 0,
+      );
+
+  final bool hasAmplitudeControl;
+  final bool hasPrimitiveSupport;
+  final bool isEnvelopeSupported;
+  final bool isFrequencyProfileSupported;
+  final int minControlPointDurationMillis;
+}
+
 /// Android-only haptic composition strategy.
 /// Ordinal values match the Android RealtimeComposerStrategy enum order.
 enum RealtimeComposerStrategy {

--- a/flutter/pulsar/lib/src/pulsar_api.dart
+++ b/flutter/pulsar/lib/src/pulsar_api.dart
@@ -107,6 +107,9 @@ class Pulsar {
   Future<bool> isHapticsSupported() async =>
       (await hapticSupport()) != HapticSupport.noSupport;
 
+  Future<HapticCapabilities> hapticCapabilities() =>
+      PulsarPlatform.instance.hapticCapabilities();
+
   /// Override haptic support level (useful for testing). Android only.
   Future<void> forceHapticsSupportLevel(HapticSupport level) =>
       PulsarPlatform.instance.forceHapticsSupportLevel(level);

--- a/flutter/pulsar/test/pulsar_method_channel_test.dart
+++ b/flutter/pulsar/test/pulsar_method_channel_test.dart
@@ -18,6 +18,15 @@ void main() {
           if (methodCall.method == 'Pulsar_hapticSupport') {
             return 3;
           }
+          if (methodCall.method == 'Pulsar_hapticCapabilities') {
+            return <String, dynamic>{
+              'hasAmplitudeControl': true,
+              'hasPrimitiveSupport': false,
+              'isEnvelopeSupported': false,
+              'isFrequencyProfileSupported': false,
+              'minControlPointDurationMillis': 35,
+            };
+          }
           return null;
         });
   });
@@ -81,5 +90,26 @@ void main() {
         'AlreadyNormalized',
       ],
     });
+  });
+
+  test('hapticCapabilities decodes the map the platform returns', () async {
+    final capabilities = await platform.hapticCapabilities();
+
+    expect(loggedCalls.single.method, 'Pulsar_hapticCapabilities');
+    expect(capabilities.hasAmplitudeControl, isTrue);
+    expect(capabilities.hasPrimitiveSupport, isFalse);
+    expect(capabilities.isEnvelopeSupported, isFalse);
+    expect(capabilities.isFrequencyProfileSupported, isFalse);
+    expect(capabilities.minControlPointDurationMillis, 35);
+  });
+
+  test('hapticCapabilities falls back to unsupported on a null reply', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async => null);
+
+    final capabilities = await platform.hapticCapabilities();
+
+    expect(capabilities.hasAmplitudeControl, isFalse);
+    expect(capabilities.minControlPointDurationMillis, 0);
   });
 }

--- a/flutter/pulsar/test/pulsar_test.dart
+++ b/flutter/pulsar/test/pulsar_test.dart
@@ -48,6 +48,16 @@ class MockPulsarPlatform
   Future<HapticSupport> hapticSupport() async => HapticSupport.standardSupport;
 
   @override
+  Future<HapticCapabilities> hapticCapabilities() async =>
+      const HapticCapabilities(
+        hasAmplitudeControl: true,
+        hasPrimitiveSupport: false,
+        isEnvelopeSupported: false,
+        isFrequencyProfileSupported: false,
+        minControlPointDurationMillis: 35,
+      );
+
+  @override
   Future<int> patternParsePattern(PatternData data, {int? composerId}) async {
     final resolvedComposerId = composerId ?? nextComposerId++;
     parsedComposerIds.add(resolvedComposerId);
@@ -145,6 +155,20 @@ void main() {
 
   test('$MethodChannelPulsar is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelPulsar>());
+  });
+
+  test('hapticCapabilities delegates to the platform interface', () async {
+    final pulsar = Pulsar();
+    final fakePlatform = MockPulsarPlatform();
+    PulsarPlatform.instance = fakePlatform;
+
+    final capabilities = await pulsar.hapticCapabilities();
+
+    expect(await pulsar.hapticSupport(), HapticSupport.standardSupport);
+    expect(capabilities.hasPrimitiveSupport, isFalse);
+    expect(capabilities.minControlPointDurationMillis, 35);
+
+    PulsarPlatform.instance = initialPlatform;
   });
 
   test('Pulsar presets delegate to the platform interface', () async {

--- a/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Pulsar.swift
@@ -62,6 +62,17 @@ import UIKit
     return engine.isHapticsSupported()
   }
 
+  @objc public func hapticCapabilities() -> HapticCapabilities {
+    let coreHapticsSupported = engine.isHapticsSupported()
+    return HapticCapabilities(
+      hasAmplitudeControl: coreHapticsSupported,
+      hasPrimitiveSupport: coreHapticsSupported,
+      isEnvelopeSupported: coreHapticsSupported,
+      isFrequencyProfileSupported: false,
+      minControlPointDurationMillis: 0
+    )
+  }
+
   @objc public func canPlayHaptics() -> Bool {
     return engine.canPlayHaptics()
   }

--- a/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Types/Types.swift
@@ -3,6 +3,27 @@ import Foundation
 /// Represents a point in a haptic pattern's continuous curve
 /// - time: Time in milliseconds (ms)
 /// - value: Normalized value between 0.0 and 1.0
+@objc public class HapticCapabilities: NSObject {
+  @objc public let hasAmplitudeControl: Bool
+  @objc public let hasPrimitiveSupport: Bool
+  @objc public let isEnvelopeSupported: Bool
+  @objc public let isFrequencyProfileSupported: Bool
+  @objc public let minControlPointDurationMillis: Double
+  @objc public init(
+    hasAmplitudeControl: Bool,
+    hasPrimitiveSupport: Bool,
+    isEnvelopeSupported: Bool,
+    isFrequencyProfileSupported: Bool,
+    minControlPointDurationMillis: Double
+  ) {
+    self.hasAmplitudeControl = hasAmplitudeControl
+    self.hasPrimitiveSupport = hasPrimitiveSupport
+    self.isEnvelopeSupported = isEnvelopeSupported
+    self.isFrequencyProfileSupported = isFrequencyProfileSupported
+    self.minControlPointDurationMillis = minControlPointDurationMillis
+  }
+}
+
 @objc public class ValuePoint: NSObject, Codable {
   @objc public let time: Double
   @objc public let value: Float

--- a/iOS/Pulsar/Tests/PulsarTests/PulsarAPITests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/PulsarAPITests.swift
@@ -18,6 +18,16 @@ import Foundation
         #expect(pulsar.canPlayHaptics() == false)
     }
 
+    @Test func hapticCapabilitiesFollowHapticSupport() {
+        let pulsar = Pulsar()
+        let capabilities = pulsar.hapticCapabilities()
+        #expect(capabilities.hasAmplitudeControl == pulsar.isHapticsSupported())
+        #expect(capabilities.hasPrimitiveSupport == pulsar.isHapticsSupported())
+        #expect(capabilities.isEnvelopeSupported == pulsar.isHapticsSupported())
+        #expect(capabilities.isFrequencyProfileSupported == false)
+        #expect(capabilities.minControlPointDurationMillis == 0)
+    }
+
     @Test func hapticsAreEnabledByDefaultAndToggle() {
         let pulsar = Pulsar()
         #expect(pulsar.isHapticsEnabled == true)

--- a/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
+++ b/kmp/Pulsar/library/src/androidMain/kotlin/com/swmansion/pulsar/AndroidPulsarFactory.kt
@@ -77,6 +77,17 @@ private class AndroidPulsarHandle(
 
     override fun hapticSupport(): CompatibilityMode = nativePulsar.hapticSupport().toCommonCompatibilityMode()
 
+    override fun hapticCapabilities(): HapticCapabilities =
+        nativePulsar.hapticCapabilities().let {
+            HapticCapabilities(
+                hasAmplitudeControl = it.hasAmplitudeControl,
+                hasPrimitiveSupport = it.hasPrimitiveSupport,
+                isEnvelopeSupported = it.isEnvelopeSupported,
+                isFrequencyProfileSupported = it.isFrequencyProfileSupported,
+                minControlPointDurationMillis = it.minControlPointDurationMillis,
+            )
+        }
+
     override fun forceHapticsSupportLevel(mode: CompatibilityMode) {
         nativePulsar.forceHapticsSupportLevel(mode.toAndroidCompatibilityMode())
     }

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Pulsar.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Pulsar.kt
@@ -68,6 +68,8 @@ class Pulsar private constructor(
 
     fun hapticSupport(): CompatibilityMode = handle.hapticSupport()
 
+    fun hapticCapabilities(): HapticCapabilities = handle.hapticCapabilities()
+
     fun forceHapticsSupportLevel(mode: CompatibilityMode) {
         handle.forceHapticsSupportLevel(mode)
     }

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/PulsarRuntime.kt
@@ -44,6 +44,14 @@ interface PulsarPlatformHandle {
     fun canPlayHaptics(): Boolean
     fun hapticSupport(): CompatibilityMode =
         if (isHapticsSupported()) CompatibilityMode.ADVANCED_SUPPORT else CompatibilityMode.NO_SUPPORT
+    fun hapticCapabilities(): HapticCapabilities =
+        HapticCapabilities(
+            hasAmplitudeControl = isHapticsSupported(),
+            hasPrimitiveSupport = isHapticsSupported(),
+            isEnvelopeSupported = isHapticsSupported(),
+            isFrequencyProfileSupported = false,
+            minControlPointDurationMillis = 0,
+        )
     fun forceHapticsSupportLevel(mode: CompatibilityMode) {}
     fun getRealtimeComposerStrategy(): RealtimeComposerStrategy = RealtimeComposerStrategy.ENVELOPE
     fun setRealtimeComposerStrategy(strategy: RealtimeComposerStrategy) {}

--- a/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
+++ b/kmp/Pulsar/library/src/commonMain/kotlin/com/swmansion/pulsar/Types.kt
@@ -13,6 +13,14 @@ enum class CompatibilityMode {
     ADVANCED_SUPPORT,
 }
 
+data class HapticCapabilities(
+    val hasAmplitudeControl: Boolean,
+    val hasPrimitiveSupport: Boolean,
+    val isEnvelopeSupported: Boolean,
+    val isFrequencyProfileSupported: Boolean,
+    val minControlPointDurationMillis: Long,
+)
+
 enum class RealtimeComposerStrategy {
     ENVELOPE,
     PRIMITIVE_TICK,

--- a/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
+++ b/kmp/Pulsar/library/src/commonTest/kotlin/com/swmansion/pulsar/PulsarFacadeTest.kt
@@ -81,11 +81,22 @@ class PulsarFacadeTest {
         assertTrue(pulsar.isHapticsSupported())
         assertTrue(pulsar.canPlayHaptics())
         assertEquals(CompatibilityMode.STANDARD_SUPPORT, pulsar.hapticSupport())
+        assertEquals(
+            HapticCapabilities(
+                hasAmplitudeControl = true,
+                hasPrimitiveSupport = false,
+                isEnvelopeSupported = false,
+                isFrequencyProfileSupported = false,
+                minControlPointDurationMillis = 35,
+            ),
+            pulsar.hapticCapabilities(),
+        )
         assertEquals(CompatibilityMode.STANDARD_SUPPORT, factory.handle.forcedSupportLevel)
         assertTrue(factory.handle.impulseCompositionModeEnabled)
         pulsar.shutDownEngine()
         assertTrue(factory.handle.engineShutDown)
     }
+
 }
 
 private class FakeFactory : PulsarPlatformFactory {
@@ -159,6 +170,15 @@ private class FakeHandle : PulsarPlatformHandle {
     override fun canPlayHaptics(): Boolean = true
 
     override fun hapticSupport(): CompatibilityMode = supportLevel
+
+    override fun hapticCapabilities(): HapticCapabilities =
+        HapticCapabilities(
+            hasAmplitudeControl = true,
+            hasPrimitiveSupport = false,
+            isEnvelopeSupported = false,
+            isFrequencyProfileSupported = false,
+            minControlPointDurationMillis = 35,
+        )
 
     override fun forceHapticsSupportLevel(mode: CompatibilityMode) {
         supportLevel = mode

--- a/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarReactNative.kt
+++ b/react-native/react-native-pulsar/android/src/main/java/com/swmansion/pulsar/reactnative/PulsarReactNative.kt
@@ -5,24 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.swmansion.pulsar.Pulsar
 import com.swmansion.pulsar.presets.PresetsWrapper
 
-data class HapticCapabilities(
-    val hasAmplitudeControl: Boolean,
-    val hasPrimitiveSupport: Boolean,
-    val isEnvelopeSupported: Boolean,
-    val isFrequencyProfileSupported: Boolean,
-    val minControlPointDurationMillis: Long,
-)
-
 class PulsarReactNative(context: Context) : Pulsar(context) {
     override fun createPresets(): PresetsWrapper =
         PresetsWrapper(this, ReactNativeActivityProvider(context as ReactApplicationContext), engine)
-
-    fun hapticCapabilities(): HapticCapabilities =
-        HapticCapabilities(
-            hasAmplitudeControl = engine.isAmplitudeSupported(),
-            hasPrimitiveSupport = engine.hasPrimitiveSupport(),
-            isEnvelopeSupported = engine.isEnvelopeSupported(),
-            isFrequencyProfileSupported = engine.isFrequencyProfileSupported(),
-            minControlPointDurationMillis = engine.getMinControlPointDurationMillis(),
-        )
 }

--- a/react-native/react-native-pulsar/ios/Haptics.mm
+++ b/react-native/react-native-pulsar/ios/Haptics.mm
@@ -248,13 +248,13 @@ RCT_EXPORT_MODULE()
 }
 
 - (nonnull NSDictionary *)Pulsar_hapticCapabilities {
-  NSNumber *coreHapticsSupported = @([pulsar_ isHapticsSupported]);
+  HapticCapabilities *capabilities = [pulsar_ hapticCapabilities];
   return @{
-    @"hasAmplitudeControl" : coreHapticsSupported,
-    @"hasPrimitiveSupport" : coreHapticsSupported,
-    @"isEnvelopeSupported" : coreHapticsSupported,
-    @"isFrequencyProfileSupported" : @(NO),
-    @"minControlPointDurationMillis" : @(0),
+    @"hasAmplitudeControl" : @(capabilities.hasAmplitudeControl),
+    @"hasPrimitiveSupport" : @(capabilities.hasPrimitiveSupport),
+    @"isEnvelopeSupported" : @(capabilities.isEnvelopeSupported),
+    @"isFrequencyProfileSupported" : @(capabilities.isFrequencyProfileSupported),
+    @"minControlPointDurationMillis" : @(capabilities.minControlPointDurationMillis),
   };
 }
 


### PR DESCRIPTION
## Motivation

`hapticSupport()` collapses the hardware into one ordered level. That is the right check for "how rich a pattern can this device play", but it cannot answer two questions an app hits once it renders its own patterns:

1. **Primitive support is not part of the level.** It is derived from amplitude control (and, on Android 16+, the frequency profile), so a `STANDARD_SUPPORT` device can still lack `VibrationEffect.Composition` primitives — and Android drops an unsupported composition *silently*, with nothing in the logs.
2. **`minControlPointDurationMillis` is unreachable**, though it is what you need when authoring envelopes at runtime.

#272 exposed these to React Native by adding accessors to the `PulsarReactNative` subclass, specifically to avoid a core release. @tslater flagged in that PR that they may belong on core `Pulsar` instead, so the Flutter and KMP bridges get them too. This PR follows up on that, now that #272 has merged.

## API

The same five fields on every SDK:

```
hasAmplitudeControl, hasPrimitiveSupport, isEnvelopeSupported,
isFrequencyProfileSupported, minControlPointDurationMillis
```

| SDK | Call |
| --- | --- |
| Android | `pulsar.hapticCapabilities(): HapticCapabilities` |
| iOS | `pulsar.hapticCapabilities() -> HapticCapabilities` |
| Flutter | `await pulsar.hapticCapabilities()` |
| KMP | `pulsar.hapticCapabilities(): HapticCapabilities` |
| React Native | `Settings.getHapticCapabilities()` (unchanged from #272) |

```dart
final capabilities = await pulsar.hapticCapabilities();

if (!capabilities.hasPrimitiveSupport) {
  await pulsar.enableImpulseCompositionMode(false);
}
```

## Implementation notes

- **Android core** reads each field from the `HapticEngineWrapper` getters that already decide the compatibility mode. `HapticCapabilities` lives in `com.swmansion.pulsar.types` next to `CompatibilityMode`.
- **iOS core** exposes an `@objc` `HapticCapabilities` class so both the RN bridge (ObjC) and the Flutter plugin (Swift) can read it. Core Haptics exposes a single capability and the Taptic Engine renders the full event set uniformly, so the render flags follow `isHapticsSupported()`; `isFrequencyProfileSupported` is `false` and `minControlPointDurationMillis` is `0`.
- **KMP** puts that same derivation on `PulsarPlatformHandle` as the interface default, so iOS and any custom factory degrade identically, and `AndroidPulsarFactory` overrides it with the real per-device values.
- **React Native** keeps the public API from #272 and now reads it from core; `PulsarReactNative` goes back to just `createPresets`.
- Docs added to all four SDK pages; the React Native page already has the section from #272.

## Verification

| Check | Result |
| --- | --- |
| Android core `:Pulsar:assembleDebug` + `testDebugUnitTest` | pass |
| iOS core `xcodebuild test -scheme Pulsar-Package` | 59 tests, 11 suites, pass (incl. a new capabilities case) |
| KMP `:library:assemble`, `testAndroidHostTest`, `iosSimulatorArm64Test` | pass (incl. a new facade case) |
| Flutter `flutter analyze` / `flutter test` | clean / 11 pass (3 new cases) |
| Flutter example Android APK | builds |
| React Native `npm test` / `tsc` | 21 pass / clean |
| RN example: Android `assembleDebug`, iOS `xcodebuild` | both build against the moved core API |
| Docs `npm run build` | passes |

**Not verified: the Flutter iOS build.** `flutter/pulsar/example` fails to compile on `main` already — `PulsarPlugin.swift:13` uses `LoadedBundle`, which the published `PulsarHaptics` 1.4.0 pod does not carry (bundles landed after that release), and `flutter/pulsar/ios/pulsar_haptics.podspec` has no `USE_LOCAL_PULSAR_IOS` escape hatch like the React Native podspec does. The Swift added here calls the same core API that the RN iOS build does exercise, but a Flutter iOS compile needs either a core pod release or local-sources support in that podspec — worth a follow-up either way.

**Release note:** this puts `hapticCapabilities()` on core, so it needs the pending Android/iOS SDK releases before the published artifacts carry it. In-repo builds already default to local sources, so nothing here is blocked today.
