### PR TITLE
ci: stage npm releases for approval, unify publish workflow names

### DIFF
--- a/.github/workflows/publish-android-library.yml
+++ b/.github/workflows/publish-android-library.yml
@@ -1,4 +1,4 @@
-name: Publish Android to Maven
+name: publish-android-library
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-android-lottie.yml
+++ b/.github/workflows/publish-android-lottie.yml
@@ -1,4 +1,4 @@
-name: Publish Android Lottie to Maven
+name: publish-android-lottie
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-flutter-lottie.yml
+++ b/.github/workflows/publish-flutter-lottie.yml
@@ -1,4 +1,4 @@
-name: Publish Flutter Lottie package to pub.dev
+name: publish-flutter-lottie
 
 on:
   push:

--- a/.github/workflows/publish-flutter-pub.yml
+++ b/.github/workflows/publish-flutter-pub.yml
@@ -1,4 +1,4 @@
-name: Publish Flutter package to pub.dev
+name: publish-flutter-pub
 
 on:
   push:

--- a/.github/workflows/publish-ios-cocoapods.yml
+++ b/.github/workflows/publish-ios-cocoapods.yml
@@ -1,4 +1,4 @@
-name: Publish iOS package to CocoaPods
+name: publish-ios-cocoapods
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-ios-lottie.yml
+++ b/.github/workflows/publish-ios-lottie.yml
@@ -1,4 +1,4 @@
-name: Publish iOS Lottie to CocoaPods
+name: publish-ios-lottie
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-kmp-library.yml
+++ b/.github/workflows/publish-kmp-library.yml
@@ -1,4 +1,4 @@
-name: Publish KMP to Maven
+name: publish-kmp-library
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-kmp-lottie.yml
+++ b/.github/workflows/publish-kmp-lottie.yml
@@ -1,4 +1,4 @@
-name: Publish KMP Lottie to Maven
+name: publish-kmp-lottie
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-pulsar-gen-gradle.yml
+++ b/.github/workflows/publish-pulsar-gen-gradle.yml
@@ -1,4 +1,4 @@
-name: Publish pulsar-gen Gradle plugin to Maven
+name: publish-pulsar-gen-gradle
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-pulsar-gen.yml
+++ b/.github/workflows/publish-pulsar-gen.yml
@@ -14,11 +14,6 @@ on:
           - rc
           - beta
         default: 'auto'
-      dry-run:
-        description: 'Dry run'
-        required: false
-        type: boolean
-        default: 'true'
 
 jobs:
   publish:
@@ -98,5 +93,5 @@ jobs:
           version: ${{ steps.release.outputs.version }}
           npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
           release-mode: stage
-          dry-run: ${{ github.event.inputs.dry-run || 'true' }}
+          dry-run: 'false'
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-pulsar-gen.yml
+++ b/.github/workflows/publish-pulsar-gen.yml
@@ -1,17 +1,19 @@
-name: Publish pulsar-gen to npm
+name: publish-pulsar-gen
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'npm tag to publish under'
+        description: 'npm dist-tag (auto resolves latest vs legacy from the version)'
         required: false
         type: choice
         options:
+          - auto
           - latest
+          - legacy
           - rc
           - beta
-        default: 'latest'
+        default: 'auto'
       dry-run:
         description: 'Dry run'
         required: false
@@ -88,12 +90,13 @@ jobs:
           echo "Publishing version $VERSION (from sdk-versions.json)"
 
       - name: Publish stable
-        uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
+        uses: software-mansion/npm-package-publish@d62244c0680bfda13644957dd83c85bd5cbb38d0
         with:
           package-name: pulsar-gen
           package-json-path: tools/pulsar-gen/package.json
           release-type: stable
           version: ${{ steps.release.outputs.version }}
