### PR TITLE
fix(ios): let a preset play again after it has been stopped

### DIFF
--- a/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
+++ b/iOS/Pulsar/Sources/Pulsar/Composers/PatternComposer.swift
@@ -52,6 +52,7 @@ public class PatternComposer: NSObject {
   }
 
   private func parse(hapticsData: PatternData, audioEvent: CHHapticEvent?) {
+    releasePlayers()
     discreteLine.reset()
     continuousLine.reset()
     hasSound = audioEvent != nil
@@ -162,6 +163,15 @@ public class PatternComposer: NSObject {
     }
   }
 
+  private func releasePlayers() {
+    if let id = continuousPlayerId { engine.removePlayer(id: id) }
+    if let id = discretePlayerId { engine.removePlayer(id: id) }
+    continuousPlayerId = nil
+    discretePlayerId = nil
+    continuousPattern = nil
+    discretePattern = nil
+  }
+
   private func releaseAudio() {
     if let id = audioResourceID {
       engine.unregisterAudioResource(id)
@@ -202,12 +212,7 @@ public class PatternComposer: NSObject {
 
   @objc public func dispose() {
     stop()
-    if let id = continuousPlayerId { engine.removePlayer(id: id) }
-    if let id = discretePlayerId { engine.removePlayer(id: id) }
-    continuousPlayerId = nil
-    discretePlayerId = nil
-    continuousPattern = nil
-    discretePattern = nil
+    releasePlayers()
     audioBuffer = nil
     hasSound = false
     releaseAudio()

--- a/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
+++ b/iOS/Pulsar/Sources/Pulsar/HapticEngineWrapper.swift
@@ -122,6 +122,7 @@ public extension HapticEngineWrapper {
   func stopPlayer(id: Int) {
     guard let player = playerRegistry[id] else { return }
     stopPlayer(player, errorPrefix: "Error stopping player")
+    unregisterPlayer(id)
   }
 
   func removePlayer(id: Int) {
@@ -129,8 +130,7 @@ public extension HapticEngineWrapper {
       try? player.stop(atTime: 0)
     }
 
-    playerRegistry.removeValue(forKey: id)
-    playerCreationOrder.removeAll { $0 == id }
+    unregisterPlayer(id)
   }
 }
 
@@ -348,6 +348,11 @@ private extension HapticEngineWrapper {
     evictOldestPlayerIfNeeded()
     playerRegistry[id] = player
     playerCreationOrder.append(id)
+  }
+
+  func unregisterPlayer(_ id: Int) {
+    playerRegistry.removeValue(forKey: id)
+    playerCreationOrder.removeAll { $0 == id }
   }
 
   func evictOldestPlayerIfNeeded() {

--- a/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMockTests.swift
+++ b/iOS/Pulsar/Tests/PulsarTests/CoreHapticsMockTests.swift
@@ -67,6 +67,24 @@ struct CoreHapticsMockTests {
         #expect(HapticMockRecorder.shared.playerStops >= 1)
     }
 
+    @Test func playingAfterAStopBuildsAFreshPlayer() {
+        CoreHapticsMock.install()
+        defer { CoreHapticsMock.uninstall() }
+
+        let engine = activeEngine()
+        let pattern = makePattern()
+        let created = engine.createPlayer(pattern: pattern)
+        #expect(created != nil)
+        guard let id = created else { return }
+
+        engine.playPlayer(id: id, pattern: pattern)
+        engine.stopPlayer(id: id)
+        engine.playPlayer(id: id, pattern: pattern)
+
+        #expect(HapticMockRecorder.shared.playersCreated == 2)
+        #expect(HapticMockRecorder.shared.playerStarts == 2)
+    }
+
     @Test func stopHapticsStopsEveryRegisteredPlayer() {
         CoreHapticsMock.install()
         defer { CoreHapticsMock.uninstall() }


### PR DESCRIPTION
## What

The Audio Sync demo in PulsarApp plays once. When the preset reaches its end and you hit Play again, nothing happens — no sound, no haptics.

`playFrom()` in the demo stops before every play. On the first play that stop is a no-op (nothing has parsed yet). On a replay at the same position it is not: `PresetHandle.ensureParsed` reuses the parsed composer, so the same `CHHapticPatternPlayer`s are reused — and `stopPlayer(id:)` kept them in the registry after stopping them, so `playPlayer` called `start(atTime: 0)` on players CoreHaptics had already stopped. That silently does nothing, and since the discrete player carries the preset's audio event, both the haptics and the audio go quiet.

Seeking kept working because a new position re-parses and builds fresh players. Same-position replay is the only broken path, which is also why it slipped past `qa-demos-audio-sync.yaml` — that flow taps replay, but it can only assert the JS clock, not whether anything actually played.

## Changes

- `HapticEngineWrapper` — stopping a player unregisters it, so the next `playPlayer` takes the existing rebuild-from-pattern path (which also restarts the engine if it went down). The registered audio resource is untouched, so the rebuilt player still carries its audio.
- `PatternComposer` — `parse()` releases the players it replaces. They were leaked into the engine registry on every re-parse, so roughly ten seeks were enough for eviction to start stopping players still in use.

## Verified on hardware

Confirmed on a physical iPhone 13 (iOS 26.6.1) by A/B-ing two builds of PulsarApp that differ by exactly one line — the `unregisterPlayer(id)` call in `stopPlayer(id:)` — with the demo's JS untouched in both:

| build | Play, let it finish, Play again |
| --- | --- |
| with the call | audio + haptics play |
| without it | silent |

Worth stating plainly: a stopped `CHHapticPatternPlayer` does not start again. That is the behaviour this change works around, and it is now measured rather than assumed.

## Tests

- New `playingAfterAStopBuildsAFreshPlayer` in the CoreHaptics mock suite. It fails on `main` (`playersCreated → 1) == 2`) and passes here.
- `Pulsar-Package`: 63 tests / 11 suites pass, plus the 7-test isolated mock suite.