### PR TITLE
feat(flutter): migrate the Android build to built-in Kotlin

### DIFF
--- a/docs/src/content/docs/sdk/flutter.mdx
+++ b/docs/src/content/docs/sdk/flutter.mdx
@@ -46,8 +46,8 @@ The Pulsar Flutter SDK exposes the same building blocks as the native SDKs — `
 
 ## Requirements
 
-- Flutter 3.3+
-- Dart 3.11+
+- Flutter 3.44+
+- Dart 3.12+
 - Android API 24+ (Android 7.0)
 - iOS 13+
 

--- a/flutter/pulsar/CHANGELOG.md
+++ b/flutter/pulsar/CHANGELOG.md
@@ -20,3 +20,12 @@
 * Bump the native cores to pulsar-ios `1.4.0` and pulsar-android `1.3.0`.
 
   No Dart API changes — this release is packaging and native dependency work only.
+
+## 0.2.0
+
+* Update the minimum supported SDK version to Flutter 3.44 / Dart 3.12.
+* Migrate the Android build to built-in Kotlin: the plugin no longer applies the Kotlin
+  Gradle Plugin, pins its own AGP/KGP classpath, or uses the legacy `kotlinOptions` block,
+  so apps on Flutter 3.44+ and AGP 9 build without the "plugins that apply KGP" warning.
+
+  No Dart API changes — this release is Android build configuration only.

--- a/flutter/pulsar/README.md
+++ b/flutter/pulsar/README.md
@@ -13,6 +13,11 @@ A haptic feedback SDK for Flutter. Pulsar gives you 150+ ready-to-play presets, 
 - **Audio simulation** – Optional companion audio so haptics feel right even on devices with weaker vibration motors
 - **Cross-platform** – The same Dart API runs on iOS 13+ and Android API 24+
 
+## Requirements
+
+- Flutter 3.44+ / Dart 3.12+ (`0.1.x` supports Flutter 3.29+)
+- Android API 24+ (Android 7.0), iOS 13+
+
 ## Quick start
 
 > **Note:** This package is published as **`pulsar_haptics`**, not `pulsar`. The shorter `pulsar` name on pub.dev was reserved by an unrelated author before this project was published and is not maintained by Software Mansion. Always depend on `pulsar_haptics`.

--- a/flutter/pulsar/android/build.gradle.kts
+++ b/flutter/pulsar/android/build.gradle.kts
@@ -2,15 +2,19 @@ group = "com.swmansion.pulsar"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    val kotlinVersion = "2.2.20"
-    repositories {
-        google()
-        mavenCentral()
-    }
+    val compilingLocalPulsarSources =
+        (rootProject.findProperty("USE_LOCAL_PULSAR_ANDROID")
+            ?: System.getenv("USE_LOCAL_PULSAR_ANDROID")) == "1"
 
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.11.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    if (compilingLocalPulsarSources) {
+        repositories {
+            google()
+            mavenCentral()
+        }
+
+        dependencies {
+            classpath("org.jetbrains.kotlin:kotlin-serialization:2.2.20")
+        }
     }
 }
 
@@ -23,8 +27,6 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
 }
 
 fun getStringPropertyOrEnv(name: String, defaultValue: String): String {
@@ -43,6 +45,7 @@ if (useLocalPulsarAndroid) {
     if (!localPulsarAndroidSourceDir.exists()) {
         throw GradleException("USE_LOCAL_PULSAR_ANDROID=1 but local Pulsar Android sources were not found at $localPulsarAndroidSourceDir")
     }
+    apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
     logger.lifecycle("Using local Pulsar Android sources from $localPulsarAndroidSourceDir")
 } else {
     logger.lifecycle("Using published Pulsar Android artifact com.swmansion:pulsar:$pulsarAndroidVersion")
@@ -60,10 +63,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     sourceSets {
@@ -97,6 +96,12 @@ android {
                 }
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/flutter/pulsar/pubspec.yaml
+++ b/flutter/pulsar/pubspec.yaml
@@ -13,8 +13,8 @@ topics:
   - android
 
 environment:
-  sdk: ^3.7.0
-  flutter: '>=3.29.0'
+  sdk: ^3.12.0
+  flutter: '>=3.44.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #215.

## Why

Flutter 3.44+ warns that plugins applying the Kotlin Gradle Plugin will fail to build in a future release, and names `pulsar_haptics`:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): pulsar_haptics
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
```