-          tag: ${{ github.event.inputs.tag || 'latest' }}
+          npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
+          release-mode: stage
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-rn-lottie.yml
+++ b/.github/workflows/publish-rn-lottie.yml
@@ -1,16 +1,18 @@
-name: Publish React Native Lottie to npm
+name: publish-rn-lottie
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'npm tag to publish under'
+        description: 'npm dist-tag (auto resolves latest vs legacy from the version)'
         required: false
         type: choice
         options:
+          - auto
           - latest
+          - legacy
           - rc
-        default: 'latest'
+        default: 'auto'
       dry-run:
         description: 'Dry run'
         required: false
@@ -47,12 +49,13 @@ jobs:
           echo "Publishing version $VERSION (from sdk-versions.json)"
 
       - name: Publish stable
-        uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
+        uses: software-mansion/npm-package-publish@d62244c0680bfda13644957dd83c85bd5cbb38d0
         with:
           package-name: react-native-pulsar-lottie
           package-json-path: react-native/react-native-pulsar-lottie/package.json
           release-type: stable
           version: ${{ steps.release.outputs.version }}
-          tag: ${{ github.event.inputs.tag || 'latest' }}
+          npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
+          release-mode: stage
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm install

--- a/.github/workflows/publish-rn-lottie.yml
+++ b/.github/workflows/publish-rn-lottie.yml
@@ -13,11 +13,6 @@ on:
           - legacy
           - rc
         default: 'auto'
-      dry-run:
-        description: 'Dry run'
-        required: false
-        type: boolean
-        default: 'true'
 
 jobs:
   publish:
@@ -57,5 +52,5 @@ jobs:
           version: ${{ steps.release.outputs.version }}
           npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
           release-mode: stage
-          dry-run: ${{ github.event.inputs.dry-run || 'true' }}
+          dry-run: 'false'
           install-dependencies-command: npm install

--- a/.github/workflows/publish-rn-stable.yml
+++ b/.github/workflows/publish-rn-stable.yml
@@ -1,16 +1,18 @@
-name: Publish React Native to npm
+name: publish-rn-stable
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'npm tag to publish under'
+        description: 'npm dist-tag (auto resolves latest vs legacy from the version)'
         required: false
         type: choice
         options:
+          - auto
           - latest
+          - legacy
           - rc
-        default: 'latest'
+        default: 'auto'
       dry-run:
         description: 'Dry run'
         required: false
@@ -47,12 +49,13 @@ jobs:
           echo "Publishing version $VERSION (from sdk-versions.json)"
 
       - name: Publish stable
-        uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
+        uses: software-mansion/npm-package-publish@d62244c0680bfda13644957dd83c85bd5cbb38d0
         with:
           package-name: react-native-pulsar
           package-json-path: react-native/react-native-pulsar/package.json
           release-type: stable
           version: ${{ steps.release.outputs.version }}
-          tag: ${{ github.event.inputs.tag || 'latest' }}
+          npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
+          release-mode: stage
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-rn-stable.yml
+++ b/.github/workflows/publish-rn-stable.yml
@@ -13,11 +13,6 @@ on:
           - legacy
           - rc
         default: 'auto'
-      dry-run:
-        description: 'Dry run'
-        required: false
-        type: boolean
-        default: 'true'
 
 jobs:
   publish:
@@ -57,5 +52,5 @@ jobs:
           version: ${{ steps.release.outputs.version }}
           npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
           release-mode: stage
-          dry-run: ${{ github.event.inputs.dry-run || 'true' }}
+          dry-run: 'false'
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-web-haptics.yml
+++ b/.github/workflows/publish-web-haptics.yml
@@ -1,17 +1,19 @@
-name: Publish pulsar-haptics to npm
+name: publish-web-haptics
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'npm tag to publish under'
+        description: 'npm dist-tag (auto resolves latest vs legacy from the version)'
         required: false
         type: choice
         options:
+          - auto
           - latest
+          - legacy
           - rc
           - beta
-        default: 'latest'
+        default: 'auto'
       dry-run:
         description: 'Dry run'
         required: false
@@ -57,12 +59,13 @@ jobs:
           echo "Publishing version $VERSION (from sdk-versions.json)"
 
       - name: Publish stable
-        uses: software-mansion/npm-package-publish@1bb885ec49bed729c8c1ec95a11a285d89f1bf45
+        uses: software-mansion/npm-package-publish@d62244c0680bfda13644957dd83c85bd5cbb38d0
         with:
           package-name: pulsar-haptics
           package-json-path: web/Pulsar/package.json
           release-type: stable
           version: ${{ steps.release.outputs.version }}
-          tag: ${{ github.event.inputs.tag || 'latest' }}
+          npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
+          release-mode: stage
           dry-run: ${{ github.event.inputs.dry-run || 'true' }}
           install-dependencies-command: npm ci

--- a/.github/workflows/publish-web-haptics.yml
+++ b/.github/workflows/publish-web-haptics.yml
@@ -14,11 +14,6 @@ on:
           - rc
           - beta
         default: 'auto'
-      dry-run:
-        description: 'Dry run'
-        required: false
-        type: boolean
-        default: 'true'
 
 jobs:
   publish:
@@ -67,5 +62,5 @@ jobs:
           version: ${{ steps.release.outputs.version }}
           npm-tag: ${{ github.event.inputs.tag != 'auto' && github.event.inputs.tag || '' }}
           release-mode: stage
-          dry-run: ${{ github.event.inputs.dry-run || 'true' }}
+          dry-run: 'false'
           install-dependencies-command: npm ci


### PR DESCRIPTION
Fixes the failed [pulsar-gen release](https://github.com/software-mansion/pulsar/actions/runs/34385167009/job/102579499537):

```
npm error 403 Forbidden - PUT https://registry.npmjs.org/pulsar-gen - OIDC permission denied for this action
```

OIDC itself was fine — provenance was signed and logged one line earlier. What npm rejected was the *operation*: the trusted publishers now leave **Allow `npm publish`** unchecked, so only `npm stage publish` is permitted, and the publish action runs `npm publish`.

## What changed

**Every npm release is staged.** All four workflows pass `release-mode: stage`, added in software-mansion/npm-package-publish#13. CI uploads the tarball with its dist-tag and provenance, but the version stays uninstallable until a maintainer approves it with 2FA — from the *Staged Packages* tab on npmjs.com, or `npm stage approve <stage-id>`. The job summary prints the command with the id filled in.

Because a staged version can still be rejected, the action performs no git operations in stage mode; the release tag is deferred until after approval rather than claiming a release that has not shipped.

**`dry-run` is gone.** Staging covers what it was for: nothing is installable until approval, and `npm stage download <stage-id>` hands back the exact tarball to inspect. A dry run would only skip the staging that makes that inspection possible. Every dispatch now stages for real, and the approval is the gate.

**A dead input.** All four workflows passed `tag:`, which the pinned revision (commit #5) does not define — GitHub ignores unknown inputs, so the `latest`/`rc`/`beta` dispatch choice has never reached npm and the dist-tag was always auto-resolved. It is `npm-tag:` now and actually takes effect. The choice gains an `auto` default that preserves today's behaviour: defaulting to `latest` would force that tag onto a maintenance release the action would otherwise put on `legacy`. `legacy` is now selectable too.

**Names.** The publish workflows adopt the `_build-*` convention of matching their file stem (`publish-rn-stable` rather than `Publish React Native to npm`), so the GitHub UI, the filename, and the OIDC trusted publisher config all refer to one name. Filenames are untouched, since OIDC pins them.

## Releasing after this

1. Dispatch the workflow (tag `auto` unless you specifically want to force one).
2. `npm stage list` → `npm stage download <id>` to inspect, if you want to.
3. `npm stage approve <id>`, or approve from npmjs.com. Both prompt for 2FA.
4. Tag the release: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.

`npm stage reject <id>` discards a version instead — the replacement for backing out of a bad dry run.

## Before merging

The action is pinned to the head of software-mansion/npm-package-publish#13. It needs re-pinning to the merge commit once that lands.