This takes option 1 from the [plugin-author guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) — the clean break — rather than conditionally applying KGP below AGP 9. The compat path costs a permanently dual build config and a doubled test matrix; at 708 downloads/30 days, with 3.44 already being current-minus-one stable (released 2026-05-18), it would serve a very small number of projects.

## What changed

`flutter/pulsar/android/build.gradle.kts`:
- removed `id("kotlin-android")` and the pinned AGP/KGP `buildscript` classpath — the host app's toolchain compiles the module now
- removed the legacy `android { kotlinOptions { … } }` block in favour of root-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }`
- the `buildscript` block now only exists for the dev-only `USE_LOCAL_PULSAR_ANDROID=1` path

`pubspec.yaml`: `sdk: ^3.12.0`, `flutter: '>=3.44.0'`. Plus a `0.2.0` CHANGELOG entry, a Requirements section in the plugin README, and a fix to the stale "Flutter 3.3+ / Dart 3.11+" line in the docs.

**Breaking:** consumers below Flutter 3.44 / Dart 3.12 will keep resolving to `0.1.x`. No Dart API change.

## Verification

Ran against Flutter 3.47.2.

- **Warning is fixed.** Flutter detects this by regex over the plugin's `plugins { }` block (`kgpRegexKotlin` in `FlutterPluginUtils.kt`), not runtime state. Running that regex over both versions: before → `hasKgpPlugin=true`, listed in the warning; after → `hasKgpPlugin=false`, not listed.
- **Built-in Kotlin compiles the plugin.** Under a throwaway AGP 9.4.0 / Gradle 9.6.0 / `android.builtInKotlin=true` example app, Gradle reported `':pulsar_haptics:compileDebugKotlin' (registered by plugin 'com.android.internal.library')` — AGP's built-in Kotlin, no KGP. That experiment is not part of this PR.
- **Dev path builds green** on the current toolchain: `USE_LOCAL_PULSAR_ANDROID=1 flutter build apk --debug` → `✓ Built app-debug.apk`.

## Reviewer notes

- **No version bump here.** Repo convention is a separate `chore(flutter): release version X` commit (cf. #175), so `pubspec.yaml`/`sdk-versions.json` still say `0.1.0` while the CHANGELOG documents `0.2.0`. Worth noting `sdk-versions.json` says `0.1.0` but tag `pulsar_haptics-flutter-0.1.1` exists — pre-existing drift.
- **`USE_LOCAL_PULSAR_ANDROID=0` does not compile**, failing on `loadBundle`, `SoundData`, `LoadedBundle`, `hapticCapabilities`. This is pre-existing and unrelated: the published `com.swmansion:pulsar:1.3.0` predates the bundle loaders and the capabilities work in 4a287ba5. CI defaults `use_local_pulsar: true`, so it stays green — but the consumer path can't be compile-verified end to end until the Android artifact is republished.
- **The local-sources path won't work under AGP 9's built-in Kotlin.** It adds `Android/Pulsar/src/main/java` via `java.srcDir(...)`; KGP swept java srcDirs into Kotlin compilation, built-in Kotlin does not, and `AndroidSourceSet` exposes no `kotlin` extension to register them on. Flagged in a comment. Dev-only and unreachable today.
- **Example apps deliberately untouched.** Migrating them to AGP 9 is blocked anyway — Flutter 3.47 rejects AGP 9's bundled Kotlin 2.2.10 as below its 2.2.20 minimum (9.0.1 through 9.4.0), so it only builds with `--android-skip-build-dependency-validation`. Worth a follow-up once that settles.

@aleclarson offered to verify a release candidate.